### PR TITLE
refactor(consensus): simplify query wrapper

### DIFF
--- a/consensus/src/intercom/core/dto.rs
+++ b/consensus/src/intercom/core/dto.rs
@@ -1,134 +1,28 @@
-use tl_proto::{TlError, TlPacket, TlRead, TlResult, TlWrite};
+use std::fmt::Debug;
 
-use crate::intercom::dto::{PointByIdResponse, SignatureResponse};
-use crate::models::{Point, PointId, Round};
+use tl_proto::{TlRead, TlWrite};
 
-#[derive(Debug)]
-pub struct BroadcastQuery(pub Point);
-
-impl BroadcastQuery {
-    pub(crate) const TL_ID: u32 = tl_proto::id!("core.broadcastQuery", scheme = "proto.tl");
+#[derive(TlRead, TlWrite, Debug)]
+#[tl(boxed, scheme = "proto.tl")]
+pub enum QueryTag {
+    #[tl(id = "core.queryTag.broadcast")]
+    Broadcast,
+    #[tl(id = "core.queryTag.pointById")]
+    PointById,
+    #[tl(id = "core.queryTag.signature")]
+    Signature,
 }
 
-impl<'a> TlRead<'a> for BroadcastQuery {
-    type Repr = tl_proto::Boxed;
-
-    fn read_from(packet: &mut &'a [u8]) -> TlResult<Self> {
-        if u32::read_from(packet)? != Self::TL_ID {
-            return Err(TlError::UnknownConstructor);
-        }
-
-        if packet.len() < 4 {
-            tracing::error!(size = %packet.len(), "Point does not contain any useful data");
-            return Err(TlError::InvalidData);
-        }
-
-        // skip 4 bytes of PointInner tag
-        if !Point::verify_hash_inner(&packet[4..]) {
-            tracing::error!("Point hash is invalid");
-            return Err(TlError::InvalidData);
-        }
-
-        Point::read_from(packet).map(Self)
-    }
+#[derive(TlRead, Debug)]
+#[tl(boxed, id = "core.queryWrapper", scheme = "proto.tl")]
+pub struct ReceiveWrapper<'tl> {
+    pub tag: QueryTag,
+    pub body: tl_proto::RawBytes<'tl, tl_proto::Boxed>,
 }
 
-impl TlWrite for BroadcastQuery {
-    type Repr = tl_proto::Boxed;
-
-    fn max_size_hint(&self) -> usize {
-        4 + self.0.max_size_hint()
-    }
-
-    fn write_to<P>(&self, packet: &mut P)
-    where
-        P: TlPacket,
-    {
-        packet.write_u32(Self::TL_ID);
-        self.0.write_to(packet);
-    }
+#[derive(TlWrite, Debug)]
+#[tl(boxed, id = "core.queryWrapper", scheme = "proto.tl")]
+pub struct SendWrapper<'a, T> {
+    pub tag: QueryTag,
+    pub body: &'a T,
 }
-
-#[derive(TlWrite, TlRead, Debug)]
-#[tl(boxed, id = "core.pointQuery", scheme = "proto.tl")]
-pub struct PointQuery(pub PointId);
-
-#[derive(TlWrite, TlRead, Debug)]
-#[tl(boxed, id = "core.signatureQuery", scheme = "proto.tl")]
-pub struct SignatureQuery(pub Round);
-
-#[derive(TlWrite, TlRead, Debug)]
-#[tl(boxed, id = "core.mpresponse.broadcast", scheme = "proto.tl")]
-pub struct BroadcastMpResponse;
-
-#[derive(Debug)]
-pub struct PointMpResponse<T>(pub PointByIdResponse<T>);
-
-impl<T> PointMpResponse<T> {
-    pub const TL_ID: u32 = tl_proto::id!("core.mpresponse.point", scheme = "proto.tl");
-}
-
-impl<T> TlWrite for PointMpResponse<T>
-where
-    PointByIdResponse<T>: TlWrite,
-{
-    type Repr = tl_proto::Boxed;
-
-    fn max_size_hint(&self) -> usize {
-        4 + self.0.max_size_hint()
-    }
-
-    fn write_to<P>(&self, packet: &mut P)
-    where
-        P: TlPacket,
-    {
-        packet.write_u32(Self::TL_ID);
-        self.0.write_to(packet);
-    }
-}
-
-impl<'tl, T> TlRead<'tl> for PointMpResponse<T>
-where
-    PointByIdResponse<T>: TlRead<'tl>,
-{
-    type Repr = tl_proto::Boxed;
-
-    fn read_from(packet: &mut &'tl [u8]) -> TlResult<Self> {
-        if u32::read_from(packet)? != Self::TL_ID {
-            return Err(TlError::UnknownConstructor);
-        }
-
-        if packet.len() < 8usize {
-            tracing::error!(size = %packet.len(), "PointByIdResponse size is too low");
-            return Err(TlError::InvalidData);
-        }
-
-        let point_by_id_response_tag = {
-            let mut prefix = [0_u8; 4];
-            prefix.copy_from_slice(&packet[..4usize]);
-            u32::from_be_bytes(prefix)
-        };
-
-        match point_by_id_response_tag {
-            PointByIdResponse::<T>::DEFINED_TL_ID => {
-                // skip 4 bytes of Point tag prefixe
-                if !Point::verify_hash_inner(&packet[8..]) {
-                    tracing::error!("Point hash is invalid");
-                    return Err(TlError::InvalidData);
-                }
-            }
-            PointByIdResponse::<T>::DEFINED_NONE_TL_ID
-            | PointByIdResponse::<T>::TRY_LATER_TL_ID => (),
-            _ => {
-                tracing::error!(tag = %point_by_id_response_tag, "Unknown PointByIdResponse tag id");
-                return Err(TlError::UnknownConstructor);
-            }
-        }
-
-        PointByIdResponse::<T>::read_from(packet).map(Self)
-    }
-}
-
-#[derive(TlWrite, TlRead, Debug)]
-#[tl(boxed, id = "core.mpresponse.signature", scheme = "proto.tl")]
-pub struct SignatureMpResponse(pub SignatureResponse);

--- a/consensus/src/intercom/dependency/downloader.rs
+++ b/consensus/src/intercom/dependency/downloader.rs
@@ -165,7 +165,7 @@ impl Downloader {
             parent: self.clone(),
             _phantom: PhantomData,
             ctx,
-            request: Dispatcher::point_by_id_request(*point_id),
+            request: Dispatcher::point_by_id_request(point_id),
             point_id: *point_id,
             peer_count,
             not_found: 0, // this node is +1 to 2F

--- a/consensus/src/intercom/dto.rs
+++ b/consensus/src/intercom/dto.rs
@@ -1,92 +1,23 @@
 use std::fmt::{Debug, Display, Formatter};
 
-use tl_proto::{TlError, TlPacket, TlRead, TlResult, TlWrite};
+use tl_proto::{TlRead, TlWrite};
 
 use crate::effects::{AltFmt, AltFormat};
-use crate::models::{Point, Signature};
+use crate::models::Signature;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, TlRead, TlWrite)]
+#[tl(boxed, scheme = "proto.tl")]
 pub enum PointByIdResponse<T> {
+    #[tl(id = "intercom.pointByIdResponse.defined")]
     Defined(T),
+    #[tl(id = "intercom.pointByIdResponse.definedNone")]
     DefinedNone,
+    #[tl(id = "intercom.pointByIdResponse.tryLater")]
     TryLater,
 }
 
-impl<T> PointByIdResponse<T> {
-    pub(crate) const DEFINED_TL_ID: u32 =
-        tl_proto::id!("intercom.pointByIdResponse.defined", scheme = "proto.tl");
-    pub(crate) const DEFINED_NONE_TL_ID: u32 = tl_proto::id!(
-        "intercom.pointByIdResponse.definedNone",
-        scheme = "proto.tl"
-    );
-    pub(crate) const TRY_LATER_TL_ID: u32 =
-        tl_proto::id!("intercom.pointByIdResponse.tryLater", scheme = "proto.tl");
-}
-
-impl<T: AsRef<[u8]>> TlWrite for PointByIdResponse<T> {
-    type Repr = tl_proto::Boxed;
-
-    fn max_size_hint(&self) -> usize {
-        4 + match self {
-            Self::Defined(t) => t.as_ref().len(),
-            Self::DefinedNone | Self::TryLater => 0,
-        }
-    }
-
-    fn write_to<P>(&self, packet: &mut P)
-    where
-        P: TlPacket,
-    {
-        match self {
-            Self::Defined(t) => {
-                packet.write_u32(Self::DEFINED_TL_ID);
-                packet.write_raw_slice(t.as_ref());
-            }
-            Self::DefinedNone => packet.write_u32(Self::DEFINED_NONE_TL_ID),
-            Self::TryLater => packet.write_u32(Self::TRY_LATER_TL_ID),
-        }
-    }
-}
-
-impl TlWrite for PointByIdResponse<Point> {
-    type Repr = tl_proto::Boxed;
-
-    fn max_size_hint(&self) -> usize {
-        4 + match self {
-            Self::Defined(t) => t.max_size_hint(),
-            Self::DefinedNone | Self::TryLater => 0,
-        }
-    }
-
-    fn write_to<P>(&self, packet: &mut P)
-    where
-        P: TlPacket,
-    {
-        match self {
-            Self::Defined(t) => {
-                packet.write_u32(Self::DEFINED_TL_ID);
-                t.write_to(packet);
-            }
-            Self::DefinedNone => packet.write_u32(Self::DEFINED_NONE_TL_ID),
-            Self::TryLater => packet.write_u32(Self::TRY_LATER_TL_ID),
-        }
-    }
-}
-
-impl<'a> TlRead<'a> for PointByIdResponse<Point> {
-    type Repr = tl_proto::Boxed;
-
-    fn read_from(packet: &mut &'a [u8]) -> TlResult<Self> {
-        let id = u32::read_from(packet)?;
-        match id {
-            Self::DEFINED_TL_ID => Ok(PointByIdResponse::Defined(Point::read_from(packet)?)),
-            Self::DEFINED_NONE_TL_ID => Ok(PointByIdResponse::DefinedNone),
-            Self::TRY_LATER_TL_ID => Ok(PointByIdResponse::TryLater),
-            _ => Err(TlError::InvalidData),
-        }
-    }
-}
-
+#[derive(TlWrite, TlRead, Debug)]
+#[tl(boxed, id = "intercom.broadcastResponse", scheme = "proto.tl")]
 pub struct BroadcastResponse;
 
 #[derive(TlWrite, TlRead, Debug)]

--- a/consensus/src/proto.tl
+++ b/consensus/src/proto.tl
@@ -65,17 +65,11 @@ point.link.indirect     to:consensus.pointId path:link.through      = point.Link
 link.through.witness    x:int256 = link.Through;
 link.through.includes   x:int256 = link.Through;
 
-
-core.broadcastQuery       x:consensus.pointInner        = core.BroadcastQuery;
-core.pointQuery           x:consensus.pointId           = core.PointQuery;
-core.signatureQuery       x:int32                       = core.SignatureQuery;
-
-
 /*
 * Representation of PointByIdResponse
 */
-intercom.pointByIdResponse.defined          x:bytes      = intercom.PointByIdResponse;
-intercom.pointByIdResponse.definedNone                   = intercom.PointByIdResponse;
+intercom.pointByIdResponse.defined          x:bytes     = intercom.PointByIdResponse;
+intercom.pointByIdResponse.definedNone                  = intercom.PointByIdResponse;
 intercom.pointByIdResponse.tryLater                     = intercom.PointByIdResponse;
 
 
@@ -88,17 +82,26 @@ intercom.signatureResponse.tryLater                     = intercom.SignatureResp
 intercom.signatureResponse.rejected                     = intercom.SignatureResponse;
 
 /*
-*
+* Representation of SignatureRejectedReason
 */
 intercom.signatureRejectedReason.tooOldRound            = intercom.SignatureRejectedReason;
 intercom.signatureRejectedReason.cannotSign             = intercom.SignatureRejectedReason;
 intercom.signatureRejectedReason.unknownPeer            = intercom.SignatureRejectedReason;
 
+
 /*
-*
+* Representation of BroadcastResponse
 */
-core.mpresponse.broadcast                                           = core.MPResponse;
-core.mpresponse.point           x:intercom.PointByIdResponse        = core.MPResponse;
-core.mpresponse.signature       x:intercom.SignatureResponse        = core.MPResponse;
+intercom.broadcastResponse                              = intercom.BroadcastResponse;
 
+/*
+* Representation of generic query wrapper
+*/
+core.queryWrapper  {X:Type}  tag:core.QueryTag  body:X  = core.QueryWrapper X;
 
+/*
+* Representation of query wrapper type tag
+*/
+core.queryTag.broadcast                                 = core.QueryTag;
+core.queryTag.pointById                                 = core.QueryTag;
+core.queryTag.signature                                 = core.QueryTag;


### PR DESCRIPTION
Exposes `Point` deserialization and hash check, so they can be delegated to rayon. Also raw point bytes can be preserved until inserted into db.