### PR TITLE
fix(collator): update has_externals on initial anchors import

### DIFF
--- a/collator/src/collator/types.rs
+++ b/collator/src/collator/types.rs
@@ -1248,6 +1248,7 @@ impl AnchorsCache {
     pub fn clear(&mut self) {
         self.cache.clear();
         self.last_imported_anchor = None;
+        self.has_pending_externals = false;
     }
 
     pub fn len(&self) -> usize {


### PR DESCRIPTION
We didn't reset `has_externals` of initial anchors import on collator resume/init after sync. So i possibly can be `has_externals: true` after initial import when actually it is not true. Now we update flag according to actual our externals count after initial import.

Use `processed_to` anchor from prev block if it ahead of master to avoid incorrect block after sync.