### PR TITLE
fix: use a single instance of mc ref tracker for all parts of the node

### DIFF
--- a/cli/src/node/mod.rs
+++ b/cli/src/node/mod.rs
@@ -9,7 +9,6 @@ use everscale_types::models::*;
 use futures_util::future;
 use futures_util::future::BoxFuture;
 use tycho_block_util::block::BlockIdRelation;
-use tycho_block_util::state::MinRefMcStateTracker;
 use tycho_collator::collator::CollatorStdImplFactory;
 use tycho_collator::internal_queue::queue::{QueueConfig, QueueFactory, QueueFactoryStdImpl};
 use tycho_collator::internal_queue::state::commited_state::CommittedStateImplFactory;
@@ -61,8 +60,6 @@ pub struct Node {
     storage: Storage,
     rpc_mempool_adapter: RpcMempoolAdapter,
     blockchain_rpc_client: BlockchainRpcClient,
-
-    state_tracker: MinRefMcStateTracker,
 
     starter_config: StarterConfig,
     rpc_config: Option<RpcConfig>,
@@ -193,9 +190,6 @@ impl Node {
             "initialized blockchain rpc"
         );
 
-        // Setup block strider
-        let state_tracker = MinRefMcStateTracker::default();
-
         Ok(Self {
             keypair,
             network,
@@ -206,7 +200,6 @@ impl Node {
             storage,
             rpc_mempool_adapter,
             blockchain_rpc_client,
-            state_tracker,
             starter_config: node_config.starter,
             rpc_config: node_config.rpc,
             control_config: node_config.control,
@@ -462,7 +455,6 @@ impl Node {
             .with_block_subscriber(
                 (
                     ShardStateApplier::new(
-                        self.state_tracker.clone(),
                         self.storage.clone(),
                         (
                             collator,

--- a/collator/tests/adapter_tests.rs
+++ b/collator/tests/adapter_tests.rs
@@ -83,11 +83,7 @@ async fn test_storage_accessors() {
             zerostate_id,
             storage.clone(),
         ))
-        .with_state_subscriber(
-            MinRefMcStateTracker::default(),
-            storage.clone(),
-            PrintSubscriber,
-        )
+        .with_state_subscriber(storage.clone(), PrintSubscriber)
         .build();
 
     block_strider.run().await.unwrap();
@@ -160,11 +156,7 @@ async fn test_add_read_handle_1000_blocks_parallel() {
             zerostate_id,
             storage.clone(),
         ))
-        .with_state_subscriber(
-            MinRefMcStateTracker::default(),
-            storage.clone(),
-            PrintSubscriber,
-        )
+        .with_state_subscriber(storage.clone(), PrintSubscriber)
         .build();
 
     block_strider.run().await.unwrap();

--- a/collator/tests/collation_tests.rs
+++ b/collator/tests/collation_tests.rs
@@ -5,7 +5,6 @@ use everscale_crypto::ed25519;
 use everscale_types::models::BlockId;
 use futures_util::future::BoxFuture;
 use tycho_block_util::block::BlockIdRelation;
-use tycho_block_util::state::MinRefMcStateTracker;
 use tycho_collator::collator::CollatorStdImplFactory;
 use tycho_collator::internal_queue::queue::{QueueFactory, QueueFactoryStdImpl};
 use tycho_collator::internal_queue::state::commited_state::CommittedStateImplFactory;
@@ -74,11 +73,7 @@ async fn test_collation_process_on_stubs() {
             zerostate_id,
             storage.clone(),
         ))
-        .with_state_subscriber(
-            MinRefMcStateTracker::default(),
-            storage.clone(),
-            PrintSubscriber,
-        )
+        .with_state_subscriber(storage.clone(), PrintSubscriber)
         .build();
 
     block_strider.run().await.unwrap();
@@ -138,11 +133,7 @@ async fn test_collation_process_on_stubs() {
             zerostate_id,
             storage.clone(),
         ))
-        .with_state_subscriber(
-            MinRefMcStateTracker::default(),
-            storage.clone(),
-            state_node_adapter,
-        )
+        .with_state_subscriber(storage.clone(), state_node_adapter)
         .build();
 
     let strider_handle = block_strider.run();

--- a/core/src/block_strider/mod.rs
+++ b/core/src/block_strider/mod.rs
@@ -9,7 +9,6 @@ use tycho_block_util::archive::ArchiveData;
 use tycho_block_util::block::{
     BlockIdExt, BlockIdRelation, BlockStuff, BlockStuffAug, ShardHeights,
 };
-use tycho_block_util::state::MinRefMcStateTracker;
 use tycho_storage::Storage;
 use tycho_util::futures::JoinTask;
 use tycho_util::metrics::HistogramGuard;
@@ -82,7 +81,6 @@ impl<T1, T2> BlockStriderBuilder<T1, T2, ()> {
 impl<T1, T2> BlockStriderBuilder<T1, T2, ()> {
     pub fn with_state_subscriber<S>(
         self,
-        mc_state_tracker: MinRefMcStateTracker,
         storage: Storage,
         state_subscriber: S,
     ) -> BlockStriderBuilder<T1, T2, ShardStateApplier<S>>
@@ -92,7 +90,7 @@ impl<T1, T2> BlockStriderBuilder<T1, T2, ()> {
         BlockStriderBuilder {
             state: self.state,
             provider: self.provider,
-            subscriber: ShardStateApplier::new(mc_state_tracker, storage, state_subscriber),
+            subscriber: ShardStateApplier::new(storage, state_subscriber),
         }
     }
 }

--- a/core/tests/utils/mod.rs
+++ b/core/tests/utils/mod.rs
@@ -26,7 +26,7 @@ pub(crate) fn parse_zerostate(data: &Vec<u8>) -> Result<ShardStateStuff> {
         file_hash,
     };
 
-    let tracker = MinRefMcStateTracker::default();
+    let tracker = MinRefMcStateTracker::new();
     ShardStateStuff::from_root(&block_id, root, &tracker)
 }
 

--- a/light-node/src/cli.rs
+++ b/light-node/src/cli.rs
@@ -6,7 +6,6 @@ use anyhow::{Context, Result};
 use clap::Args;
 use everscale_crypto::ed25519;
 use everscale_types::models::*;
-use tycho_block_util::state::MinRefMcStateTracker;
 use tycho_core::block_strider::{
     ArchiveBlockProvider, ArchiveBlockProviderConfig, BlockProviderExt, BlockStrider,
     BlockSubscriberExt, BlockchainBlockProvider, BlockchainBlockProviderConfig,
@@ -118,8 +117,6 @@ pub struct Node<C> {
     overlay_service: OverlayService,
     storage: Storage,
     blockchain_rpc_client: BlockchainRpcClient,
-
-    state_tracker: MinRefMcStateTracker,
 
     rpc_config: Option<RpcConfig>,
     blockchain_block_provider_config: BlockchainBlockProviderConfig,
@@ -238,9 +235,6 @@ impl<C> Node<C> {
             "initialized blockchain rpc"
         );
 
-        // Setup block strider
-        let state_tracker = MinRefMcStateTracker::default();
-
         Ok(Self {
             zerostate,
             dht_client,
@@ -248,7 +242,6 @@ impl<C> Node<C> {
             overlay_service,
             storage,
             blockchain_rpc_client,
-            state_tracker,
             config,
             rpc_config: node_config.rpc,
             blockchain_block_provider_config: node_config.blockchain_block_provider,
@@ -377,7 +370,6 @@ impl<C> Node<C> {
             .with_block_subscriber(
                 (
                     ShardStateApplier::new(
-                        self.state_tracker.clone(),
                         self.storage.clone(),
                         (rpc_state.1, subscriber, ps_subscriber),
                     ),

--- a/storage/src/store/persistent_state/tests.rs
+++ b/storage/src/store/persistent_state/tests.rs
@@ -52,10 +52,8 @@ async fn persistent_shard_state() -> Result<()> {
 
     // Check seqno
     let min_ref_mc_state = shard_states.min_ref_mc_state();
-    assert_eq!(
-        min_ref_mc_state.seqno(),
-        Some(zerostate.as_ref().min_ref_mc_seqno)
-    );
+    // NOTE: Zerostates do not affect the minimal seqno reference.
+    assert_eq!(min_ref_mc_state.seqno(), None);
 
     // Load zerostate from db
     {

--- a/storage/src/store/shard_state/mod.rs
+++ b/storage/src/store/shard_state/mod.rs
@@ -52,7 +52,7 @@ impl ShardStateStorage {
             temp_file_storage,
             cell_storage,
             gc_lock: Default::default(),
-            min_ref_mc_state: Default::default(),
+            min_ref_mc_state: MinRefMcStateTracker::new(),
             max_new_mc_cell_count: AtomicUsize::new(0),
             max_new_sc_cell_count: AtomicUsize::new(0),
         }))


### PR DESCRIPTION
We were using a couple of unrelated trackers which caused GC to delete states loaded from the storage despite having alive handles acquired by state applier.

Now we use a single instance of this tracker provided by `ShardStateStorage::min_ref_mc_state`.