### PR TITLE
reduce accumulated wu used on initial anchors import

### DIFF
--- a/collator/src/mempool/impls/std_impl.rs
+++ b/collator/src/mempool/impls/std_impl.rs
@@ -297,14 +297,9 @@ impl MempoolAdapter for MempoolAdapterStdImpl {
         Ok(())
     }
 
-    async fn get_anchor_by_id(
-        &self,
-        top_processed_to_anchor: MempoolAnchorId,
-        anchor_id: MempoolAnchorId,
-    ) -> Result<GetAnchorResult> {
+    async fn get_anchor_by_id(&self, anchor_id: MempoolAnchorId) -> Result<GetAnchorResult> {
         tracing::debug!(
             target: tracing_targets::MEMPOOL_ADAPTER,
-            %top_processed_to_anchor,
             %anchor_id,
             "get_anchor_by_id"
         );
@@ -317,14 +312,9 @@ impl MempoolAdapter for MempoolAdapterStdImpl {
         Ok(result)
     }
 
-    async fn get_next_anchor(
-        &self,
-        top_processed_to_anchor: MempoolAnchorId,
-        prev_anchor_id: MempoolAnchorId,
-    ) -> Result<GetAnchorResult> {
+    async fn get_next_anchor(&self, prev_anchor_id: MempoolAnchorId) -> Result<GetAnchorResult> {
         tracing::debug!(
             target: tracing_targets::MEMPOOL_ADAPTER,
-            %top_processed_to_anchor,
             %prev_anchor_id,
             "get_next_anchor"
         );

--- a/collator/src/mempool/impls/stub_impl.rs
+++ b/collator/src/mempool/impls/stub_impl.rs
@@ -182,11 +182,7 @@ impl MempoolAdapter for MempoolAdapterStubImpl {
         Ok(())
     }
 
-    async fn get_anchor_by_id(
-        &self,
-        _: MempoolAnchorId,
-        anchor_id: MempoolAnchorId,
-    ) -> Result<GetAnchorResult> {
+    async fn get_anchor_by_id(&self, anchor_id: MempoolAnchorId) -> Result<GetAnchorResult> {
         let mut last_attempt_at = None;
         loop {
             let Some(anchor) = self.anchors_cache.read().get(&anchor_id).cloned() else {
@@ -263,11 +259,7 @@ impl MempoolAdapter for MempoolAdapterStubImpl {
         }
     }
 
-    async fn get_next_anchor(
-        &self,
-        _: MempoolAnchorId,
-        prev_anchor_id: MempoolAnchorId,
-    ) -> Result<GetAnchorResult> {
+    async fn get_next_anchor(&self, prev_anchor_id: MempoolAnchorId) -> Result<GetAnchorResult> {
         let range = (
             std::ops::Bound::Excluded(prev_anchor_id),
             std::ops::Bound::Unbounded,
@@ -491,30 +483,28 @@ mod tests {
         let adapter =
             MempoolAdapterStubImpl::with_stub_externals(Arc::new(MempoolEventStubListener), None);
 
-        const STUB: MempoolAnchorId = 0;
-
         // try get existing anchor by id
-        let result = adapter.get_anchor_by_id(STUB, 3).await?;
+        let result = adapter.get_anchor_by_id(3).await?;
         assert!(result.anchor().is_some());
         assert_eq!(result.anchor().unwrap().id, 3);
 
         // try get next anchor after (id: 3)
-        let result = adapter.get_next_anchor(STUB, 3).await?;
+        let result = adapter.get_next_anchor(3).await?;
         assert!(result.anchor().is_some());
         assert_eq!(result.anchor().unwrap().id, 4);
 
         // try get next anchor after (id: 5), will wait some time
-        let result = adapter.get_next_anchor(STUB, 5).await?;
+        let result = adapter.get_next_anchor(5).await?;
         assert!(result.anchor().is_some());
         assert_eq!(result.anchor().unwrap().id, 6);
 
         // test clear anchors cache
         adapter.clear_anchors_cache(6)?;
-        let result = adapter.get_anchor_by_id(STUB, 3).await?;
+        let result = adapter.get_anchor_by_id(3).await?;
         assert!(result.anchor().is_none());
-        let result = adapter.get_anchor_by_id(STUB, 4).await?;
+        let result = adapter.get_anchor_by_id(4).await?;
         assert!(result.anchor().is_none());
-        let result = adapter.get_anchor_by_id(STUB, 6).await?;
+        let result = adapter.get_anchor_by_id(6).await?;
         assert!(result.anchor().is_some());
         assert_eq!(result.anchor().unwrap().id, 6);
 

--- a/collator/src/mempool/mod.rs
+++ b/collator/src/mempool/mod.rs
@@ -69,20 +69,12 @@ pub trait MempoolAdapter: Send + Sync + 'static {
 
     /// Request, await, and return anchor from connected mempool by id.
     /// Return None if the requested anchor does not exist and cannot be synced from other nodes.
-    async fn get_anchor_by_id(
-        &self,
-        top_processed_to_anchor: MempoolAnchorId,
-        anchor_id: MempoolAnchorId,
-    ) -> Result<GetAnchorResult>;
+    async fn get_anchor_by_id(&self, anchor_id: MempoolAnchorId) -> Result<GetAnchorResult>;
 
     /// Request, await, and return the next anchor after the specified previous one.
     /// If anchor does not exist then await until it be produced or downloaded during sync.
     /// Return None if anchor cannot be produced or synced from other nodes.
-    async fn get_next_anchor(
-        &self,
-        top_processed_to_anchor: MempoolAnchorId,
-        prev_anchor_id: MempoolAnchorId,
-    ) -> Result<GetAnchorResult>;
+    async fn get_next_anchor(&self, prev_anchor_id: MempoolAnchorId) -> Result<GetAnchorResult>;
 
     /// Clean cache from all anchors that before specified.
     /// We can do this for anchors that processed in blocks


### PR DESCRIPTION
**NODE CONFIGURATION CHANGES**
None
**BLOCKCHAIN CONFIGURATION CHANGES**
None

**COMPATIBILITY**
Message Processing Algorithm - fully compatible
Messages reading in ReFill mode little bit changes but this does not affect messages collection at all

**SPECIAL DEPLOYMENT ACTIONS**
Not Required

**PERFORMANCE IMPACT**
Expected impact
Little bit better overall performance of network because there are no endless syncs. But in it is not notable with existing tests. It is not the main goal.

**TESTS**
**Unit Tests**
Covered by: test_import_init_anchors, test_read_externals, test_refill_messages
**Network Tests**
No special coverage
**Manual Tests**
Any heavy test (swaps 1300, transfers 20k, 1-255) which causes many syncs. We should not have mismatched blocks in this case.

[metrics](https://grafana.broxus.com/d/cdlaji62a1b0gb1/tycho-node-metrics-new-queue?orgId=1&from=2025-05-01T13:07:36.303Z&to=2025-05-01T14:39:31.995Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet2-validator1&var-instance=tycho-devnet2-validator2&var-instance=tycho-devnet2-validator3&var-instance=tycho-devnet2-validator4&var-instance=tycho-devnet2-validator5&var-instance=tycho-devnet2-validator6&var-instance=tycho-devnet2-validator7&var-instance=tycho-devnet2-validator8&var-instance=tycho-devnet2-validator9&var-instance=tycho-devnet2-validator10&var-instance=tycho-devnet2-validator11&var-instance=tycho-devnet2-validator12&var-instance=tycho-devnet2-validator13&var-instance=tycho-devnet2-validator14&var-instance=tycho-devnet2-validator15&var-instance=tycho-devnet2-validator16&var-instance=tycho-devnet2-validator17&var-instance=tycho-devnet2-validator18&var-instance=tycho-devnet2-validator19&var-workchain=$__all&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)

Before:
![image](https://github.com/user-attachments/assets/6e47dfa1-2bac-4e47-a8a0-c78f61873185)
![image](https://github.com/user-attachments/assets/f69f5ac5-b3b9-4594-8ae3-84d588495446)

After:
![image](https://github.com/user-attachments/assets/a9bdfe39-ea9c-48fa-ada2-72a3309a1769)
![image](https://github.com/user-attachments/assets/cf31a906-d1b3-4127-9a58-e67ae3bf0ef4)