### PR TITLE
fix(consensus): future rounds cache in `BroadcastFilter`

### DIFF
--- a/consensus/src/engine/mempool_config.rs
+++ b/consensus/src/engine/mempool_config.rs
@@ -160,9 +160,10 @@ pub struct MempoolNodeConfig {
     /// How often (in rounds) delete obsolete data and trigger rocksDB compaction.
     pub clean_db_period_rounds: NonZeroU16,
 
-    /// amount of future [Round]s that [`BroadcastFilter`](crate::intercom::BroadcastFilter) caches
-    /// to extend [`Dag`](crate::dag::DagFront) without downloading points for locally skipped rounds
-    pub cache_future_broadcasts_rounds: NonZeroU16,
+    /// amount of future [Round]s (beyond current [`Dag`](crate::dag::DagHead))
+    /// that [`BroadcastFilter`](crate::intercom::BroadcastFilter) caches
+    /// to extend [`Dag`](crate::engine::ConsensusConfigExt) without downloading points
+    pub cache_future_broadcasts_rounds: u16,
 }
 
 impl Default for MempoolNodeConfig {
@@ -170,7 +171,7 @@ impl Default for MempoolNodeConfig {
         Self {
             log_truncate_long_values: true,
             clean_db_period_rounds: NonZeroU16::new(105).unwrap(),
-            cache_future_broadcasts_rounds: NonZeroU16::new(105).unwrap(),
+            cache_future_broadcasts_rounds: 105,
         }
     }
 }

--- a/consensus/src/intercom/broadcast/broadcast_filter.rs
+++ b/consensus/src/intercom/broadcast/broadcast_filter.rs
@@ -159,10 +159,9 @@ impl BroadcastFilterInner {
                             }
                         }
                         hash_map::Entry::Vacant(vacant) => {
-                            let cached = if head.current().round()
-                                + (CachedConfig::get().node.cache_future_broadcasts_rounds).get()
-                                <= self.consensus_round.get()
-                            {
+                            let max_cached_future_round =
+                                top_round + CachedConfig::get().node.cache_future_broadcasts_rounds;
+                            let cached = if round <= max_cached_future_round {
                                 Ok(point.clone())
                             } else {
                                 Err(*point.digest())

--- a/consensus/src/intercom/dependency/uploader.rs
+++ b/consensus/src/intercom/dependency/uploader.rs
@@ -20,7 +20,10 @@ impl Uploader {
         if point_id.round > head.current().round() {
             return PointByIdResponse::TryLater;
         }
-        match Self::from_store(peer_id, point_id, store, round_ctx) {
+        match Self::from_store(peer_id, point_id, store, round_ctx)
+            // point has default status during validation - should retry when finished
+            .filter(|status| *status != PointStatus::default())
+        {
             Some(status) => {
                 if status.is_valid || status.is_trusted || status.is_certified {
                     match store.get_point_raw(point_id.round, point_id.digest) {

--- a/consensus/src/test_utils/bootstrap.rs
+++ b/consensus/src/test_utils/bootstrap.rs
@@ -28,7 +28,7 @@ pub fn default_test_config() -> MempoolConfig {
     let node_config = MempoolNodeConfig {
         log_truncate_long_values: true,
         clean_db_period_rounds: NonZeroU16::new(10).unwrap(),
-        cache_future_broadcasts_rounds: NonZeroU16::new(105).unwrap(),
+        cache_future_broadcasts_rounds: 105,
     };
 
     let mut builder = MempoolConfigBuilder::default();

--- a/storage/src/store/mempool/point_status.rs
+++ b/storage/src/store/mempool/point_status.rs
@@ -6,7 +6,7 @@ use crate::MempoolStorage;
 /// Flags are stored in their order from left to right
 /// and may be merged from `false` to `true` but not vice versa.
 /// Point must be committed at single round.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, PartialEq)]
 pub struct PointStatus {
     // points are stored only after verified: points with sig or digest mismatch are never stored;
     // certified points are validated, and validation takes place only after verification;
@@ -20,7 +20,7 @@ pub struct PointStatus {
     pub committed_at_round: Option<u32>, // not committed are stored with impossible zero round
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum AnchorChainRole {
     Trigger, // not necessarily unique; contained in some point field
     Anchor,  // unique; not contained in point


### PR DESCRIPTION
* clause was inverted so cache dropped point bodies so dag had to download them
* `Uploader` responded that point does not exist (as final decision) if it had default status in storage during validation