### PR TITLE
fix(collator): set gen_software to block from blockchain config

### DIFF
--- a/collator/src/collator/do_collate/finalize.rs
+++ b/collator/src/collator/do_collate/finalize.rs
@@ -396,9 +396,12 @@ impl Phase<FinalizeState> {
         // info.want_split = false;
         // info.want_merge = false;
 
-        let capabilities = self.state.mc_data.config.get_global_version()?.capabilities;
-        if capabilities.contains(GlobalCapability::CapReportVersion) {
-            new_block_info.set_gen_software(Some(self.state.collation_data.global_version));
+        let bc_global_version = self.state.mc_data.config.get_global_version()?;
+        if bc_global_version
+            .capabilities
+            .contains(GlobalCapability::CapReportVersion)
+        {
+            new_block_info.set_gen_software(Some(bc_global_version));
         }
 
         let build_state_update_elapsed;

--- a/collator/src/collator/do_collate/mod.rs
+++ b/collator/src/collator/do_collate/mod.rs
@@ -242,13 +242,8 @@ impl CollatorStdImpl {
         let histogram_prepare =
             HistogramGuard::begin_with_labels("tycho_do_collate_prepare_time", &labels);
 
-        let prepare_phase = Phase::<PrepareState>::new(
-            collator_config.clone(),
-            mq_adapter.clone(),
-            reader_state,
-            anchors_cache,
-            state,
-        );
+        let prepare_phase =
+            Phase::<PrepareState>::new(mq_adapter.clone(), reader_state, anchors_cache, state);
 
         let mut execute_phase = prepare_phase.run()?;
 
@@ -732,10 +727,6 @@ impl CollatorStdImpl {
             mc_data.block_id.seqno,
             next_chain_time,
             created_by,
-            GlobalVersion {
-                version: self.config.supported_block_version,
-                capabilities: self.config.supported_capabilities,
-            },
             self.mempool_config_override.clone(),
         );
 

--- a/collator/src/collator/types.rs
+++ b/collator/src/collator/types.rs
@@ -7,10 +7,10 @@ use everscale_types::cell::{Cell, HashBytes, UsageTree, UsageTreeMode};
 use everscale_types::dict::Dict;
 use everscale_types::models::{
     AccountState, BlockId, BlockIdShort, BlockInfo, BlockLimits, BlockParamLimits, BlockRef,
-    CollationConfig, CurrencyCollection, GlobalVersion, HashUpdate, ImportFees, InMsg, Lazy,
-    LibDescr, MsgInfo, MsgsExecutionParams, OptionalAccount, OutMsg, PrevBlockRef, ShardAccount,
-    ShardAccounts, ShardDescription, ShardFeeCreated, ShardFees, ShardIdent, ShardIdentFull,
-    ShardStateUnsplit, SimpleLib, SpecialFlags, StateInit, Transaction, ValueFlow,
+    CollationConfig, CurrencyCollection, HashUpdate, ImportFees, InMsg, Lazy, LibDescr, MsgInfo,
+    MsgsExecutionParams, OptionalAccount, OutMsg, PrevBlockRef, ShardAccount, ShardAccounts,
+    ShardDescription, ShardFeeCreated, ShardFees, ShardIdent, ShardIdentFull, ShardStateUnsplit,
+    SimpleLib, SpecialFlags, StateInit, Transaction, ValueFlow,
 };
 use tl_proto::TlWrite;
 use ton_executor::{AccountMeta, ExecutedTransaction};
@@ -203,7 +203,6 @@ pub(super) struct BlockCollationDataBuilder {
     #[cfg(feature = "block-creator-stats")]
     pub block_create_count: FastHashMap<HashBytes, u64>,
     pub created_by: HashBytes,
-    pub global_version: GlobalVersion,
     pub top_shard_blocks: Vec<TopShardBlockInfo>,
 
     /// Mempool config override for a new genesis
@@ -218,7 +217,6 @@ impl BlockCollationDataBuilder {
         min_ref_mc_seqno: u32,
         next_chain_time: u64,
         created_by: HashBytes,
-        global_version: GlobalVersion,
         mempool_config_override: Option<MempoolGlobalConfig>,
     ) -> Self {
         let gen_utime = (next_chain_time / 1000) as u32;
@@ -235,7 +233,6 @@ impl BlockCollationDataBuilder {
             #[cfg(feature = "block-creator-stats")]
             block_create_count: Default::default(),
             created_by,
-            global_version,
             shards: None,
             top_shard_blocks: vec![],
             mempool_config_override,
@@ -294,7 +291,6 @@ impl BlockCollationDataBuilder {
             min_ref_mc_seqno: self.min_ref_mc_seqno,
             rand_seed: self.rand_seed,
             created_by: self.created_by,
-            global_version: self.global_version,
             shards: self.shards,
             top_shard_blocks: self.top_shard_blocks,
             shard_fees: self.shard_fees,
@@ -385,8 +381,6 @@ pub(super) struct BlockCollationData {
     pub rand_seed: HashBytes,
 
     pub created_by: HashBytes,
-
-    pub global_version: GlobalVersion,
 
     /// Mempool config override for a new genesis
     pub mempool_config_override: Option<MempoolGlobalConfig>,


### PR DESCRIPTION
`CollatorConfig.supported_block_version` and `CollatorConfig.supported_capabilities` are now set up only in code.

We need to remove `collator.supported_block_version` and `collator.supported_capabilities` from the node's `config.json`.