### PR TITLE
feat(collator): update VM and executor to v10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -744,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "everscale-types"
 version = "0.1.2"
-source = "git+https://github.com/broxus/everscale-types.git?rev=acc7b79eee0712c48e7678ceafaf143cad2e4ca9#acc7b79eee0712c48e7678ceafaf143cad2e4ca9"
+source = "git+https://github.com/broxus/everscale-types.git?rev=82c343b2bd17ceb51db0575b6b8ee821ccda037e#82c343b2bd17ceb51db0575b6b8ee821ccda037e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "everscale-types-abi-proc"
 version = "0.1.0"
-source = "git+https://github.com/broxus/everscale-types.git?rev=acc7b79eee0712c48e7678ceafaf143cad2e4ca9#acc7b79eee0712c48e7678ceafaf143cad2e4ca9"
+source = "git+https://github.com/broxus/everscale-types.git?rev=82c343b2bd17ceb51db0575b6b8ee821ccda037e#82c343b2bd17ceb51db0575b6b8ee821ccda037e"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -997,7 +997,7 @@ dependencies = [
 [[package]]
 name = "everscale-types-proc"
 version = "0.1.5"
-source = "git+https://github.com/broxus/everscale-types.git?rev=acc7b79eee0712c48e7678ceafaf143cad2e4ca9#acc7b79eee0712c48e7678ceafaf143cad2e4ca9"
+source = "git+https://github.com/broxus/everscale-types.git?rev=82c343b2bd17ceb51db0575b6b8ee821ccda037e#82c343b2bd17ceb51db0575b6b8ee821ccda037e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "tycho-executor"
 version = "0.1.0"
-source = "git+https://github.com/broxus/tycho-vm.git?rev=1b76f974eae5fdbd311ac17c20747a875efe8072#1b76f974eae5fdbd311ac17c20747a875efe8072"
+source = "git+https://github.com/broxus/tycho-vm.git?rev=e3c1473a8749cde50cbf5c57166169de09e41000#e3c1473a8749cde50cbf5c57166169de09e41000"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3890,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "tycho-vm"
 version = "0.1.0"
-source = "git+https://github.com/broxus/tycho-vm.git?rev=1b76f974eae5fdbd311ac17c20747a875efe8072#1b76f974eae5fdbd311ac17c20747a875efe8072"
+source = "git+https://github.com/broxus/tycho-vm.git?rev=e3c1473a8749cde50cbf5c57166169de09e41000#e3c1473a8749cde50cbf5c57166169de09e41000"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "tycho-vm-proc"
 version = "0.1.0"
-source = "git+https://github.com/broxus/tycho-vm.git?rev=1b76f974eae5fdbd311ac17c20747a875efe8072#1b76f974eae5fdbd311ac17c20747a875efe8072"
+source = "git+https://github.com/broxus/tycho-vm.git?rev=e3c1473a8749cde50cbf5c57166169de09e41000#e3c1473a8749cde50cbf5c57166169de09e41000"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,8 @@ weedb = "0.4.1"
 zstd-safe = "7.2"
 zstd-sys = "2.0"
 
-tycho-executor = { git = "https://github.com/broxus/tycho-vm.git", rev = "1b76f974eae5fdbd311ac17c20747a875efe8072" }
-tycho-vm = { git = "https://github.com/broxus/tycho-vm.git", rev = "1b76f974eae5fdbd311ac17c20747a875efe8072" }
+tycho-executor = { git = "https://github.com/broxus/tycho-vm.git", rev = "e3c1473a8749cde50cbf5c57166169de09e41000" }
+tycho-vm = { git = "https://github.com/broxus/tycho-vm.git", rev = "e3c1473a8749cde50cbf5c57166169de09e41000" }
 
 # local deps
 tycho-block-util = { path = "./block-util", version = "0.2.7" }
@@ -135,7 +135,7 @@ tycho-storage = { path = "./storage", version = "0.2.7" }
 tycho-util = { path = "./util", version = "0.2.7" }
 
 [patch.crates-io]
-everscale-types = { git = "https://github.com/broxus/everscale-types.git", rev = "acc7b79eee0712c48e7678ceafaf143cad2e4ca9" }
+everscale-types = { git = "https://github.com/broxus/everscale-types.git", rev = "82c343b2bd17ceb51db0575b6b8ee821ccda037e" }
 
 [workspace.lints.rust]
 future_incompatible = "warn"

--- a/block-util/benches/common.rs
+++ b/block-util/benches/common.rs
@@ -1,4 +1,4 @@
-use everscale_types::cell::{Cell, CellBuilder, CellSliceRange};
+use everscale_types::cell::{Cell, CellBuilder};
 use everscale_types::models::{MsgInfo, OwnedMessage};
 use tycho_block_util::message::ExtMsgRepr;
 
@@ -6,12 +6,10 @@ pub fn create_big_message() -> anyhow::Result<Cell> {
     let mut count = 0;
     let body = make_big_tree(8, &mut count, ExtMsgRepr::MAX_MSG_CELLS as u16 - 100);
 
-    let body_range = CellSliceRange::full(body.as_ref());
-
     let cell = CellBuilder::build_from(OwnedMessage {
         info: MsgInfo::ExtIn(Default::default()),
         init: None,
-        body: (body, body_range),
+        body: body.into(),
         layout: None,
     })?;
 

--- a/block-util/src/message/ext_msg_repr.rs
+++ b/block-util/src/message/ext_msg_repr.rs
@@ -275,12 +275,10 @@ mod test {
             let body = make_big_tree(8, &mut count, ExtMsgRepr::MAX_MSG_CELLS as u16 - 100);
             println!("{count}");
 
-            let body_range = CellSliceRange::full(body.as_ref());
-
             CellBuilder::build_from(OwnedMessage {
                 info: MsgInfo::ExtIn(Default::default()),
                 init: None,
-                body: (body, body_range),
+                body: body.into(),
                 layout: None,
             })?
         });
@@ -294,12 +292,11 @@ mod test {
             let body = MerkleProof::create(leaf_proof.as_ref(), AlwaysInclude)
                 .build()
                 .and_then(CellBuilder::build_from)?;
-            let body_range = CellSliceRange::full(body.as_ref());
 
             CellBuilder::build_from(OwnedMessage {
                 info: MsgInfo::ExtIn(Default::default()),
                 init: None,
-                body: (body, body_range),
+                body: body.into(),
                 layout: Some(MessageLayout {
                     body_to_cell: true,
                     init_to_cell: false,
@@ -429,12 +426,10 @@ mod test {
         let mut count = 0;
         let body = make_big_tree(8, &mut count, ExtMsgRepr::MAX_MSG_CELLS as u16 + 100);
 
-        let body_range = CellSliceRange::full(body.as_ref());
-
         let cell = CellBuilder::build_from(OwnedMessage {
             info: MsgInfo::ExtIn(Default::default()),
             init: None,
-            body: (body, body_range),
+            body: body.into(),
             layout: None,
         })?;
 
@@ -453,12 +448,11 @@ mod test {
         let body = MerkleProof::create(inner_proof.as_ref(), AlwaysInclude)
             .build()
             .and_then(CellBuilder::build_from)?;
-        let body_range = CellSliceRange::full(body.as_ref());
 
         let cell = CellBuilder::build_from(OwnedMessage {
             info: MsgInfo::ExtIn(Default::default()),
             init: None,
-            body: (body, body_range),
+            body: body.into(),
             layout: Some(MessageLayout {
                 body_to_cell: true,
                 init_to_cell: false,

--- a/cli/src/cmd/elect/mod.rs
+++ b/cli/src/cmd/elect/mod.rs
@@ -969,7 +969,6 @@ impl Wallet {
             .with_pubkey(&self.public)
             .build_input()?
             .sign(&self.secret, self.signature_id)?;
-        let body_range = CellSliceRange::full(body.as_ref());
 
         let message = OwnedMessage {
             info: MsgInfo::ExtIn(ExtInMsgInfo {
@@ -978,7 +977,7 @@ impl Wallet {
                 ..Default::default()
             }),
             init,
-            body: (body, body_range),
+            body: body.into(),
             layout: None,
         };
         let message_cell = CellBuilder::build_from(message)?;

--- a/cli/src/cmd/tools/bc.rs
+++ b/cli/src/cmd/tools/bc.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use everscale_crypto::ed25519;
 use everscale_types::abi::extend_signature_with_id;
 use everscale_types::boc::Boc;
-use everscale_types::cell::{Cell, CellBuilder, CellSliceRange};
+use everscale_types::cell::{Cell, CellBuilder};
 use everscale_types::models::{
     AccountState, BlockchainConfigParams, ExtInMsgInfo, GlobalCapability, MsgInfo, OwnedMessage,
     StdAddr,
@@ -340,7 +340,6 @@ fn create_message(
     builder.prepend_raw(&signature, 512)?;
 
     let body = builder.build()?;
-    let body_range = CellSliceRange::full(body.as_ref());
 
     let message = Box::new(OwnedMessage {
         info: MsgInfo::ExtIn(ExtInMsgInfo {
@@ -348,7 +347,7 @@ fn create_message(
             ..Default::default()
         }),
         init: None,
-        body: (body, body_range),
+        body: body.into(),
         layout: None,
     });
 

--- a/collator/src/collator/do_collate/prepare.rs
+++ b/collator/src/collator/do_collate/prepare.rs
@@ -70,6 +70,7 @@ impl Phase<PrepareState> {
                 disable_delete_frozen_accounts: true,
                 full_body_in_bounced: capabilities.contains(GlobalCapability::CapFullBodyInBounced),
                 charge_action_fees_on_fail: true,
+                strict_extra_currency: true,
                 vm_modifiers: tycho_vm::BehaviourModifiers {
                     signature_with_id: capabilities
                         .contains(GlobalCapability::CapSignatureWithId)

--- a/collator/tests/internal_queue.rs
+++ b/collator/tests/internal_queue.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::Duration;
 
-use everscale_types::cell::{Cell, CellSliceRange, HashBytes, Lazy};
+use everscale_types::cell::{Cell, HashBytes, Lazy};
 use everscale_types::models::{
     AccountStatus, BlockId, BlockIdShort, ComputePhase, ComputePhaseSkipReason, CurrencyCollection,
     HashUpdate, IntAddr, IntMsgInfo, IntermediateAddr, MsgEnvelope, MsgInfo, OrdinaryTxInfo,
@@ -900,15 +900,13 @@ fn test_queue_diff_with_messages_from_queue_diff_stuff() -> anyhow::Result<()> {
         .unwrap(),
     };
 
-    let message_body = Cell::default();
-
     let message1 = Lazy::new(&OwnedMessage {
         info: MsgInfo::Int(IntMsgInfo {
             created_lt: 0x01,
             ..Default::default()
         }),
         init: None,
-        body: (message_body.clone(), CellSliceRange::default()),
+        body: Default::default(),
         layout: None,
     })
     .unwrap();
@@ -929,7 +927,7 @@ fn test_queue_diff_with_messages_from_queue_diff_stuff() -> anyhow::Result<()> {
             ..Default::default()
         }),
         init: None,
-        body: (message_body.clone(), CellSliceRange::default()),
+        body: Default::default(),
         layout: None,
     })
     .unwrap();
@@ -950,7 +948,7 @@ fn test_queue_diff_with_messages_from_queue_diff_stuff() -> anyhow::Result<()> {
             ..Default::default()
         }),
         init: None,
-        body: (message_body.clone(), CellSliceRange::default()),
+        body: Default::default(),
         layout: None,
     })
     .unwrap();


### PR DESCRIPTION
- Adds support for `RUNVM`, `RUNVMX` and `GASCONSUMED` opcodes;
- Changes behaviour for extra currencies;
- Changes behaviour for some address rewrite opcodes;