### PR TITLE
fix(consensus): clean mempool tables on init

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -152,7 +152,7 @@ impl StorageBuilder {
                 .with_options(|opts, _| update_options(opts, threads, fdlimit))
                 .build()?;
 
-        let mempool_storage = MempoolStorage::new(mempool_db);
+        let mempool_storage = MempoolStorage::new(mempool_db).await?;
 
         let inner = Arc::new(Inner {
             root,

--- a/storage/src/store/mempool/mod.rs
+++ b/storage/src/store/mempool/mod.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, Result};
 use weedb::rocksdb::{ReadOptions, WriteBatch};
 
 use crate::MempoolDb;
@@ -9,8 +10,37 @@ pub struct MempoolStorage {
 impl MempoolStorage {
     pub const KEY_LEN: usize = 4 + 32;
 
-    pub fn new(db: MempoolDb) -> Self {
-        Self { db }
+    pub async fn new(db: MempoolDb) -> Result<Self> {
+        tokio::task::spawn_blocking({
+            let db = db.clone();
+            move || Self::clean_all(db)
+        })
+        .await??;
+
+        Ok(Self { db })
+    }
+
+    fn clean_all(db: MempoolDb) -> Result<()> {
+        let flags_cf = db.tables().points_flags.cf();
+        let info_cf = db.tables().points_info.cf();
+        let points_cf = db.tables().points.cf();
+
+        let min = [u8::MIN; Self::KEY_LEN];
+        let max = [u8::MAX; Self::KEY_LEN];
+
+        db.rocksdb()
+            .delete_file_in_range_cf(&flags_cf, min, max)
+            .context("delete old point flags")?;
+
+        db.rocksdb()
+            .delete_file_in_range_cf(&info_cf, min, max)
+            .context("delete old point info")?;
+
+        db.rocksdb()
+            .delete_file_in_range_cf(&points_cf, min, max)
+            .context("delete old point data")?;
+
+        Ok(())
     }
 
     pub fn write_batch() -> WriteBatch {


### PR DESCRIPTION
temporary ensure tables are empty

PS: follows https://tikv.github.io/deep-dive-tikv/key-value-engine/rocksdb.html#deletefilesinrange