### PR TITLE
do not mix externals above the vertical limit on account

### DIFF
--- a/collator/src/collator/do_collate/execute.rs
+++ b/collator/src/collator/do_collate/execute.rs
@@ -152,11 +152,11 @@ impl Phase<ExecuteState> {
             execute_msgs_total_elapsed.as_millis();
         metrics::gauge!("tycho_do_collate_exec_msgs_groups_per_block", &labels)
             .set(executed_groups_count as f64);
-        metrics::histogram!("tycho_do_collate_fill_msgs_total_time", &labels)
+        metrics::histogram!("tycho_do_collate_fill_msgs_total_time_high", &labels)
             .record(fill_msgs_total_elapsed);
-        metrics::histogram!("tycho_do_collate_exec_msgs_total_time", &labels)
+        metrics::histogram!("tycho_do_collate_exec_msgs_total_time_high", &labels)
             .record(execute_msgs_total_elapsed);
-        metrics::histogram!("tycho_do_collate_process_txs_total_time", &labels)
+        metrics::histogram!("tycho_do_collate_process_txs_total_time_high", &labels)
             .record(process_txs_total_elapsed);
 
         let process_txs_wu = calc_process_txs_wu(
@@ -284,15 +284,15 @@ impl Phase<ExecuteState> {
             ..
         }) = &self.extra.execute_result
         {
-            metrics::histogram!("tycho_do_collate_init_iterator_time", &labels)
+            metrics::histogram!("tycho_do_collate_init_iterator_time_high", &labels)
                 .record(metrics.init_iterator_timer.total_elapsed);
-            metrics::histogram!("tycho_do_collate_read_int_msgs_time", &labels)
+            metrics::histogram!("tycho_do_collate_read_int_msgs_time_high", &labels)
                 .record(metrics.read_existing_messages_timer.total_elapsed);
-            metrics::histogram!("tycho_do_collate_read_new_msgs_time", &labels)
+            metrics::histogram!("tycho_do_collate_read_new_msgs_time_high", &labels)
                 .record(metrics.read_new_messages_timer.total_elapsed);
-            metrics::histogram!("tycho_do_collate_read_ext_msgs_time", &labels)
+            metrics::histogram!("tycho_do_collate_read_ext_msgs_time_high", &labels)
                 .record(metrics.read_ext_messages_timer.total_elapsed);
-            metrics::histogram!("tycho_do_collate_add_to_msg_groups_time", &labels)
+            metrics::histogram!("tycho_do_collate_add_to_msg_groups_time_high", &labels)
                 .record(metrics.add_to_message_groups_timer.total_elapsed);
         }
     }

--- a/collator/src/collator/do_collate/execution_wrapper.rs
+++ b/collator/src/collator/do_collate/execution_wrapper.rs
@@ -153,6 +153,7 @@ impl ExecutorWrapper {
                 special_origin: Some(special_origin),
                 block_seqno: Some(collation_data.block_id_short.seqno),
                 from_same_shard: None,
+                ext_msg_chain_time: None,
             })
         };
 
@@ -314,6 +315,7 @@ fn new_transaction(
                     special_origin: None,
                     block_seqno: Some(collation_data.block_id_short.seqno),
                     from_same_shard: Some(true),
+                    ext_msg_chain_time: None,
                 }));
             }
             MsgInfo::ExtOut(_) => {

--- a/collator/src/collator/do_collate/finalize.rs
+++ b/collator/src/collator/do_collate/finalize.rs
@@ -150,7 +150,7 @@ impl Phase<FinalizeState> {
             anchors_cache,
         } = {
             let histogram_create_queue_diff = HistogramGuard::begin_with_labels(
-                "tycho_do_collate_create_queue_diff_time",
+                "tycho_do_collate_create_queue_diff_time_high",
                 &labels,
             );
             let finalize_message_reader_res = messages_reader.finalize(
@@ -199,7 +199,7 @@ impl Phase<FinalizeState> {
                 let _span = span.enter();
 
                 let histogram = HistogramGuard::begin_with_labels(
-                    "tycho_do_collate_build_statistics_time",
+                    "tycho_do_collate_build_statistics_time_high",
                     &labels,
                 );
 
@@ -214,7 +214,7 @@ impl Phase<FinalizeState> {
 
                 // apply queue diff
                 let histogram = HistogramGuard::begin_with_labels(
-                    "tycho_do_collate_apply_queue_diff_time",
+                    "tycho_do_collate_apply_queue_diff_time_high",
                     &labels,
                 );
 
@@ -280,7 +280,7 @@ impl Phase<FinalizeState> {
 
         let labels = &[("workchain", shard.workchain().to_string())];
         let histogram =
-            HistogramGuard::begin_with_labels("tycho_collator_finalize_block_time", labels);
+            HistogramGuard::begin_with_labels("tycho_collator_finalize_block_time_high", labels);
 
         let executor = self.extra.executor;
 
@@ -306,13 +306,13 @@ impl Phase<FinalizeState> {
         let mut out_msgs_res = Ok(Default::default());
         let mut build_out_msgs_elapsed = Duration::ZERO;
         let histogram_build_account_blocks_and_messages = HistogramGuard::begin_with_labels(
-            "tycho_collator_finalize_build_account_blocks_and_msgs_time",
+            "tycho_collator_finalize_build_account_blocks_and_msgs_time_high",
             labels,
         );
         rayon::scope(|s| {
             s.spawn(|_| {
                 let histogram = HistogramGuard::begin_with_labels(
-                    "tycho_collator_finalize_build_in_msgs_time",
+                    "tycho_collator_finalize_build_in_msgs_time_high",
                     labels,
                 );
                 in_msgs_res = Self::build_in_msgs(&collation_data.in_msgs);
@@ -320,7 +320,7 @@ impl Phase<FinalizeState> {
             });
             s.spawn(|_| {
                 let histogram = HistogramGuard::begin_with_labels(
-                    "tycho_collator_finalize_build_out_msgs_time",
+                    "tycho_collator_finalize_build_out_msgs_time_high",
                     labels,
                 );
                 out_msgs_res = Self::build_out_msgs(&collation_data.out_msgs);
@@ -328,7 +328,7 @@ impl Phase<FinalizeState> {
             });
 
             let histogram = HistogramGuard::begin_with_labels(
-                "tycho_collator_finalize_build_account_blocks_time",
+                "tycho_collator_finalize_build_account_blocks_time_high",
                 labels,
             );
 
@@ -377,7 +377,7 @@ impl Phase<FinalizeState> {
         let build_mc_state_extra_elapsed;
         let (mc_state_extra, master_ref) = if is_masterchain {
             let histogram = HistogramGuard::begin_with_labels(
-                "tycho_collator_finish_build_mc_state_extra_time",
+                "tycho_collator_finish_build_mc_state_extra_time_high",
                 labels,
             );
 
@@ -466,7 +466,7 @@ impl Phase<FinalizeState> {
         let finalize_wu_total;
         let (state_update, new_observable_state) = {
             let histogram = HistogramGuard::begin_with_labels(
-                "tycho_collator_finalize_build_state_update_time",
+                "tycho_collator_finalize_build_state_update_time_high",
                 labels,
             );
 
@@ -577,7 +577,7 @@ impl Phase<FinalizeState> {
         let build_block_elapsed;
         let (new_block, new_block_extra, new_mc_block_extra) = {
             let histogram = HistogramGuard::begin_with_labels(
-                "tycho_collator_finalize_build_block_time",
+                "tycho_collator_finalize_build_block_time_high",
                 labels,
             );
 
@@ -1488,7 +1488,7 @@ fn create_merkle_update(
 ) -> Result<MerkleUpdate> {
     let labels = [("workchain", shard_id.workchain().to_string())];
     let histogram =
-        HistogramGuard::begin_with_labels("tycho_collator_create_merkle_update_time", &labels);
+        HistogramGuard::begin_with_labels("tycho_collator_create_merkle_update_time_high", &labels);
 
     let merkle_update_builder =
         MerkleUpdate::create(old_state_root.as_ref(), new_state_root.as_ref(), usage_tree);

--- a/collator/src/collator/do_collate/mod.rs
+++ b/collator/src/collator/do_collate/mod.rs
@@ -67,7 +67,7 @@ impl CollatorStdImpl {
     ) -> Result<()> {
         let labels: [(&str, String); 1] = [("workchain", self.shard_id.workchain().to_string())];
         let total_collation_histogram =
-            HistogramGuard::begin_with_labels("tycho_do_collate_total_time", &labels);
+            HistogramGuard::begin_with_labels("tycho_do_collate_total_time_high", &labels);
 
         let WorkingState {
             next_block_id_short,
@@ -286,7 +286,7 @@ impl CollatorStdImpl {
 
         // prepare execution
         let histogram_prepare =
-            HistogramGuard::begin_with_labels("tycho_do_collate_prepare_time", &labels);
+            HistogramGuard::begin_with_labels("tycho_do_collate_prepare_time_high", &labels);
 
         let shards_processed_to_by_partitions = state
             .collation_data
@@ -317,7 +317,7 @@ impl CollatorStdImpl {
         // execute incoming messages
         let execute_elapsed = {
             let histogram =
-                HistogramGuard::begin_with_labels("tycho_do_collate_execute_time", &labels);
+                HistogramGuard::begin_with_labels("tycho_do_collate_execute_time_high", &labels);
 
             execute_phase.run()?;
 
@@ -920,7 +920,7 @@ impl CollatorStdImpl {
             };
             async move {
                 let _histogram = HistogramGuard::begin_with_labels(
-                    "tycho_collator_build_new_state_time",
+                    "tycho_collator_build_new_state_time_high",
                     &labels,
                 );
                 adapter
@@ -932,7 +932,7 @@ impl CollatorStdImpl {
         let handle_block_candidate_elapsed;
         {
             let histogram = HistogramGuard::begin_with_labels(
-                "tycho_do_collate_handle_block_candidate_time",
+                "tycho_do_collate_handle_block_candidate_time_high",
                 &labels,
             );
 

--- a/collator/src/collator/messages_reader/internals_reader.rs
+++ b/collator/src/collator/messages_reader/internals_reader.rs
@@ -13,8 +13,8 @@ use super::{
 };
 use crate::collator::error::CollatorError;
 use crate::collator::messages_buffer::{
-    BufferFillStateByCount, BufferFillStateBySlots, FillMessageGroupResult, MessageGroup,
-    MessagesBuffer, MessagesBufferLimits, SaturatingAddAssign,
+    BufferFillStateByCount, BufferFillStateBySlots, FillMessageGroupResult, IncludeAllMessages,
+    MessageGroup, MessagesBuffer, MessagesBufferLimits, SaturatingAddAssign,
 };
 use crate::collator::types::{
     ConcurrentQueueStatistics, MsgsExecutionParamsExtension, ParsedMessage,
@@ -745,6 +745,7 @@ impl<V: InternalMessageValue> InternalsPartitionReader<V> {
                                 special_origin: None,
                                 block_seqno: None,
                                 from_same_shard: Some(int_msg.item.source == self.for_shard_id),
+                                ext_msg_chain_time: None,
                             });
 
                             metrics.add_to_message_groups_timer.start();
@@ -1117,7 +1118,7 @@ impl<V: InternalMessageValue> InternalsRangeReader<V> {
         let FillMessageGroupResult {
             collected_queue_msgs_keys,
             ops_count,
-        } = self.reader_state.buffer.fill_message_group(
+        } = self.reader_state.buffer.fill_message_group::<_, _>(
             msg_group,
             self.buffer_limits.slots_count,
             self.buffer_limits.slot_vert_size,
@@ -1186,6 +1187,7 @@ impl<V: InternalMessageValue> InternalsRangeReader<V> {
 
                 (false, check_ops_count)
             },
+            IncludeAllMessages,
         );
 
         CollectMessagesFromRangeReaderResult {

--- a/collator/src/collator/messages_reader/mod.rs
+++ b/collator/src/collator/messages_reader/mod.rs
@@ -1107,6 +1107,9 @@ impl<V: InternalMessageValue> MessagesReader<V> {
         par_0_metrics.add_to_message_groups_timer.stop();
 
         tracing::debug!(target: tracing_targets::COLLATOR,
+            expired_ext_msgs_count = ?DebugIter(
+                metrics_by_partitions.inner.iter().map(|(par_id, m)| (par_id, m.expired_ext_msgs_count))
+            ),
             has_not_fully_read_externals_ranges = self.has_not_fully_read_externals_ranges(),
             has_not_fully_read_internals_ranges = self.has_not_fully_read_internals_ranges(),
             has_pending_new_messages = self.has_pending_new_messages(),
@@ -1450,6 +1453,9 @@ pub(super) struct MessagesReaderMetrics {
     /// num of external messages read
     pub read_ext_msgs_count: u64,
 
+    /// num of expired external messages
+    pub expired_ext_msgs_count: u64,
+
     pub add_to_msgs_groups_ops_count: u64,
 }
 
@@ -1467,6 +1473,8 @@ impl MessagesReaderMetrics {
         self.read_existing_msgs_count += other.read_existing_msgs_count;
         self.read_new_msgs_count += other.read_new_msgs_count;
         self.read_ext_msgs_count += other.read_ext_msgs_count;
+
+        self.expired_ext_msgs_count += other.expired_ext_msgs_count;
 
         self.add_to_msgs_groups_ops_count = self
             .add_to_msgs_groups_ops_count

--- a/collator/src/collator/messages_reader/mod.rs
+++ b/collator/src/collator/messages_reader/mod.rs
@@ -138,6 +138,8 @@ impl<V: InternalMessageValue> MessagesReader<V> {
 
         // TODO: msgs-v3: should create partitions 1+ only when exist in current processed_upto
 
+        const ADDITIONAL_EXTERNALS_COUNT: usize = 0;
+
         // internals: normal partition 0: 80% of `group_limit`, but min 1
         let par_0_slots_fraction = slots_fractions.get(&0).cloned().unwrap() as usize;
         internals_buffer_limits_by_partitions.insert(0, MessagesBufferLimits {
@@ -148,11 +150,11 @@ impl<V: InternalMessageValue> MessagesReader<V> {
                 .max(1),
             slot_vert_size: group_vert_size,
         });
-        // externals: normal partition 0: 100%, but min 2, vert size +1
+        // externals: normal partition 0: 100%, but min 2, vert size + ADDITIONAL_EXTERNALS_COUNT
         externals_buffer_limits_by_partitions.insert(0, MessagesBufferLimits {
             max_count: msgs_buffer_max_count,
             slots_count: group_limit.saturating_mul(100).saturating_div(100).max(2),
-            slot_vert_size: group_vert_size + 1,
+            slot_vert_size: group_vert_size + ADDITIONAL_EXTERNALS_COUNT,
         });
 
         // internals: low-priority partition 1: 10%, but min 1
@@ -165,13 +167,13 @@ impl<V: InternalMessageValue> MessagesReader<V> {
                 .max(1),
             slot_vert_size: group_vert_size,
         });
-        // externals: low-priority partition 1: equal to internals, vert size +1
+        // externals: low-priority partition 1: equal to internals, vert size + ADDITIONAL_EXTERNALS_COUNT
         {
             let int_buffer_limits = internals_buffer_limits_by_partitions.get(&1).unwrap();
             externals_buffer_limits_by_partitions.insert(1, MessagesBufferLimits {
                 max_count: msgs_buffer_max_count,
                 slots_count: int_buffer_limits.slots_count,
-                slot_vert_size: int_buffer_limits.slot_vert_size + 1,
+                slot_vert_size: int_buffer_limits.slot_vert_size + ADDITIONAL_EXTERNALS_COUNT,
             });
         }
 

--- a/collator/src/collator/messages_reader/new_messages.rs
+++ b/collator/src/collator/messages_reader/new_messages.rs
@@ -327,6 +327,7 @@ impl<V: InternalMessageValue> InternalsPartitionReader<V> {
                             special_origin: None,
                             block_seqno: Some(block_seqno),
                             from_same_shard: Some(msg.source == for_shard_id),
+                            ext_msg_chain_time: None,
                         }));
                     res.metrics
                         .add_to_msgs_groups_ops_count

--- a/collator/src/collator/mod.rs
+++ b/collator/src/collator/mod.rs
@@ -587,7 +587,7 @@ impl CollatorStdImpl {
     ) -> Result<()> {
         let labels = [("workchain", self.shard_id.workchain().to_string())];
         let histogram =
-            HistogramGuard::begin_with_labels("tycho_collator_resume_collation_time", &labels);
+            HistogramGuard::begin_with_labels("tycho_collator_resume_collation_time_high", &labels);
 
         // update collation session info to refer to a correct subset in collated block
         self.collation_session = collation_session;
@@ -826,7 +826,7 @@ impl CollatorStdImpl {
     ) -> Result<()> {
         let labels = [("workchain", self.shard_id.workchain().to_string())];
         let _histogram = HistogramGuard::begin_with_labels(
-            "tycho_collator_prepare_working_state_update_time",
+            "tycho_collator_prepare_working_state_update_time_high",
             &labels,
         );
 
@@ -1072,7 +1072,7 @@ impl CollatorStdImpl {
         let labels = [("workchain", shard_id.workchain().to_string())];
 
         let _histogram =
-            HistogramGuardWithLabels::begin("tycho_collator_import_next_anchor_time", &labels);
+            HistogramGuardWithLabels::begin("tycho_collator_import_next_anchor_time_high", &labels);
 
         let timer = std::time::Instant::now();
 
@@ -2045,8 +2045,10 @@ impl DelayedWorkingState {
 
     async fn wait(&mut self) -> Result<Box<WorkingState>> {
         let labels = [("workchain", self.shard_id.workchain().to_string())];
-        let _histogram =
-            HistogramGuardWithLabels::begin("tycho_collator_wait_for_working_state_time", &labels);
+        let _histogram = HistogramGuardWithLabels::begin(
+            "tycho_collator_wait_for_working_state_time_high",
+            &labels,
+        );
 
         if let Some(state) = self.unused.take() {
             return Ok(state);

--- a/collator/src/collator/tests/externals_reader_tests.rs
+++ b/collator/src/collator/tests/externals_reader_tests.rs
@@ -476,7 +476,7 @@ fn test_read_externals() {
     assert_eq!(by_par.processed_offset, 1);
 
     let by_par = range_reader.reader_state.get_state_by_partition(1).unwrap();
-    assert_eq!(by_par.buffer.msgs_count(), 3);
+    assert_eq!(by_par.buffer.msgs_count(), 2); // 1 ext msg expired in buffer
     assert_eq!(by_par.skip_offset, 1);
     assert_eq!(by_par.processed_offset, 1);
 
@@ -510,7 +510,7 @@ fn test_read_externals() {
     let msg_group = msg_groups.get(&0).unwrap();
     assert_eq!(msg_group.messages_count(), 1);
     let msg_group = msg_groups.get(&1).unwrap();
-    assert_eq!(msg_group.messages_count(), 3);
+    assert_eq!(msg_group.messages_count(), 2);
 
     let by_par = externals_reader
         .reader_state

--- a/collator/src/collator/types.rs
+++ b/collator/src/collator/types.rs
@@ -1064,6 +1064,7 @@ pub struct ParsedMessage {
     pub special_origin: Option<SpecialOrigin>,
     pub block_seqno: Option<BlockSeqno>,
     pub from_same_shard: Option<bool>,
+    pub ext_msg_chain_time: Option<u64>,
 }
 
 impl ParsedMessage {

--- a/scripts/gen-dashboard.py
+++ b/scripts/gen-dashboard.py
@@ -999,42 +999,42 @@ def jrpc_timings() -> RowPanel:
 def collator_finalize_block() -> RowPanel:
     metrics = [
         create_heatmap_panel(
-            "tycho_collator_finalize_block_time",
+            "tycho_collator_finalize_block_time_high",
             "Total time to finalize block",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_finalize_build_account_blocks_and_msgs_time",
+            "tycho_collator_finalize_build_account_blocks_and_msgs_time_high",
             "Build in parallel account blocks, InMsgDescr, OutMsgDescr",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_finalize_build_account_blocks_time",
+            "tycho_collator_finalize_build_account_blocks_time_high",
             "only Build account blocks",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_finalize_build_in_msgs_time",
+            "tycho_collator_finalize_build_in_msgs_time_high",
             "only Build InMsgDescr",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_finalize_build_out_msgs_time",
+            "tycho_collator_finalize_build_out_msgs_time_high",
             "only Build OutMsgDescr",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_finish_build_mc_state_extra_time",
+            "tycho_collator_finish_build_mc_state_extra_time_high",
             "Build McStateExtra",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_finalize_build_state_update_time",
+            "tycho_collator_finalize_build_state_update_time_high",
             "Compute MerkleUpdate",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_create_merkle_update_time",
+            "tycho_collator_create_merkle_update_time_high",
             "inc. Create MerkleUpdate",
             labels=['workchain=~"$workchain"'],
         ),
@@ -1049,7 +1049,7 @@ def collator_finalize_block() -> RowPanel:
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_finalize_build_block_time",
+            "tycho_collator_finalize_build_block_time_high",
             "Build Block",
             labels=['workchain=~"$workchain"'],
         ),
@@ -1486,22 +1486,22 @@ def collator_time_metrics() -> RowPanel:
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_prepare_working_state_update_time",
+            "tycho_collator_prepare_working_state_update_time_high",
             "Prepare WorkingState update",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_resume_collation_time",
+            "tycho_collator_resume_collation_time_high",
             "Resume collation",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_build_new_state_time",
+            "tycho_collator_build_new_state_time_high",
             "Build Pure State for next collation",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_wait_for_working_state_time",
+            "tycho_collator_wait_for_working_state_time_high",
             "Wait for updated WorkingState",
             labels=['workchain=~"$workchain"'],
         ),
@@ -1514,7 +1514,7 @@ def collator_time_metrics() -> RowPanel:
             "Try collate next shard block",
         ),
         create_heatmap_panel(
-            "tycho_collator_import_next_anchor_time",
+            "tycho_collator_import_next_anchor_time_high",
             "Import next anchor time",
             labels=['workchain=~"$workchain"'],
         ),
@@ -1631,82 +1631,82 @@ def collator_wu_metrics() -> RowPanel:
 def collator_core_operations_metrics() -> RowPanel:
     metrics = [
         create_heatmap_panel(
-            "tycho_do_collate_total_time",
+            "tycho_do_collate_total_time_high",
             "Total collation time",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_do_collate_prepare_time",
+            "tycho_do_collate_prepare_time_high",
             "Collation prepare time",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_do_collate_execute_time",
+            "tycho_do_collate_execute_time_high",
             "Execution time",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_do_collate_fill_msgs_total_time",
+            "tycho_do_collate_fill_msgs_total_time_high",
             "Execution time: incl Fill messages",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_do_collate_init_iterator_time",
+            "tycho_do_collate_init_iterator_time_high",
             "Execution time: incl Fill messages: init iterator",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_do_collate_read_int_msgs_time",
+            "tycho_do_collate_read_int_msgs_time_high",
             "Execution time: incl Fill messages: read existing",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_do_collate_read_ext_msgs_time",
+            "tycho_do_collate_read_ext_msgs_time_high",
             "Execution time: incl Fill messages: read externals",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_do_collate_read_new_msgs_time",
+            "tycho_do_collate_read_new_msgs_time_high",
             "Execution time: incl Fill messages: read new",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_do_collate_add_to_msg_groups_time",
+            "tycho_do_collate_add_to_msg_groups_time_high",
             "Execution time: incl Fill messages: add to msg groups",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_do_collate_exec_msgs_total_time",
+            "tycho_do_collate_exec_msgs_total_time_high",
             "Execution time: incl Execute messages",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_do_collate_process_txs_total_time",
+            "tycho_do_collate_process_txs_total_time_high",
             "Execution time: incl Process transactions",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_do_collate_create_queue_diff_time",
-            "async Create message queue diff",
+            "tycho_do_collate_create_queue_diff_time_high",
+            "Create message queue diff",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_do_collate_apply_queue_diff_time",
+            "tycho_do_collate_apply_queue_diff_time_high",
             "async Apply message queue diff",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_do_collate_build_statistics_time",
+            "tycho_do_collate_build_statistics_time_high",
             "async Apply message queue diff: inc. Build statistics",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_finalize_block_time",
+            "tycho_collator_finalize_block_time_high",
             "Finalize block",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_do_collate_handle_block_candidate_time",
+            "tycho_do_collate_handle_block_candidate_time_high",
             "Handle block candidate",
             labels=['workchain=~"$workchain"'],
         ),

--- a/util/src/cli/metrics.rs
+++ b/util/src/cli/metrics.rs
@@ -38,6 +38,12 @@ pub fn init_metrics(config: &MetricsConfig) -> anyhow::Result<()> {
         7.5, 10.0, 30.0, 60.0, 120.0, 180.0, 240.0, 300.0,
     ];
 
+    const EXPONENTIAL_SECONDS_HIGH: &[f64] = &[
+        0.00001, 0.0001, 0.001, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.125, 0.15, 0.175, 0.2,
+        0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.5, 2.0, 2.5,
+        3.0,
+    ];
+
     const EXPONENTIAL_LONG_SECONDS: &[f64] = &[
         0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 240.0, 300.0, 600.0, 1800.0, 3600.0, 7200.0,
         14400.0, 28800.0, 43200.0, 86400.0,
@@ -47,6 +53,10 @@ pub fn init_metrics(config: &MetricsConfig) -> anyhow::Result<()> {
 
     metrics_exporter_prometheus::PrometheusBuilder::new()
         .set_buckets_for_metric(Matcher::Suffix("_time".to_string()), EXPONENTIAL_SECONDS)?
+        .set_buckets_for_metric(
+            Matcher::Suffix("_time_high".to_string()),
+            EXPONENTIAL_SECONDS_HIGH,
+        )?
         .set_buckets_for_metric(Matcher::Suffix("_threads".to_string()), EXPONENTIAL_THREADS)?
         .set_buckets_for_metric(
             Matcher::Suffix("_time_long".to_string()),


### PR DESCRIPTION
**NODE CONFIGURATION CHANGES**
None
**BLOCKCHAIN CONFIGURATION CHANGES**
None

**COMPATIBILITY**
Message Processing Algorithm - incompatible. Now we skip externals in buffer if they expired. So, if we have large externals queue on node update then refill may result into inconsistent queue state because before expired externals were always collected from buffer.

**SPECIAL DEPLOYMENT ACTIONS**
Required
* We need to perform deploy when workload is low and there is no externals queue. Otherwise updated node may skip external or execute it one more time.
* Needs to update the Grafana dashboard.
* Needs to set up the externals timeout
```
.params.28.msgs_exec_params.externals_expire_timeout = 58
```

**PERFORMANCE IMPACT**
Expected impact
Will reduce the "Fill messages" phase performance little bit because now we will check all externals in buffer on collect.
[metrics](https://grafana.broxus.com/d/cdlaji62a1b0gb1/tycho-node-metrics-high-times?orgId=1&from=2025-05-16T06:49:50.035Z&to=2025-05-16T07:40:54.900Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet2-validator1&var-instance=tycho-devnet2-validator10&var-instance=tycho-devnet2-validator11&var-instance=tycho-devnet2-validator12&var-instance=tycho-devnet2-validator13&var-instance=tycho-devnet2-validator14&var-instance=tycho-devnet2-validator15&var-instance=tycho-devnet2-validator16&var-instance=tycho-devnet2-validator17&var-instance=tycho-devnet2-validator18&var-instance=tycho-devnet2-validator19&var-instance=tycho-devnet2-validator9&var-instance=tycho-devnet2-validator8&var-instance=tycho-devnet2-validator7&var-instance=tycho-devnet2-validator6&var-instance=tycho-devnet2-validator5&var-instance=tycho-devnet2-validator3&var-instance=tycho-devnet2-validator2&var-instance=tycho-devnet2-validator4&var-workchain=$__all&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)

"Fill messages" changed from "25-50 ms" to "50-75 ms"
![image](https://github.com/user-attachments/assets/0a44f1a7-1399-409a-9df2-13808095d836)
because "add to msgs groups" changed from "10-25 ms" to "25-50 ms"
![image](https://github.com/user-attachments/assets/25f7a9b5-b077-4d3b-80b5-92a993fd3fae)

It is a moderated impact.

Here is the [task to fix performance](https://github.com/orgs/broxus/projects/4/views/2?pane=issue&itemId=110995527).

**TESTS**
**Unit Tests**
test_refill_messages, test_read_externals
**Network Tests**
No special coverage
**Manual Tests**
Run transfers 30k to check that imported externals expire on a hard load.