### PR TITLE
fix next internals range reader creation

### DIFF
--- a/collator/src/collator/do_collate/execute.rs
+++ b/collator/src/collator/do_collate/execute.rs
@@ -159,9 +159,6 @@ impl Phase<ExecuteState> {
         metrics::histogram!("tycho_do_collate_process_txs_total_time", &labels)
             .record(process_txs_total_elapsed);
 
-        let last_read_to_anchor_chain_time =
-            self.extra.messages_reader.last_read_to_anchor_chain_time();
-
         let process_txs_wu = calc_process_txs_wu(
             &self.state.collation_data,
             &self.state.collation_config.work_units_params.execute,
@@ -188,7 +185,6 @@ impl Phase<ExecuteState> {
             execute_msgs_total_elapsed,
             process_txs_total_elapsed,
             msgs_reader_metrics: msgs_reader_metrics_total,
-            last_read_to_anchor_chain_time,
         });
 
         Ok(())

--- a/collator/src/collator/do_collate/mod.rs
+++ b/collator/src/collator/do_collate/mod.rs
@@ -187,6 +187,8 @@ impl CollatorStdImpl {
             res => res?,
         };
 
+        let last_read_to_anchor_chain_time = reader_state.externals.last_read_to_anchor_chain_time;
+
         self.anchors_cache = anchors_cache;
 
         let block_id = *finalized.block_candidate.block.id();
@@ -245,10 +247,8 @@ impl CollatorStdImpl {
         };
 
         // block time diff from min ext chain time
-        let diff_time = now_millis() as i64
-            - execute_result
-                .last_read_to_anchor_chain_time
-                .unwrap_or(next_chain_time) as i64;
+        let diff_time =
+            now_millis() as i64 - last_read_to_anchor_chain_time.unwrap_or(next_chain_time) as i64;
         metrics::gauge!("tycho_do_collate_ext_msgs_time_diff", &labels)
             .set(diff_time as f64 / 1000.0);
 

--- a/collator/src/collator/execution_manager.rs
+++ b/collator/src/collator/execution_manager.rs
@@ -94,7 +94,6 @@ impl MessagesExecutor {
         let labels = &[("workchain", self.shard_id.workchain().to_string())];
         let mut ext_msgs_skipped = 0;
 
-        // TODO: msgs-v3: rename to group_slots_count
         let group_horizontal_size = msg_group.len();
         let group_messages_count = msg_group.messages_count();
         let group_mean_vert_size: usize = group_messages_count

--- a/collator/src/collator/messages_reader/internals_reader.rs
+++ b/collator/src/collator/messages_reader/internals_reader.rs
@@ -159,8 +159,6 @@ impl<V: InternalMessageValue> InternalsPartitionReader<V> {
             .peekable();
         let mut max_processed_offset = 0;
         while let Some((seqno, mut range_reader)) = range_readers.next() {
-            // TODO: msgs-v3: update offset in the last range reader on the go?
-
             // otherwise update offset in the last range reader state
             // if current offset is greater than the maximum stored one among all ranges
             max_processed_offset =
@@ -358,6 +356,7 @@ impl<V: InternalMessageValue> InternalsPartitionReader<V> {
 
             ranges.push(QueueShardRange {
                 shard_ident: *shard_id,
+                // TODO: may be we should pass `from` here because we should load stats for the full range
                 from: shard_reader_state.current_position,
                 to: shard_range_to,
             });

--- a/collator/src/collator/messages_reader/mod.rs
+++ b/collator/src/collator/messages_reader/mod.rs
@@ -195,16 +195,6 @@ impl<V: InternalMessageValue> MessagesReader<V> {
                 .set(buffer_limits.slot_vert_size as f64);
         }
 
-        // TODO: msgs-v3: remove if we do not need this field
-        let _msg_group_max_limits = MessagesBufferLimits {
-            max_count: msgs_buffer_max_count,
-            slots_count: externals_buffer_limits_by_partitions
-                .values()
-                .map(|l| l.slots_count)
-                .sum(),
-            slot_vert_size: group_vert_size,
-        };
-
         let mut new_messages = NewMessagesState::new(cx.for_shard_id);
 
         let mut cumulative_statistics = None;
@@ -741,10 +731,6 @@ impl<V: InternalMessageValue> MessagesReader<V> {
         Ok(moved_from_par_0_accounts)
     }
 
-    pub fn last_read_to_anchor_chain_time(&self) -> Option<u64> {
-        self.externals_reader.last_read_to_anchor_chain_time()
-    }
-
     pub fn metrics_by_partitions(&self) -> &MessagesReaderMetricsByPartitions {
         &self.metrics_by_partitions
     }
@@ -980,7 +966,7 @@ impl<V: InternalMessageValue> MessagesReader<V> {
 
             let read_metrics = self
                 .externals_reader
-                .read_into_buffers(read_mode, self.new_messages.partition_router());
+                .read_into_buffers(read_mode, self.new_messages.partition_router())?;
             metrics_by_partitions.append(read_metrics);
         }
 

--- a/collator/src/collator/messages_reader/reader_state.rs
+++ b/collator/src/collator/messages_reader/reader_state.rs
@@ -320,11 +320,16 @@ impl std::fmt::Display for DisplayRangeReaderStateByPartition<'_> {
     }
 }
 
-// TODO: msgs-v3: implement simplified Debug
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ExternalKey {
     pub anchor_id: MempoolAnchorId,
     pub msgs_offset: u64,
+}
+
+impl std::fmt::Debug for ExternalKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({}, {})", self.anchor_id, self.msgs_offset)
+    }
 }
 
 impl From<(MempoolAnchorId, u64)> for ExternalKey {

--- a/collator/src/collator/tests/externals_reader_tests.rs
+++ b/collator/src/collator/tests/externals_reader_tests.rs
@@ -136,8 +136,9 @@ fn test_read_externals() {
 
     // read 1 for block 1
     println!("read 1 for block  1");
-    let metrics =
-        externals_reader.read_into_buffers(GetNextMessageGroupMode::Continue, &partition_router);
+    let metrics = externals_reader
+        .read_into_buffers(GetNextMessageGroupMode::Continue, &partition_router)
+        .unwrap();
     let metrics = metrics.get_total();
     println!("read_ext_msgs_count: {}", metrics.read_ext_msgs_count);
     print_state(&externals_reader);
@@ -279,8 +280,9 @@ fn test_read_externals() {
 
     // refill after restart on block 2
     println!("refill after restart on block 2");
-    let metrics =
-        externals_reader.read_into_buffers(GetNextMessageGroupMode::Refill, &partition_router);
+    let metrics = externals_reader
+        .read_into_buffers(GetNextMessageGroupMode::Refill, &partition_router)
+        .unwrap();
     let metrics = metrics.get_total();
     println!("read_ext_msgs_count: {}", metrics.read_ext_msgs_count);
     print_state(&externals_reader);
@@ -343,8 +345,9 @@ fn test_read_externals() {
 
     // continue reading on block 2
     println!("continue reading 1 on block 2");
-    let metrics =
-        externals_reader.read_into_buffers(GetNextMessageGroupMode::Continue, &partition_router);
+    let metrics = externals_reader
+        .read_into_buffers(GetNextMessageGroupMode::Continue, &partition_router)
+        .unwrap();
     let metrics = metrics.get_total();
     println!("read_ext_msgs_count: {}", metrics.read_ext_msgs_count);
     print_state(&externals_reader);
@@ -656,8 +659,9 @@ fn test_read_externals() {
 
     // continue reading 1 on block 3
     println!("continue reading on block 3");
-    let metrics =
-        externals_reader.read_into_buffers(GetNextMessageGroupMode::Continue, &partition_router);
+    let metrics = externals_reader
+        .read_into_buffers(GetNextMessageGroupMode::Continue, &partition_router)
+        .unwrap();
     let metrics = metrics.get_total();
     println!("read_ext_msgs_count: {}", metrics.read_ext_msgs_count);
     print_state(&externals_reader);
@@ -907,8 +911,9 @@ fn test_read_externals() {
     // read and collect 4 times
     for i in 1..=4 {
         println!("read messages on refill {}", i);
-        let metrics =
-            externals_reader.read_into_buffers(GetNextMessageGroupMode::Refill, &partition_router);
+        let metrics = externals_reader
+            .read_into_buffers(GetNextMessageGroupMode::Refill, &partition_router)
+            .unwrap();
         let metrics = metrics.get_total();
         println!("read_ext_msgs_count: {}", metrics.read_ext_msgs_count);
 

--- a/collator/src/collator/types.rs
+++ b/collator/src/collator/types.rs
@@ -1062,9 +1062,6 @@ pub struct ExecuteResult {
 
     /// Accumulated messages reader metrics across all partitions
     pub msgs_reader_metrics: MessagesReaderMetrics,
-
-    // TODO: msgs-v3: take from ReaderState instead
-    pub last_read_to_anchor_chain_time: Option<u64>,
 }
 
 pub struct FinalizeBlockResult {


### PR DESCRIPTION
**NODE CONFIGURATION CHANGES**
None
**BLOCKCHAIN CONFIGURATION CHANGES**
None

**COMPATIBILITY**
Message Processing Algorithm - fully compatible

**SPECIAL DEPLOYMENT ACTIONS**
Not Required

**PERFORMANCE IMPACT**
No impact expected

**TESTS**
**Unit Tests**
externals_reader_tests.rs, messages_reader_tests.rs
**Network Tests**
No special coverage

**Manual Tests**
To test this we run 1-255 and 10k transfers in parallel.

Before the fix node stucks after all messages in isolated partition 1 processed
![image](https://github.com/user-attachments/assets/22c1a9fd-6f3b-43e2-8b0b-984498b4ed8c)
![image](https://github.com/user-attachments/assets/ca6bfa8d-539a-43dc-8e1d-e0092c7a9047)
[grafana](https://grafana.broxus.com/d/cdlaji62a1b0gb1/tycho-node-metrics-new-queue?orgId=1&from=2025-05-07T11:30:17.619Z&to=2025-05-07T12:14:24.532Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet2-validator1&var-instance=tycho-devnet2-validator2&var-instance=tycho-devnet2-validator3&var-instance=tycho-devnet2-validator4&var-instance=tycho-devnet2-validator5&var-instance=tycho-devnet2-validator6&var-instance=tycho-devnet2-validator7&var-instance=tycho-devnet2-validator8&var-instance=tycho-devnet2-validator9&var-instance=tycho-devnet2-validator10&var-instance=tycho-devnet2-validator11&var-instance=tycho-devnet2-validator13&var-instance=tycho-devnet2-validator14&var-instance=tycho-devnet2-validator15&var-instance=tycho-devnet2-validator16&var-instance=tycho-devnet2-validator17&var-instance=tycho-devnet2-validator18&var-instance=tycho-devnet2-validator19&var-workchain=$__all&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)

After the fix
![image](https://github.com/user-attachments/assets/7ffa218a-f461-4064-bc79-ebaa79e2b5f1)
![image](https://github.com/user-attachments/assets/7113b53b-bedb-4f43-8983-4aa878859c3f)
[grafana](https://grafana.broxus.com/d/cdlaji62a1b0gb1/tycho-node-metrics-new-queue?orgId=1&from=2025-05-07T16:04:48.343Z&to=2025-05-07T16:50:07.929Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet2-validator1&var-instance=tycho-devnet2-validator2&var-instance=tycho-devnet2-validator3&var-instance=tycho-devnet2-validator4&var-instance=tycho-devnet2-validator5&var-instance=tycho-devnet2-validator6&var-instance=tycho-devnet2-validator7&var-instance=tycho-devnet2-validator8&var-instance=tycho-devnet2-validator9&var-instance=tycho-devnet2-validator10&var-instance=tycho-devnet2-validator11&var-instance=tycho-devnet2-validator12&var-instance=tycho-devnet2-validator13&var-instance=tycho-devnet2-validator14&var-instance=tycho-devnet2-validator15&var-instance=tycho-devnet2-validator16&var-instance=tycho-devnet2-validator17&var-instance=tycho-devnet2-validator18&var-instance=tycho-devnet2-validator19&var-workchain=$__all&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)