### PR TITLE
feat(collator): collate empty shard block by timeout when no messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -310,7 +310,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.86",
+ "syn 2.0.87",
  "which",
 ]
 
@@ -462,7 +462,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -624,7 +624,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -759,7 +759,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -772,7 +772,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "everscale-types"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b19eb51a3984a4badb380ee9bb7f36e4675880b2014a0321870e85c93fdd1b"
+checksum = "9b73dfe88b44fb8dab157b67818568764a4e43f049313eecaf58e13c55e913af"
 dependencies = [
  "ahash",
  "anyhow",
@@ -838,13 +838,13 @@ dependencies = [
 
 [[package]]
 name = "everscale-types-proc"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323d8b61c76be2c16eb2d72d007f1542fdeb3760fdf2e2cae219fc0da3db0c09"
+checksum = "817dbaf10f56aa40db0f83452c51671bd9f0b8741d56f38459ebb911959437e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -971,7 +971,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1680,7 +1680,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1878,7 +1878,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1919,7 +1919,7 @@ checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1979,7 +1979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2018,7 +2018,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.86",
+ "syn 2.0.87",
  "tempfile",
 ]
 
@@ -2032,7 +2032,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2531,7 +2531,7 @@ checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2697,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.86"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89275301d38033efb81a6e60e3497e734dfcc62571f2854bf4b16690398824c"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2817,7 +2817,7 @@ checksum = "b08be0f17bd307950653ce45db00cd31200d82b624b36e181337d9c7d92765b5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2940,7 +2940,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc-hash 1.1.0",
- "syn 2.0.86",
+ "syn 2.0.87",
  "tl-scheme",
 ]
 
@@ -2983,7 +2983,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3149,7 +3149,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3251,7 +3251,7 @@ checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3779,7 +3779,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -3813,7 +3813,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4105,7 +4105,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ dirs = "5.0.1"
 ed25519 = "2.0"
 ed25519-dalek = "2.1"
 everscale-crypto = { version = "0.2", features = ["tl-proto", "serde"] }
-everscale-types = { version = "0.1.0", features = ["tycho"] }
+everscale-types = { version = "0.1.2", features = ["tycho"] }
 exponential-backoff = "1"
 fdlimit = "0.3.0"
 futures-util = "0.3"
@@ -66,7 +66,10 @@ pkcs8 = "0.10"
 prost = "0.13"
 prost-build = "0.13"
 quick_cache = "0.6.0"
-quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls"] }
+quinn = { version = "0.11", default-features = false, features = [
+    "runtime-tokio",
+    "rustls",
+] }
 rand = "0.8"
 rand_pcg = { version = "0.3" }
 rayon = "1.10"

--- a/cli/src/cmd/tools/gen_zerostate.rs
+++ b/cli/src/cmd/tools/gen_zerostate.rs
@@ -640,6 +640,8 @@ fn make_default_params() -> Result<BlockchainConfigParams> {
         shuffle_mc_validators: true,
 
         mc_block_min_interval_ms: 2500,
+        empty_sc_block_interval_ms: 60_000,
+
         max_uncommitted_chain_length: 31,
 
         msgs_exec_params: MsgsExecutionParams {

--- a/collator/src/collator/mod.rs
+++ b/collator/src/collator/mod.rs
@@ -528,6 +528,7 @@ impl CollatorStdImpl {
 
             // update mc_data if newer
             if working_state.mc_data.block_id.seqno < mc_data.block_id.seqno {
+                working_state.collation_config = Arc::new(mc_data.config.get_collation_config()?);
                 working_state.mc_data = mc_data;
 
                 if working_state.has_unprocessed_messages == Some(false) {

--- a/collator/src/collator/mq_iterator_adapter.rs
+++ b/collator/src/collator/mq_iterator_adapter.rs
@@ -170,10 +170,8 @@ impl<V: InternalMessageValue> QueueIteratorAdapter<V> {
                 // when current iterator exists or existing ranges fully read
                 // then try to calc new ranges from current states
                 // add masterchain default range if not exist
-                let mc_shard_id = ShardIdent::new_full(-1);
-
                 let mut ranges_updated = self.try_update_ranges_for_shard(
-                    mc_shard_id,
+                    ShardIdent::MASTERCHAIN,
                     self.mc_state_gen_lt,
                     &mut current_range.ranges_from,
                     &mut current_range.ranges_to,

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -30,7 +30,7 @@ sudo apt install build-essential git libssl-dev zlib1g-dev pkg-config clang jq
 git clone https://github.com/broxus/tycho
 cd tycho
 git checkout tags/v0.1.0 -b mynode
-cargo install --path ./cli
+cargo install --path ./cli --locked
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Waiting when macros in `everscale-types` will be updated to support versioning. Then will update `CollationConfig` in types with backward compatibility and finish this feature.