### PR TITLE
fix(consensus): broadcast filter should not hold points for engine round

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,6 +3438,7 @@ dependencies = [
  "blake3",
  "bytes",
  "clap",
+ "dashmap",
  "everscale-crypto",
  "everscale-types",
  "futures-util",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = { workspace = true }
 arc-swap = { workspace = true }
 blake3 = { workspace = true }
 bytes = { workspace = true, features = ["serde"] }
+dashmap = { workspace = true }
 everscale-crypto = { workspace = true }
 everscale-types = { workspace = true }
 futures-util = { workspace = true }

--- a/consensus/src/intercom/broadcast/broadcaster.rs
+++ b/consensus/src/intercom/broadcast/broadcaster.rs
@@ -237,7 +237,7 @@ impl Broadcaster {
         match result {
             Err(error) => {
                 self.sig_peers.insert(*peer_id); // lighter weight retry loop
-                tracing::error!(
+                tracing::warn!(
                     parent: self.effects.span(),
                     peer = display(peer_id.alt()),
                     error = display(error),
@@ -260,7 +260,7 @@ impl Broadcaster {
         match result {
             Err(error) => {
                 self.sig_peers.insert(*peer_id); // let it retry
-                tracing::error!(
+                tracing::warn!(
                     parent: self.effects.span(),
                     peer = display(peer_id.alt()),
                     error = display(error),


### PR DESCRIPTION
duplicates error reproduced during node restart suddenly stable.  
and, surprisingly, points were exactly of the engine round, not the next (top) one.