### PR TITLE
move blobs from rocksdb-blobdb to cas based storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 [[package]]
 name = "cassadilia"
 version = "0.1.0"
-source = "git+https://github.com/0xdeafbeef/cassadilia.git?rev=a3a4d730#a3a4d730bc91bc738a7d64ef8fc9dc4de04febe7"
+source = "git+https://github.com/0xdeafbeef/cassadilia.git?rev=36961a988918#36961a98891850b89becd6d27078830670e8bc8e"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -923,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "endian-type"
@@ -3908,6 +3908,7 @@ dependencies = [
  "cassadilia",
  "crc32c",
  "dashmap",
+ "either",
  "everscale-types",
  "fdlimit",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -298,6 +298,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +423,22 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "cassadilia"
+version = "0.1.0"
+source = "git+https://github.com/0xdeafbeef/cassadilia.git?rev=a3a4d730#a3a4d730bc91bc738a7d64ef8fc9dc4de04febe7"
+dependencies = [
+ "anyhow",
+ "bincode 2.0.1",
+ "blake3",
+ "bytes",
+ "hex",
+ "rand 0.9.1",
+ "tempfile",
+ "thiserror 2.0.11",
+ "tracing",
 ]
 
 [[package]]
@@ -947,7 +983,7 @@ dependencies = [
  "curve25519-dalek",
  "generic-array",
  "hex",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2",
  "tl-proto",
@@ -972,7 +1008,7 @@ dependencies = [
  "hex",
  "num-bigint",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "scc",
  "serde",
@@ -1191,7 +1227,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1293,7 +1341,7 @@ dependencies = [
  "hickory-proto",
  "once_cell",
  "radix_trie",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.66",
  "tokio",
  "tracing",
@@ -1315,7 +1363,7 @@ dependencies = [
  "idna 0.4.0",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.66",
  "tinyvec",
  "tokio",
@@ -1757,7 +1805,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1941,7 +1989,7 @@ dependencies = [
  "once_cell",
  "opentelemetry_api",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.66",
 ]
 
@@ -2240,7 +2288,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -2282,7 +2330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
- "rand",
+ "rand 0.8.5",
  "ring",
  "rustc-hash 2.1.0",
  "rustls",
@@ -2315,6 +2363,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "radix_trie"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,8 +2385,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2342,7 +2406,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2351,7 +2425,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -2360,7 +2443,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2407,7 +2490,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.66",
 ]
@@ -2507,7 +2590,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -2805,7 +2888,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2958,7 +3041,7 @@ dependencies = [
  "humantime",
  "opentelemetry",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "serde",
  "static_assertions",
  "tarpc-plugins",
@@ -3237,7 +3320,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "bytes",
  "educe",
  "futures-core",
@@ -3512,7 +3595,7 @@ dependencies = [
  "metrics",
  "num-bigint",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "reqwest",
  "rustc_version",
@@ -3558,7 +3641,7 @@ dependencies = [
  "indexmap 2.6.0",
  "metrics",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "scc",
  "scopeguard",
@@ -3602,7 +3685,7 @@ dependencies = [
  "itertools 0.12.1",
  "metrics",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "rayon",
  "scopeguard",
@@ -3665,7 +3748,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "scopeguard",
  "serde",
  "tempfile",
@@ -3708,7 +3791,7 @@ dependencies = [
  "clap",
  "everscale-crypto",
  "everscale-types",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tokio",
@@ -3746,7 +3829,7 @@ dependencies = [
  "pin-project-lite",
  "pkcs8",
  "quinn",
- "rand",
+ "rand 0.8.5",
  "ring",
  "rustls",
  "rustls-webpki",
@@ -3780,7 +3863,7 @@ dependencies = [
  "num-bigint",
  "parking_lot",
  "prost",
- "rand",
+ "rand 0.8.5",
  "scopeguard",
  "serde",
  "serde_json",
@@ -3822,6 +3905,7 @@ dependencies = [
  "bumpalo",
  "bytes",
  "bytesize",
+ "cassadilia",
  "crc32c",
  "dashmap",
  "everscale-types",
@@ -3834,7 +3918,7 @@ dependencies = [
  "parking_lot",
  "parking_lot_core",
  "quick_cache",
- "rand",
+ "rand 0.8.5",
  "rlimit",
  "scopeguard",
  "serde",
@@ -3869,7 +3953,7 @@ dependencies = [
  "libc",
  "metrics",
  "metrics-exporter-prometheus",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "serde_json",
@@ -3971,6 +4055,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3993,7 +4083,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -4013,6 +4103,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"
@@ -4038,6 +4134,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -4377,6 +4482,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ dashmap = "5.5.3"
 dirs = "5.0.1"
 ed25519 = "2.0"
 ed25519-dalek = "2.1"
+either = "1.15.0"
 everscale-crypto = { version = "0.3", features = ["tl-proto", "serde"] }
 everscale-types = { version = "0.1.2", features = ["tycho"] }
 exponential-backoff = "1"

--- a/block-util/src/archive/proto.rs
+++ b/block-util/src/archive/proto.rs
@@ -17,7 +17,7 @@ pub struct ArchiveEntryHeader {
 
 pub const ARCHIVE_ENTRY_HEADER_LEN: usize = 4 + 4 + 8 + 4 + 32 + 32 + 4 + 4;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TlRead, TlWrite)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TlRead, TlWrite, Ord, PartialOrd)]
 #[tl(boxed, scheme = "proto.tl")]
 #[repr(u8)]
 pub enum ArchiveEntryType {

--- a/control/src/server.rs
+++ b/control/src/server.rs
@@ -5,7 +5,6 @@ use std::sync::{Arc, OnceLock};
 
 use anyhow::{Context as _, Result};
 use arc_swap::ArcSwapOption;
-use bytes::Bytes;
 use everscale_crypto::ed25519;
 use everscale_types::cell::Lazy;
 use everscale_types::models::{
@@ -597,10 +596,7 @@ impl proto::ControlServer for ControlServer {
             return Ok(proto::BlockResponse::NotFound);
         };
 
-        let data = {
-            let data = blocks.load_block_data_raw_ref(&handle).await?;
-            Bytes::copy_from_slice(data.as_ref())
-        };
+        let data = blocks.load_block_data_raw(&handle).await?;
         Ok(proto::BlockResponse::Found { data })
     }
 
@@ -616,10 +612,8 @@ impl proto::ControlServer for ControlServer {
             return Ok(proto::BlockResponse::NotFound);
         };
 
-        let data = {
-            let data = blocks.load_block_proof_raw_ref(&handle).await?;
-            Bytes::copy_from_slice(data.as_ref())
-        };
+        let data = blocks.load_block_proof_raw(&handle).await?;
+
         Ok(proto::BlockResponse::Found { data })
     }
 
@@ -635,10 +629,8 @@ impl proto::ControlServer for ControlServer {
             return Ok(proto::BlockResponse::NotFound);
         };
 
-        let data = {
-            let data = blocks.load_queue_diff_raw_ref(&handle).await?;
-            Bytes::copy_from_slice(data.as_ref())
-        };
+        let data = blocks.load_queue_diff_raw(&handle).await?;
+
         Ok(proto::BlockResponse::Found { data })
     }
 
@@ -672,11 +664,8 @@ impl proto::ControlServer for ControlServer {
         req: proto::ArchiveSliceRequest,
     ) -> ServerResult<proto::ArchiveSliceResponse> {
         let blocks = self.inner.storage.block_storage();
+        let data = blocks.get_archive_chunk(req.archive_id, req.offset).await?;
 
-        let data = {
-            let data = blocks.get_archive_chunk(req.archive_id, req.offset).await?;
-            Bytes::copy_from_slice(data.as_ref())
-        };
         Ok(proto::ArchiveSliceResponse { data })
     }
 

--- a/core/tests/storage/mod.rs
+++ b/core/tests/storage/mod.rs
@@ -61,7 +61,10 @@ pub(crate) async fn init_storage() -> Result<(Storage, TempDir)> {
             .store_block_proof(&proof, handle.into())
             .await?
             .handle;
-        let bp = blocks.load_block_proof(&handle).await?;
+        let bp = blocks
+            .load_block_proof(&handle)
+            .await
+            .context("Failed to load proof")?;
 
         assert_eq!(bp.is_link(), proof.is_link());
         assert_eq!(bp.proof().root, proof.as_ref().root);

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -17,6 +17,7 @@ bitflags = { workspace = true }
 bumpalo = { workspace = true }
 bytes = { workspace = true }
 bytesize = { workspace = true }
+cassadilia = { git = "https://github.com/0xdeafbeef/cassadilia.git", rev = "a3a4d730" }
 crc32c = { workspace = true }
 dashmap = { workspace = true }
 everscale-types = { workspace = true, features = ["tycho", "stats"] }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -17,9 +17,10 @@ bitflags = { workspace = true }
 bumpalo = { workspace = true }
 bytes = { workspace = true }
 bytesize = { workspace = true }
-cassadilia = { git = "https://github.com/0xdeafbeef/cassadilia.git", rev = "a3a4d730" }
+cassadilia = { git = "https://github.com/0xdeafbeef/cassadilia.git", rev = "36961a988918" }
 crc32c = { workspace = true }
 dashmap = { workspace = true }
+either = { workspace = true }
 everscale-types = { workspace = true, features = ["tycho", "stats"] }
 fdlimit = { workspace = true }
 humantime = { workspace = true }

--- a/storage/src/config.rs
+++ b/storage/src/config.rs
@@ -223,18 +223,12 @@ pub struct BlocksCacheConfig {
     /// Default: `5 min`.
     #[serde(with = "serde_helpers::humantime")]
     pub ttl: Duration,
-
-    /// Cache capacity in bytes.
-    ///
-    /// Default: `500 MB`.
-    pub size: ByteSize,
 }
 
 impl Default for BlocksCacheConfig {
     fn default() -> Self {
         Self {
             ttl: Duration::from_secs(300),
-            size: ByteSize::mb(500),
         }
     }
 }

--- a/storage/src/db/kv_db/mod.rs
+++ b/storage/src/db/kv_db/mod.rs
@@ -121,7 +121,6 @@ impl WithMigrations for BaseDb {
 weedb::tables! {
     pub struct BaseTables<Caches> {
         pub state: tables::State,
-        pub archives: tables::Archives,
         pub archive_block_ids: tables::ArchiveBlockIds,
         pub block_handles: tables::BlockHandles,
         pub key_blocks: tables::KeyBlocks,

--- a/storage/src/db/kv_db/mod.rs
+++ b/storage/src/db/kv_db/mod.rs
@@ -86,7 +86,7 @@ impl BaseDbExt for BaseDb {
 
         // Check if the DB is NOT EMPTY
         {
-            let mut package_entires_iter = self.package_entries.raw_iterator();
+            let mut package_entires_iter = self.cells.raw_iterator(); // todo: why are we doing this?
             package_entires_iter.seek_to_first();
             package_entires_iter.status()?;
             if package_entires_iter.item().is_none() {
@@ -125,8 +125,8 @@ weedb::tables! {
         pub block_handles: tables::BlockHandles,
         pub key_blocks: tables::KeyBlocks,
         pub full_block_ids: tables::FullBlockIds,
-        pub package_entries: tables::PackageEntries,
-        pub block_data_entries: tables::BlockDataEntries,
+        // pub package_entries: tables::PackageEntries,
+        // pub block_data_entries: tables::BlockDataEntries,
         pub shard_states: tables::ShardStates,
         pub cells: tables::Cells,
         pub temp_cells: tables::TempCells,
@@ -145,13 +145,15 @@ mod base_migrations {
 
     use everscale_types::boc::Boc;
     use tycho_block_util::archive::ArchiveEntryType;
-    use weedb::rocksdb::CompactOptions;
+    use weedb::rocksdb::{CompactOptions, DBRawIterator};
 
     use super::*;
     use crate::util::StoredValue;
 
     pub fn v0_0_1_to_0_0_2(db: &BaseDb, cancelled: CancellationFlag) -> Result<(), MigrationError> {
-        let mut block_data_iter = db.package_entries.raw_iterator();
+        return Ok(());
+        // let mut block_data_iter = db.package_entries.raw_iterator();
+        let mut block_data_iter: DBRawIterator = todo!();
         block_data_iter.seek_to_first();
 
         tracing::info!("stated migrating package entries");

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -171,8 +171,6 @@ impl StorageBuilder {
 
         temp_file_storage.remove_outdated_files().await?;
 
-        block_storage.finish_block_data().await?;
-
         let internal_queue_db = InternalQueueDB::builder_prepared(
             self.config.root_dir.join(INT_QUEUE_SUBDIR),
             caches.clone(),

--- a/storage/src/store/block/mod.rs
+++ b/storage/src/store/block/mod.rs
@@ -447,7 +447,9 @@ impl BlockStorage {
         if !handle.has_proof() {
             let data = proof.as_new_archive_data()?;
 
+            let start = std::time::Instant::now();
             let _lock = handle.proof_data_lock().write().await;
+            tracing::info!("lock proof data lock took {:?}", start.elapsed());
             if !handle.has_proof() {
                 self.add_block_data_compressed(&archive_id, data).await?;
                 if handle.meta().add_flags(BlockFlags::HAS_PROOF) {

--- a/storage/src/store/block/mod.rs
+++ b/storage/src/store/block/mod.rs
@@ -5,13 +5,12 @@ use std::num::NonZeroU32;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Instant;
 
 use anyhow::{Context, Result};
 use bytes::{Buf, Bytes};
 use bytesize::ByteSize;
 use cassadilia::Bubs;
-use everscale_types::boc::{Boc, BocRepr};
+use everscale_types::boc::BocRepr;
 use everscale_types::cell::HashBytes;
 use everscale_types::models::*;
 use parking_lot::RwLock;
@@ -29,14 +28,14 @@ use tycho_util::compression::ZstdCompressStream;
 use tycho_util::metrics::HistogramGuard;
 use tycho_util::sync::{rayon_run, CancellationFlag};
 use tycho_util::{FastHashSet, FastHasherState};
-use weedb::{rocksdb, ColumnFamily, OwnedPinnableSlice};
+use weedb::rocksdb;
 
 pub use self::package_entry::{BlockDataEntryKey, PackageEntryKey, PartialBlockId};
 use crate::db::*;
 use crate::util::*;
 use crate::{
-    BlockConnectionStorage, BlockDataGuard, BlockFlags, BlockHandle, BlockHandleStorage,
-    BlocksCacheConfig, HandleCreationStatus, NewBlockMeta, NodeStateStorage, StorageConfig,
+    BlockConnectionStorage, BlockFlags, BlockHandle, BlockHandleStorage, BlocksCacheConfig,
+    HandleCreationStatus, NewBlockMeta, NodeStateStorage, StorageConfig,
 };
 
 mod package_entry;
@@ -65,9 +64,10 @@ pub struct BlockStorage {
     in_progress_archives: FileDb,
 }
 
+#[derive(Clone)]
 pub struct BlobDbs {
     pub archives: cassadilia::Bubs<u32>,
-    pub package_entries: cassadilia::Bubs<String>,
+    pub package_entries: cassadilia::Bubs<PackageEntryKey>,
 }
 
 impl BlobDbs {
@@ -91,21 +91,35 @@ impl BlobDbs {
             }
         }
 
-        struct NOOPEncoder;
+        struct PackageEntryEncoder;
 
-        impl cassadilia::KeyEncoder<String> for NOOPEncoder {
-            fn encode(&self, key: &String) -> Result<Vec<u8>> {
-                todo!()
+        impl cassadilia::KeyEncoder<PackageEntryKey> for PackageEntryEncoder {
+            fn encode(&self, key: &PackageEntryKey) -> Result<Vec<u8>> {
+                let mut buf = Vec::with_capacity(PackageEntryKey::SIZE_HINT);
+                key.serialize(&mut buf);
+
+                Ok(buf)
             }
 
-            fn decode(&self, data: &[u8]) -> Result<String> {
-                todo!()
+            fn decode(&self, data: &[u8]) -> Result<PackageEntryKey> {
+                if data.len() != PackageEntryKey::SIZE_HINT {
+                    return Err(anyhow::anyhow!("Invalid length for PackageEntryKey"));
+                }
+                let mut slice = data;
+                let key = PackageEntryKey::deserialize(&mut slice);
+                anyhow::ensure!(slice.is_empty(), "Invalid length for PackageEntryKey");
+                Ok(key)
             }
         }
 
-        let archives = cassadilia::Bubs::open(db_root.join("archives"), U32Encoder).unwrap();
+        let config = cassadilia::Config {
+            sync_mode: cassadilia::SyncMode::Async,
+        };
+        let archives =
+            cassadilia::Bubs::open(db_root.join("archives"), U32Encoder, config.clone()).unwrap();
         let package_entries =
-            cassadilia::Bubs::open(db_root.join("package_entries"), NOOPEncoder).unwrap();
+            cassadilia::Bubs::open(db_root.join("package_entries"), PackageEntryEncoder, config)
+                .unwrap();
 
         BlobDbs {
             archives,
@@ -132,18 +146,8 @@ impl BlockStorage {
         archive_chunk_size: ByteSize,
         node_state_storage: NodeStateStorage,
     ) -> Result<Self> {
-        fn weigher(_key: &BlockId, value: &BlockStuff) -> u32 {
-            const BLOCK_STUFF_OVERHEAD: u32 = 1024; // 1 KB
-
-            size_of::<BlockId>() as u32
-                + BLOCK_STUFF_OVERHEAD
-                + value.data_size().try_into().unwrap_or(u32::MAX)
-        }
-
         let blocks_cache = moka::sync::Cache::builder()
-            .time_to_live(config.blocks_cache.ttl)
-            .max_capacity(config.blocks_cache.size.as_u64())
-            .weigher(weigher)
+            .time_to_idle(config.blocks_cache.ttl)
             .build_with_hasher(Default::default());
 
         let in_progress_archives = file_db.create_subdir("archive_ids")?;
@@ -234,77 +238,6 @@ impl BlockStorage {
         NonZeroU32::new(BLOCK_DATA_CHUNK_SIZE).unwrap()
     }
 
-    pub async fn finish_block_data(&self) -> Result<()> {
-        let started_at = Instant::now();
-
-        tracing::info!("started finishing compressed block data");
-
-        let mut iter = self.db.block_data_entries.raw_iterator();
-        iter.seek_to_first();
-
-        let mut blocks_to_finish = Vec::new();
-
-        loop {
-            let Some(key) = iter.key() else {
-                if let Err(e) = iter.status() {
-                    tracing::error!("failed to iterate through compressed block data: {e:?}");
-                }
-                break;
-            };
-
-            let key = BlockDataEntryKey::from_slice(key);
-
-            const _: () = const {
-                // Rely on the specific order of these constants
-                assert!(BLOCK_DATA_STARTED_MAGIC < BLOCK_DATA_SIZE_MAGIC);
-            };
-
-            // Chunk keys are sorted by offset.
-            match key.chunk_index {
-                // "Started" magic comes first, and indicates that the block exists.
-                BLOCK_DATA_STARTED_MAGIC => {
-                    blocks_to_finish.push(key.block_id);
-                }
-                // "Size" magic comes last, and indicates that the block data is finished.
-                BLOCK_DATA_SIZE_MAGIC => {
-                    // Last block id is already finished
-                    let last = blocks_to_finish.pop();
-                    anyhow::ensure!(last == Some(key.block_id), "invalid block data SIZE entry");
-                }
-                _ => {}
-            }
-
-            iter.next();
-        }
-
-        drop(iter);
-
-        for block_id in blocks_to_finish {
-            tracing::info!(?block_id, "found unfinished block");
-
-            let key = PackageEntryKey {
-                block_id,
-                ty: ArchiveEntryType::Block,
-            };
-
-            let data = match self.db.package_entries.get(key.to_vec())? {
-                Some(data) => data,
-                None => return Err(BlockStorageError::BlockDataNotFound.into()),
-            };
-
-            let permit = self.split_block_semaphore.clone().acquire_owned().await?;
-            self.spawn_split_block_data(&block_id, &data, permit)
-                .await??;
-        }
-
-        tracing::info!(
-            elapsed = %humantime::format_duration(started_at.elapsed()),
-            "finished handling unfinished blocks"
-        );
-
-        Ok(())
-    }
-
     // === Subscription stuff ===
 
     pub async fn wait_for_block(&self, block_id: &BlockId) -> Result<BlockStuffAug> {
@@ -367,7 +300,7 @@ impl BlockStorage {
 
             let _lock = handle.block_data_lock().write().await;
             if !handle.has_data() {
-                self.add_block_data_and_split(&archive_id, data).await?;
+                self.add_block_data_compressed(&archive_id, data).await?;
                 if handle.meta().add_flags(BlockFlags::HAS_DATA) {
                     self.block_handle_storage.store_handle(&handle, false);
                     updated = true;
@@ -407,23 +340,19 @@ impl BlockStorage {
             return Ok(block.clone());
         }
 
-        let FullBlockDataGuard { _lock, data } = self
-            .get_data_ref(handle, &PackageEntryKey::block(handle.id()))
+        let data = self
+            .get_data(handle, &PackageEntryKey::block(handle.id()))
             .await?;
 
         if data.len() > BIG_DATA_THRESHOLD {
             BlockStuff::deserialize(handle.id(), data.as_ref())
         } else {
             let handle = handle.clone();
-
-            // SAFETY: `data` was created by the `self.db` RocksDB instance.
-            let owned_data =
-                unsafe { weedb::OwnedPinnableSlice::new(self.db.rocksdb().clone(), data) };
-            rayon_run(move || BlockStuff::deserialize(handle.id(), owned_data.as_ref())).await
+            rayon_run(move || BlockStuff::deserialize(handle.id(), data.as_ref())).await
         }
     }
 
-    pub async fn load_block_data_raw(&self, handle: &BlockHandle) -> Result<OwnedPinnableSlice> {
+    pub async fn load_block_data_raw(&self, handle: &BlockHandle) -> Result<Bytes> {
         if !handle.has_data() {
             return Err(BlockStorageError::BlockDataNotFound.into());
         }
@@ -435,123 +364,63 @@ impl BlockStorage {
         &self,
         continuation: Option<BlockIdShort>,
     ) -> Result<(Vec<BlockId>, Option<BlockIdShort>)> {
-        const LIMIT: usize = 1000; // Max blocks per response
-        const MAX_BYTES: usize = 1 << 20; // 1 MB processed per response
+        const LIMIT: usize = 1000;
 
-        let continuation = continuation.map(|block_id| {
-            PackageEntryKey::block(&BlockId {
-                shard: block_id.shard,
-                seqno: block_id.seqno,
-                root_hash: HashBytes::ZERO,
-                file_hash: HashBytes::ZERO,
-            })
-            .to_vec()
-        });
+        let all_blocks: BTreeSet<BlockId> = self
+            .blob_dbs
+            .package_entries
+            .index_snapshot()
+            .into_iter()
+            .filter(|(k, _)| k.ty == ArchiveEntryType::Block)
+            .map(|(k, v)| k.block_id.make_full(HashBytes::from_slice(v.as_ref())))
+            .collect();
 
-        let mut iter = {
-            let mut readopts = rocksdb::ReadOptions::default();
-            tables::PackageEntries::read_options(&mut readopts);
-            if let Some(key) = &continuation {
-                readopts.set_iterate_lower_bound(key.as_slice());
-            }
-            self.db
-                .rocksdb()
-                .raw_iterator_cf_opt(&self.db.package_entries.cf(), readopts)
-        };
-
-        // NOTE: Despite setting the lower bound we must still seek to the exact key.
-        match continuation {
-            None => iter.seek_to_first(),
-            Some(key) => iter.seek(key),
-        }
-
-        let mut bytes = 0;
-        let mut blocks = Vec::new();
-
-        let continuation = loop {
-            let (key, value) = match iter.item() {
-                Some(item) => item,
-                None => {
-                    iter.status()?;
-                    break None;
-                }
+        let page_iter = if let Some(cont_short) = continuation.as_ref() {
+            let start_bound = BlockId {
+                shard: cont_short.shard,
+                seqno: cont_short.seqno,
+                root_hash: Default::default(),
+                file_hash: Default::default(),
             };
-
-            let id = PackageEntryKey::from_slice(key);
-            if id.ty != ArchiveEntryType::Block {
-                // Ignore non-block entries
-                iter.next();
-                continue;
-            }
-
-            if blocks.len() >= LIMIT || bytes >= MAX_BYTES {
-                break Some(id.block_id.as_short_id());
-            }
-
-            let file_hash = Boc::file_hash_blake(value);
-            let block_id = id.block_id.make_full(file_hash);
-
-            bytes += value.len();
-            blocks.push(block_id);
-
-            iter.next();
+            either::Either::Left(all_blocks.range(start_bound..).skip_while(|block| {
+                block.shard < cont_short.shard
+                    || (block.shard == cont_short.shard && block.seqno <= cont_short.seqno)
+            }))
+        } else {
+            either::Either::Right(all_blocks.iter())
         };
 
-        Ok((blocks, continuation))
+        let mut result_blocks: Vec<BlockId> = page_iter.take(LIMIT + 1).cloned().collect();
+
+        let next_continuation = if result_blocks.len() > LIMIT {
+            result_blocks.pop().map(|block| block.as_short_id())
+        } else {
+            None
+        };
+
+        Ok((result_blocks, next_continuation))
     }
 
-    pub fn list_archive_ids(&self) -> Vec<u32> {
-        let mut keys = self.blob_dbs.archives.known_keys();
-        keys.sort_unstable();
-        keys
-    }
-
-    pub async fn load_block_data_raw_ref<'a>(
-        &'a self,
-        handle: &'a BlockHandle,
-    ) -> Result<impl AsRef<[u8]> + 'a> {
-        if !handle.has_data() {
-            return Err(BlockStorageError::BlockDataNotFound.into());
-        }
-        self.get_data_ref(handle, &PackageEntryKey::block(handle.id()))
-            .await
+    pub fn list_archive_ids(&self) -> BTreeSet<u32> {
+        self.blob_dbs.archives.known_keys()
     }
 
     pub fn find_mc_block_data(&self, mc_seqno: u32) -> Result<Option<Block>> {
-        let package_entries = &self.db.package_entries;
-
-        let bound = BlockId {
-            shard: ShardIdent::MASTERCHAIN,
-            seqno: mc_seqno,
-            root_hash: HashBytes::ZERO,
-            file_hash: HashBytes::ZERO,
+        let Some(key) = self
+            .blob_dbs
+            .package_entries
+            .known_keys()
+            .iter()
+            .find(|k| k.block_id.shard == ShardIdent::MASTERCHAIN && k.block_id.seqno == mc_seqno)
+            .cloned()
+        else {
+            return Ok(None);
         };
 
-        let mut bound = PackageEntryKey::block(&bound);
-
-        let mut readopts = package_entries.new_read_config();
-        readopts.set_iterate_lower_bound(bound.to_vec().into_vec());
-        bound.block_id.seqno += 1;
-        readopts.set_iterate_upper_bound(bound.to_vec().into_vec());
-
-        let mut iter = self
-            .db
-            .rocksdb()
-            .raw_iterator_cf_opt(&package_entries.cf(), readopts);
-
-        iter.seek_to_first();
-        loop {
-            let Some((key, value)) = iter.item() else {
-                iter.status()?;
-                return Ok(None);
-            };
-
-            let Some(ArchiveEntryType::Block) = extract_entry_type(key) else {
-                continue;
-            };
-
-            return Ok(Some(BocRepr::decode::<Block, _>(value)?));
-        }
+        Ok(match self.blob_dbs.package_entries.get(&key)? {
+            None => None,
+            Some(b) => Some(BocRepr::decode(b.as_ref())?),
+        })
     }
 
     // === Block proof ===
@@ -580,7 +449,7 @@ impl BlockStorage {
 
             let _lock = handle.proof_data_lock().write().await;
             if !handle.has_proof() {
-                self.add_data(&archive_id, data)?;
+                self.add_block_data_compressed(&archive_id, data).await?;
                 if handle.meta().add_flags(BlockFlags::HAS_PROOF) {
                     self.block_handle_storage.store_handle(&handle, false);
                     updated = true;
@@ -596,28 +465,16 @@ impl BlockStorage {
     }
 
     pub async fn load_block_proof(&self, handle: &BlockHandle) -> Result<BlockProofStuff> {
-        let raw_proof = self.load_block_proof_raw_ref(handle).await?;
+        let raw_proof = self.load_block_proof_raw(handle).await?;
         BlockProofStuff::deserialize(handle.id(), raw_proof.as_ref())
     }
 
-    pub async fn load_block_proof_raw(&self, handle: &BlockHandle) -> Result<OwnedPinnableSlice> {
+    pub async fn load_block_proof_raw(&self, handle: &BlockHandle) -> Result<Bytes> {
         if !handle.has_proof() {
             return Err(BlockStorageError::BlockProofNotFound.into());
         }
 
         self.get_data(handle, &PackageEntryKey::proof(handle.id()))
-            .await
-    }
-
-    pub async fn load_block_proof_raw_ref<'a>(
-        &'a self,
-        handle: &'a BlockHandle,
-    ) -> Result<impl AsRef<[u8]> + 'a> {
-        if !handle.has_proof() {
-            return Err(BlockStorageError::BlockProofNotFound.into());
-        }
-
-        self.get_data_ref(handle, &PackageEntryKey::proof(handle.id()))
             .await
     }
 
@@ -647,7 +504,7 @@ impl BlockStorage {
 
             let _lock = handle.queue_diff_data_lock().write().await;
             if !handle.has_queue_diff() {
-                self.add_data(&archive_id, data)?;
+                self.add_block_data_compressed(&archive_id, data).await?;
                 if handle.meta().add_flags(BlockFlags::HAS_QUEUE_DIFF) {
                     self.block_handle_storage.store_handle(&handle, false);
                     updated = true;
@@ -663,27 +520,16 @@ impl BlockStorage {
     }
 
     pub async fn load_queue_diff(&self, handle: &BlockHandle) -> Result<QueueDiffStuff> {
-        let raw_diff = self.load_queue_diff_raw_ref(handle).await?;
+        let raw_diff = self.load_queue_diff_raw(handle).await?;
         QueueDiffStuff::deserialize(handle.id(), raw_diff.as_ref())
     }
 
-    pub async fn load_queue_diff_raw(&self, handle: &BlockHandle) -> Result<OwnedPinnableSlice> {
+    pub async fn load_queue_diff_raw(&self, handle: &BlockHandle) -> Result<Bytes> {
         if !handle.has_queue_diff() {
             return Err(BlockStorageError::QueueDiffNotFound.into());
         }
 
         self.get_data(handle, &PackageEntryKey::queue_diff(handle.id()))
-            .await
-    }
-
-    pub async fn load_queue_diff_raw_ref<'a>(
-        &'a self,
-        handle: &'a BlockHandle,
-    ) -> Result<impl AsRef<[u8]> + 'a> {
-        if !handle.has_queue_diff() {
-            return Err(BlockStorageError::QueueDiffNotFound.into());
-        }
-        self.get_data_ref(handle, &PackageEntryKey::queue_diff(handle.id()))
             .await
     }
 
@@ -704,10 +550,8 @@ impl BlockStorage {
         let archive_block_ids_cf = self.db.archive_block_ids.cf();
 
         // Prepare archive
-        let archive_id = self.prepare_archive_id(
-            handle.ref_by_mc_seqno(),
-            mc_is_key_block || handle.is_key_block(),
-        );
+        let force_split = mc_is_key_block || handle.is_key_block();
+        let archive_id = self.prepare_archive_id(handle.ref_by_mc_seqno(), force_split);
         let archive_id_bytes = archive_id.id.to_be_bytes();
 
         // 0. Create transaction
@@ -718,8 +562,7 @@ impl BlockStorage {
 
         self.db.rocksdb().write(batch)?;
 
-        tracing::debug!(block_id = %handle.id(), ?archive_id,  "saved block id into archive");
-        // Block will be removed after blocks gc
+        tracing::debug!(block_id = %handle.id(), ?archive_id, force_split,  "saved block id into archive");
 
         if let Some(to_commit) = archive_id.to_commit {
             let mut should_start_commit = true;
@@ -761,15 +604,56 @@ impl BlockStorage {
 
     /// Returns a corresponding archive id for the specified masterchain seqno.
     pub fn get_archive_meta(&self, mc_seqno: u32) -> ArchiveMeta {
+        let archive_ids: BTreeSet<u32> = self.blob_dbs.archives.known_keys();
+
+        // Find the largest archive ID that is less than or equal to mc_seqno.
+        // This is our candidate archive.
+        let maybe_candidate_id_and_end = archive_ids
+            .range(..=mc_seqno)
+            .next_back()
+            .map(|&id| (id, id.saturating_add(ARCHIVE_PACKAGE_SIZE)));
+
+        // 1. Check if mc_seqno falls into an existing, retrievable archive package
+        if let Some((candidate_id, archive_end_exclusive)) = maybe_candidate_id_and_end {
+            if mc_seqno < archive_end_exclusive {
+                // mc_seqno is within this candidate package's theoretical range.
+                // Now check if the data actually exists.
+                return match self.blob_dbs.archives.size(&candidate_id) {
+                    Ok(Some(len)) => ArchiveMeta::Found {
+                        mc_block_id: candidate_id,
+                        len,
+                    },
+                    Ok(None) => {
+                        tracing::warn!(
+                            archive_id = candidate_id,
+                            target_mc_seqno = mc_seqno,
+                            "archive was present in known_keys but size not found (deleted by gc or index corrupted?)"
+                        );
+                        ArchiveMeta::NotFound // Treat as not found if data is gone
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            archive_id = candidate_id,
+                            target_mc_seqno = mc_seqno,
+                            error = %e,
+                            "Failed to get archive size"
+                        );
+                        ArchiveMeta::NotFound // Or introduce an ArchiveMeta::Error variant
+                    }
+                };
+            }
+            // If mc_seqno >= archive_end_exclusive, it's after this candidate's package.
+            // Fall through to determine if TooNew or NotFound (gap).
+        }
+
+        // 2. If not found in a retrievable package, determine if TooNew or NotFound.
         let Some(last_mc_block) = self.node_state_storage.load_last_mc_block_id() else {
-            return ArchiveMeta::TooNew; // Node has no known masterchain blocks yet
+            // Node has no known masterchain blocks yet. Any request is TooNew relative to node state.
+            return ArchiveMeta::TooNew;
         };
 
-        // If mc_seqno is too far ahead of the latest known block, it's too new.
-        // Example: last_mc_block.seqno = 500, ARCHIVE_PACKAGE_SIZE = 100.
-        // If mc_seqno = 300, 500 - 300 = 200. 200 - 100 = 100. is_some(). OK.
-        // If mc_seqno = 450, 500 - 450 = 50. 50 - 100 = None. TooNew.
-        // If mc_seqno = 600, 500 - 600 = None. TooNew.
+        // Global "TooNew" check: Is mc_seqno too recent relative to the node's latest block?
+        // This is the original logic from your snippet.
         if last_mc_block
             .seqno
             .checked_sub(mc_seqno)
@@ -779,84 +663,35 @@ impl BlockStorage {
             return ArchiveMeta::TooNew;
         }
 
-        // Assuming self.blob_dbs.archives.known_keys() now returns a BTreeSet<u32>
-        let archive_ids: BTreeSet<u32> = self.blob_dbs.archives.known_keys();
+        // At this point:
+        // - Not found in a specific, existing, covering archive package (step 1).
+        // - Not "globally too new" according to last_mc_block and ARCHIVE_PACKAGE_SIZE.
+        // Now distinguish "NotFound" (gap, or older than any archive)
+        // from "TooNew" (newer than the *last existing* archive).
 
         if archive_ids.is_empty() {
-            return ArchiveMeta::NotFound; // No archives at all
+            // No archives exist at all, and it's not globally TooNew. So, it's NotFound.
+            return ArchiveMeta::NotFound;
         }
 
-        // Find the largest archive ID that is less than or equal to mc_seqno.
-        // This is our candidate archive, as mc_seqno could potentially fall into its range.
-        // BTreeSet::range(..=value) gives an iterator to elements <= value.
-        // .next_back() gives the largest of these.
-        let Some(&candidate_id) = archive_ids.range(..=mc_seqno).next_back() else {
-            // All archive IDs in the set are > mc_seqno.
-            // This means mc_seqno is smaller than the ID of the very first archive.
-            // Example: mc_seqno = 5, archive_ids = {10, 20} -> range(..=5) is empty.
-            return ArchiveMeta::NotFound;
-        };
-
-        // Now `candidate_id` is the largest archive ID <= `mc_seqno`.
-        // Example: mc_seqno = 15, archive_ids = {10, 20} -> candidate_id = 10.
-        // Example: mc_seqno = 10, archive_ids = {10, 20} -> candidate_id = 10.
-        // Example: mc_seqno = 25, archive_ids = {10, 20} -> candidate_id = 20.
-
-        // Check if mc_seqno is within the range covered by this candidate archive package.
-        // The range is [candidate_id, candidate_id + ARCHIVE_PACKAGE_SIZE).
-        let archive_end_exclusive = candidate_id.saturating_add(ARCHIVE_PACKAGE_SIZE);
-
-        if mc_seqno < archive_end_exclusive {
-            // mc_seqno falls within the candidate package's range.
-            match self.blob_dbs.archives.size(&candidate_id) {
-                Ok(Some(len)) => ArchiveMeta::Found {
-                    mc_block_id: candidate_id,
-                    len,
-                },
-                Ok(None) => {
-                    // Archive ID existed in keys, but size() returned None (deleted by GC?)
-                    tracing::warn!(
-                        archive_id = candidate_id,
-                        target_mc_seqno = mc_seqno,
-                        "archive was present in known_keys but size not found (deleted by gc or index corrupted?)"
-                    );
-                    ArchiveMeta::NotFound // Treat as not found if data is gone
-                }
-                Err(e) => {
-                    tracing::error!(
-                        archive_id = candidate_id,
-                        target_mc_seqno = mc_seqno,
-                        error = %e,
-                        "Failed to get archive size"
-                    );
-                    ArchiveMeta::NotFound // Or introduce an ArchiveMeta::Error variant
+        match maybe_candidate_id_and_end {
+            Some((candidate_id, _)) => {
+                // A candidate_id (largest archive_id <= mc_seqno) was found,
+                // but mc_seqno was >= its package end (handled in step 1 fall-through).
+                if Some(&candidate_id) == archive_ids.last() {
+                    // mc_seqno is after the *last existing* archive package.
+                    // Since it's not globally TooNew, it implies an expectation for an archive
+                    // that isn't present yet. Consistent with original logic's "TooNew".
+                    ArchiveMeta::TooNew
+                } else {
+                    // mc_seqno is after candidate_id's package, but candidate_id is NOT the last archive.
+                    // This means mc_seqno falls into a gap between existing archive packages.
+                    ArchiveMeta::NotFound
                 }
             }
-        } else {
-            // mc_seqno is >= candidate_id + ARCHIVE_PACKAGE_SIZE.
-            // It falls *after* the range covered by the candidate package.
-            // Now we need to distinguish: is it in a gap, or truly too new (newer than the latest archive)?
-
-            // Check if the candidate we found was the *last* known archive ID in the set.
-            // BTreeSet::last() returns an Option<&T> to the largest element.
-            // We know archive_ids is not empty here, so .last() will be Some.
-            if Some(&candidate_id) == archive_ids.last() {
-                // Yes, `candidate_id` is the ID of the last archive package.
-                // Since `mc_seqno` is outside its range (and it's the last archive),
-                // it's newer than any known archive package.
-                // Example: mc_seqno = 1025, archive_ids = {10, 20}, ARCHIVE_PACKAGE_SIZE = 1000.
-                // candidate_id = 20. archive_end_exclusive = 1020. 1025 < 1020 is false.
-                // archive_ids.last() = Some(20). Some(&20) == Some(&20). -> TooNew.
-                ArchiveMeta::TooNew
-            } else {
-                // No, `candidate_id` is not the last archive ID in the set.
-                // This means there's another archive ID after `candidate_id`
-                // (e.g., *archive_ids.range((candidate_id+1)..).next() would yield a value).
-                // `mc_seqno` falls into a gap between the package starting
-                // at `candidate_id` and the next package.
-                // Example: mc_seqno=1015, archive_ids={10, 1020}, ARCHIVE_PACKAGE_SIZE=1000.
-                // candidate_id = 10. archive_end_exclusive = 1010. 1015 < 1010 is false.
-                // archive_ids.last() = Some(1020). Some(&10) != Some(&1020). -> NotFound (gap).
+            None => {
+                // No candidate_id (all archive_ids in the non-empty set are > mc_seqno).
+                // This means mc_seqno is older than the very first archive.
                 ArchiveMeta::NotFound
             }
         }
@@ -871,39 +706,22 @@ impl BlockStorage {
             .ok_or(BlockStorageError::ArchiveNotFound)?)
     }
 
-    pub fn get_block_data_size(&self, block_id: &BlockId) -> Result<Option<u32>> {
-        let key = BlockDataEntryKey {
-            block_id: block_id.into(),
-            chunk_index: BLOCK_DATA_SIZE_MAGIC,
-        };
-        let size = self
-            .db
-            .block_data_entries
-            .get(key.to_vec())?
-            .map(|slice| u32::from_le_bytes(slice.as_ref().try_into().unwrap()));
-
-        Ok(size)
+    pub fn get_block_data_size(&self, block_id: &BlockId) -> Result<Option<u64>> {
+        self.blob_dbs
+            .package_entries
+            .size(&PackageEntryKey::block(block_id))
     }
 
-    pub fn get_block_data_chunk(
-        &self,
-        block_id: &BlockId,
-        offset: u32,
-    ) -> Result<Option<OwnedPinnableSlice>> {
+    pub fn get_block_data_chunk(&self, block_id: &BlockId, offset: u32) -> Result<Option<Bytes>> {
         let chunk_size = self.block_data_chunk_size().get();
         if offset % chunk_size != 0 {
             return Err(BlockStorageError::InvalidOffset.into());
         }
 
-        let key = BlockDataEntryKey {
-            block_id: block_id.into(),
-            chunk_index: offset / chunk_size,
-        };
-
-        Ok(self.db.block_data_entries.get(key.to_vec())?.map(|value| {
-            // SAFETY: A value was received from the same RocksDB instance.
-            unsafe { OwnedPinnableSlice::new(self.db.rocksdb().clone(), value) }
-        }))
+        let key = PackageEntryKey::block(block_id);
+        self.blob_dbs
+            .package_entries
+            .get_range(&key, offset as u64, (offset + chunk_size) as u64)
     }
 
     pub fn subscribe_to_archive_ids(&self) -> broadcast::Receiver<u32> {
@@ -956,6 +774,7 @@ impl BlockStorage {
         let span = tracing::Span::current();
         let cancelled = cancelled.clone();
         let db = self.db.clone();
+        let blob_dbs = self.blob_dbs.clone();
 
         let BlockGcStats {
             mc_blocks_removed,
@@ -969,6 +788,7 @@ impl BlockStorage {
 
             let stats = remove_blocks(
                 db,
+                blob_dbs,
                 max_blocks_per_batch,
                 mc_seqno,
                 shard_heights,
@@ -991,35 +811,13 @@ impl BlockStorage {
 
     #[tracing::instrument(skip(self))]
     pub fn remove_outdated_archives(&self, until_id: u32) -> Result<()> {
-        tracing::trace!("started archives GC");
+        tracing::debug!("started archives GC");
 
-        let mut archive_ids = self.blob_dbs.archives.known_keys();
-        archive_ids.sort_unstable();
-
-        // Find the index up to which we need to remove IDs (exclusive of until_id)
-        let partition_idx = archive_ids.partition_point(|&id| id < until_id);
-
-        // Collect IDs to remove
-        let removed_ids: Vec<u32> = archive_ids.drain(..partition_idx).collect();
-
-        if removed_ids.is_empty() {
-            tracing::info!("nothing to remove, until_id: {}", until_id);
-            return Ok(());
-        }
-
-        let first = *removed_ids.first().unwrap(); // Safe due to is_empty check
-        let last = *removed_ids.last().unwrap(); // Safe due to is_empty check
-        let len = removed_ids.len();
-
-        for id_to_remove in &removed_ids {
-            self.blob_dbs.archives.remove(id_to_remove)?;
-        }
+        let removed = self.blob_dbs.archives.remove_range(0..until_id)?;
 
         tracing::info!(
-            archive_count = len,
-            first,
-            last,
-            until_id,
+            removed_count = removed,
+            gc_threshold_id = until_id,
             "finished archives GC"
         );
         Ok(())
@@ -1027,68 +825,49 @@ impl BlockStorage {
 
     // === Internal ===
 
-    fn add_data(&self, id: &PackageEntryKey, data: &[u8]) -> Result<(), rocksdb::Error> {
-        self.db.package_entries.insert(id.to_vec(), data)
-    }
-
-    async fn add_block_data_and_split(&self, id: &PackageEntryKey, data: &[u8]) -> Result<()> {
-        let mut batch = rocksdb::WriteBatch::default();
-
-        batch.put_cf(&self.db.package_entries.cf(), id.to_vec(), data);
-
-        // Store info that new block was started
-        let key = BlockDataEntryKey {
-            block_id: id.block_id,
-            chunk_index: BLOCK_DATA_STARTED_MAGIC,
+    async fn get_data(&self, handle: &BlockHandle, id: &PackageEntryKey) -> Result<Bytes> {
+        tracing::info!(id =? id,"loading data");
+        let (lock, would_block) = match id.ty {
+            ArchiveEntryType::Block => (handle.block_data_lock(), true),
+            ArchiveEntryType::Proof => (handle.proof_data_lock(), false),
+            ArchiveEntryType::QueueDiff => (handle.queue_diff_data_lock(), false),
         };
-        batch.put_cf(&self.db.block_data_entries.cf(), key.to_vec(), []);
+        let _lock = lock.read().await;
 
-        self.db.rocksdb().write(batch)?;
-
-        // Start splitting block data
-        let permit = self.split_block_semaphore.clone().acquire_owned().await?;
-        let _handle = self.spawn_split_block_data(&id.block_id, data, permit);
-
-        Ok(())
-    }
-
-    async fn get_data(
-        &self,
-        handle: &BlockHandle,
-        id: &PackageEntryKey,
-    ) -> Result<OwnedPinnableSlice> {
-        let _lock = match id.ty {
-            ArchiveEntryType::Block => handle.block_data_lock(),
-            ArchiveEntryType::Proof => handle.proof_data_lock(),
-            ArchiveEntryType::QueueDiff => handle.queue_diff_data_lock(),
-        }
-        .read()
-        .await;
-
-        match self.db.package_entries.get(id.to_vec())? {
-            // SAFETY: A value was received from the same RocksDB instance.
-            Some(value) => Ok(unsafe { OwnedPinnableSlice::new(self.db.rocksdb().clone(), value) }),
-            None => Err(BlockStorageError::PackageEntryNotFound.into()),
+        if would_block {
+            {
+                let db = self.blob_dbs.package_entries.clone();
+                let id = id.clone();
+                Ok(
+                    tokio::task::spawn_blocking(move || Self::load_package_entry(&db, &id))
+                        .await??,
+                )
+            }
+        } else {
+            Self::load_package_entry(&self.blob_dbs.package_entries, id)
         }
     }
 
-    async fn get_data_ref<'a, 'b: 'a>(
-        &'a self,
-        handle: &'b BlockHandle,
-        id: &PackageEntryKey,
-    ) -> Result<FullBlockDataGuard<'a>> {
-        let lock = match id.ty {
-            ArchiveEntryType::Block => handle.block_data_lock(),
-            ArchiveEntryType::Proof => handle.proof_data_lock(),
-            ArchiveEntryType::QueueDiff => handle.queue_diff_data_lock(),
-        }
-        .read()
-        .await;
+    fn load_package_entry(db: &Bubs<PackageEntryKey>, id: &PackageEntryKey) -> Result<Bytes> {
+        let block = db.get(id)?.ok_or(BlockStorageError::PackageEntryNotFound)?;
 
-        match self.db.package_entries.get(id.to_vec())? {
-            Some(data) => Ok(FullBlockDataGuard { _lock: lock, data }),
-            None => Err(BlockStorageError::PackageEntryNotFound.into()),
-        }
+        // zstd -e10  -b1 res.blob
+        //  1#res.blob          :   1750269 ->   1458151 (x1.200),  421.5 MB/s, 2424.7 MB/s
+        //  2#res.blob          :   1750269 ->   1417723 (x1.235),  395.7 MB/s, 3359.8 MB/s
+        //  3#res.blob          :   1750269 ->   1356087 (x1.291),  229.6 MB/s, 3166.9 MB/s
+        //  4#res.blob          :   1750269 ->   1339545 (x1.307),  190.7 MB/s, 3088.6 MB/s
+        //  5#res.blob          :   1750269 ->   1334660 (x1.311),  125.4 MB/s, 3162.7 MB/s
+        //  6#res.blob          :   1750269 ->   1327555 (x1.318),  103.9 MB/s, 3241.7 MB/s
+        //  7#res.blob          :   1750269 ->   1325189 (x1.321),   96.8 MB/s, 3266.1 MB/s
+        //  8#res.blob          :   1750269 ->   1324270 (x1.322),   94.8 MB/s  3246.1 MB/s
+        Ok(match id.ty {
+            ArchiveEntryType::Block => {
+                let mut out = Vec::with_capacity(block.len() * 2); // best compression ratio
+                tycho_util::compression::zstd_decompress(&block, &mut out)?;
+                Bytes::from(out)
+            }
+            ArchiveEntryType::Proof | ArchiveEntryType::QueueDiff => block,
+        })
     }
 
     fn prepare_archive_id(&self, mc_seqno: u32, force_split_archive: bool) -> PreparedArchiveId {
@@ -1122,7 +901,7 @@ impl BlockStorage {
 
     #[tracing::instrument(skip(self))]
     fn spawn_commit_archive(&self, archive_id: u32) -> CommitArchiveTask {
-        let blob_db = self.blob_dbs.archives.clone();
+        let blob_db = self.blob_dbs.clone();
         let db = self.db.clone();
         let block_handle_storage = self.block_handle_storage.clone();
         let chunk_size = self.archive_chunk_size().get() as u64;
@@ -1164,7 +943,8 @@ impl BlockStorage {
                     .ok_or(BlockStorageError::ArchiveNotFound)?;
                 assert_eq!(raw_block_ids.len() % BlockId::SIZE_HINT, 0);
 
-                let mut writer = ArchiveWriter::new(&blob_db, &db, archive_id, chunk_size)?;
+                let mut writer =
+                    ArchiveWriter::new(&blob_db.archives, &db, archive_id, chunk_size)?;
                 let mut header_buffer = Vec::with_capacity(ARCHIVE_ENTRY_HEADER_LEN);
 
                 // Write archive prefix
@@ -1204,8 +984,13 @@ impl BlockStorage {
                         }
 
                         let key = PackageEntryKey::from((block_id, ty));
-                        let Some(data) = db.package_entries.get(key.to_vec()).unwrap() else {
-                            return Err(BlockStorageError::BlockDataNotFound.into());
+
+                        let data = match Self::load_package_entry(&blob_db.package_entries, &key) {
+                            Ok(data) => data,
+                            Err(e) => {
+                                tracing::error!("failed to load package entry: {e:?}");
+                                return Err(BlockStorageError::BlockDataNotFound.into());
+                            }
                         };
 
                         // Serialize entry header
@@ -1254,53 +1039,68 @@ impl BlockStorage {
         }
     }
 
-    #[tracing::instrument(skip(self, data))]
-    fn spawn_split_block_data(
+    async fn add_block_data_compressed(&self, id: &PackageEntryKey, data: &[u8]) -> Result<()> {
+        let permit = self.split_block_semaphore.clone().acquire_owned().await?;
+        // should take 50 ms to compress 20mib block
+        self.spawn_compress_block_data(id, data, permit).await??; //  20117649 ->  16075134 (x1.251),  425.8 MB/s, 2292.9 MB/s
+
+        Ok(())
+    }
+
+    fn spawn_compress_block_data(
         &self,
-        block_id: &PartialBlockId,
+        block_id: &PackageEntryKey,
         data: &[u8],
         permit: OwnedSemaphorePermit,
     ) -> JoinHandle<Result<()>> {
-        let db = self.db.clone();
-        let chunk_size = self.block_data_chunk_size().get() as usize;
-
+        let db = self.blob_dbs.package_entries.clone();
         let span = tracing::Span::current();
-        let handle = tokio::task::spawn_blocking({
-            let block_id = *block_id;
+
+        tokio::task::spawn_blocking({
+            let block_id = block_id.clone();
             let data = data.to_vec();
 
             move || {
                 let _span = span.enter();
-
                 let _histogram = HistogramGuard::begin("tycho_storage_split_block_data_time");
 
-                let mut compressed = Vec::new();
-                tycho_util::compression::zstd_compress(&data, &mut compressed, 3);
-
-                let chunks = compressed.chunks(chunk_size);
-                for (index, chunk) in chunks.enumerate() {
-                    let key = BlockDataEntryKey {
-                        block_id,
-                        chunk_index: index as u32,
-                    };
-
-                    db.block_data_entries.insert(key.to_vec(), chunk)?;
+                // Only compress and write if block doesn't exist
+                if db.contains_key(&block_id) {
+                    drop(permit);
+                    return Ok(());
                 }
 
-                let key = BlockDataEntryKey {
-                    block_id,
-                    chunk_index: BLOCK_DATA_SIZE_MAGIC,
-                };
-                db.block_data_entries
-                    .insert(key.to_vec(), (compressed.len() as u32).to_le_bytes())?;
+                // Compression
+                let start = std::time::Instant::now();
+                let mut compressed = Vec::new();
+
+                // only blocks are big enough to compress
+                if block_id.ty != ArchiveEntryType::Block {
+                    compressed = data;
+                } else if data.len() as u64 > bytesize::MIB * 2 {
+                    let mut compressor = ZstdCompressStream::new(1, data.len() as _)?;
+                    compressor.multithreaded(std::thread::available_parallelism()?.get() as _)?;
+
+                    compressor.write(&data, &mut compressed)?;
+                    compressor.finish(&mut compressed)?;
+                } else {
+                    tycho_util::compression::zstd_compress(&data, &mut compressed, 1);
+                }
+                let elapsed = start.elapsed().as_secs_f64();
+                tracing::info!(took = elapsed, "COMPRESS_BLOCK");
+
+                // Writing
+                let start = std::time::Instant::now();
+                let mut tx = db.put(block_id)?;
+                tx.write(&compressed)?;
+                tx.finish()?;
+                let elapsed = start.elapsed().as_secs_f64();
+                tracing::info!(took = elapsed, "WRITE_BLOCK");
 
                 drop(permit);
-
                 Ok(())
             }
-        });
-
-        handle
+        })
     }
 }
 
@@ -1442,6 +1242,7 @@ impl ArchiveMeta {
 
 fn remove_blocks(
     db: BaseDb,
+    blob_dbs: BlobDbs,
     max_blocks_per_batch: Option<usize>,
     mc_seqno: u32,
     shard_heights: ShardHeights,
@@ -1452,13 +1253,10 @@ fn remove_blocks(
     let raw = db.rocksdb().as_ref();
     let full_block_ids_cf = db.full_block_ids.cf();
     let block_connections_cf = db.block_connections.cf();
-    let package_entries_cf = db.package_entries.cf();
-    let block_data_entries_cf = db.block_data_entries.cf();
+    let package_entries = &blob_dbs.package_entries;
     let block_handles_cf = db.block_handles.cf();
 
-    // Create batch
     let mut batch = rocksdb::WriteBatch::default();
-    let mut batch_len = 0;
 
     // Iterate all entries and find expired items
     let mut blocks_iter =
@@ -1492,15 +1290,7 @@ fn remove_blocks(
             let mut range_to = *range_from;
             range_to[12..16].copy_from_slice(&to.seqno.saturating_add(1).to_be_bytes());
 
-            // At this point we have two keys:
-            // [workchain, shard, from_seqno, 0...]
-            // [workchain, shard, to_seqno + 1, 0...]
-            //
-            // It will delete all entries in range [from_seqno, to_seqno) for this shard.
-            // Note that package entry keys are the same as block connection keys.
             batch.delete_range_cf(&full_block_ids_cf, &*range_from, &range_to);
-            batch.delete_range_cf(&package_entries_cf, &*range_from, &range_to);
-            batch.delete_range_cf(&block_data_entries_cf, &*range_from, &range_to);
             batch.delete_range_cf(&block_connections_cf, &*range_from, &range_to);
 
             tracing::debug!(%from, %to, "delete_range");
@@ -1508,6 +1298,7 @@ fn remove_blocks(
 
     let mut cancelled = cancelled.map(|c| c.debounce(100));
     let mut current_range = None::<(BlockIdShort, BlockIdShort)>;
+
     loop {
         let key = match blocks_iter.key() {
             Some(key) => key,
@@ -1530,68 +1321,109 @@ fn remove_blocks(
         let root_hash: &[u8; 32] = key[16..48].try_into().unwrap();
         let is_masterchain = block_id.shard.is_masterchain();
 
+        // --- Filtering Logic ---
         // Don't gc latest blocks, key blocks or persistent blocks
-        if block_id.seqno == 0
-            || is_masterchain && block_id.seqno >= mc_seqno
-            || !is_masterchain
-                && shard_heights.contains_shard_seqno(&block_id.shard, block_id.seqno)
-            || is_persistent(root_hash)?
-        {
-            // Remove the current range
+        let should_keep = block_id.seqno == 0
+            || (is_masterchain && block_id.seqno >= mc_seqno)
+            || (!is_masterchain
+                && shard_heights.contains_shard_seqno(&block_id.shard, block_id.seqno))
+            || is_persistent(root_hash)?;
+
+        if should_keep {
+            // Block should be kept. If we were tracking a range of blocks to delete,
+            // finalize that range now.
             if let Some((from, to)) = current_range.take() {
                 delete_range(&mut batch, &from, &to);
-                batch_len += 1; // Ensure that we flush the batch
             }
             blocks_iter.next();
             continue;
         }
 
+        // --- Deletion Logic ---
+        // Block should be removed.
+
+        // Update or start the delete range for CFs handled by delete_range
         match &mut current_range {
-            // Delete the previous range and start a new one
-            Some((from, to)) if from.shard != block_id.shard => {
-                delete_range(&mut batch, from, to);
-                *from = block_id;
+            Some((from, to)) if from.shard == block_id.shard => {
+                // Extend the current range for the same shard
                 *to = block_id;
             }
-            // Update the current range
-            Some((_, to)) => *to = block_id,
-            // Start a new range
-            None => current_range = Some((block_id, block_id)),
+            _ => {
+                // Finalize the previous range (if any) because the shard changed or no range existed
+                if let Some((from, to)) = current_range.take() {
+                    delete_range(&mut batch, &from, &to);
+                }
+                // Start a new range
+                current_range = Some((block_id, block_id));
+            }
         }
 
-        // Count entry
+        // --- Individual Deletions ---
+
+        // 1. Delete from block_handles_cf (using the RocksDB batch)
+        batch.delete_cf(&block_handles_cf, root_hash);
+
+        // 2. Delete corresponding entries from package_entries (using its own remove method)
+        let partial_block_id = PartialBlockId {
+            shard: block_id.shard,
+            seqno: block_id.seqno,
+            root_hash: HashBytes(*root_hash),
+        };
+
+        for ty in [
+            ArchiveEntryType::Block,
+            ArchiveEntryType::Proof,
+            ArchiveEntryType::QueueDiff,
+        ] {
+            let key = PackageEntryKey {
+                block_id: partial_block_id,
+                ty,
+            };
+            package_entries.remove(&key)?;
+        }
+
+        // --- Update Stats ---
         stats.total_blocks_removed += 1;
         if is_masterchain {
             stats.mc_blocks_removed += 1;
         }
 
-        batch.delete_cf(&block_handles_cf, root_hash);
-
-        batch_len += 1;
+        // --- Batch Flushing ---
         if matches!(
             max_blocks_per_batch,
-            Some(max_blocks_per_batch) if batch_len >= max_blocks_per_batch
+            Some(limit) if batch.len() >= limit // Compare with items *in the RocksDB batch*
         ) {
+            // Finalize the current range before flushing the batch
+            if let Some((from, to)) = current_range.take() {
+                delete_range(&mut batch, &from, &to);
+            }
+
             tracing::info!(
+                batch_len = batch.len(), // Log actual batch size
                 total_blocks_removed = stats.total_blocks_removed,
                 "applying intermediate batch",
             );
-            let batch = std::mem::take(&mut batch);
-            raw.write(batch)?;
-            batch_len = 0;
+            let batch_to_write = std::mem::take(&mut batch);
+            raw.write(batch_to_write)
+                .context("Failed to write intermediate batch")?;
         }
 
         blocks_iter.next();
-    }
+    } // End loop
 
+    // Finalize any remaining range
     if let Some((from, to)) = current_range.take() {
         delete_range(&mut batch, &from, &to);
-        batch_len += 1; // Ensure that we flush the batch
     }
 
-    if batch_len > 0 {
-        tracing::info!("applying final batch");
-        raw.write(batch)?;
+    // Write the final batch if it contains anything
+    if !batch.is_empty() {
+        tracing::info!(
+            batch_len = batch.len(),
+            total_blocks_removed = stats.total_blocks_removed,
+            "applying final batch",
+        );
+        raw.write(batch).context("Failed to write final batch")?;
     }
 
     // Done
@@ -1610,28 +1442,8 @@ pub struct BlockGcStats {
     pub total_blocks_removed: usize,
 }
 
-struct FullBlockDataGuard<'a> {
-    _lock: BlockDataGuard<'a>,
-    data: rocksdb::DBPinnableSlice<'a>,
-}
-
-impl AsRef<[u8]> for FullBlockDataGuard<'_> {
-    fn as_ref(&self) -> &[u8] {
-        self.data.as_ref()
-    }
-}
-
-fn extract_entry_type(key: &[u8]) -> Option<ArchiveEntryType> {
-    key.get(48).copied().and_then(ArchiveEntryType::from_byte)
-}
-
 const ARCHIVE_PACKAGE_SIZE: u32 = 100;
 const BLOCK_DATA_CHUNK_SIZE: u32 = 1024 * 1024; // 1MB
-
-// Reserved key in which the compressed block size is stored
-const BLOCK_DATA_SIZE_MAGIC: u32 = u32::MAX;
-// Reserved key in which we store the fact that compressed block was started
-const BLOCK_DATA_STARTED_MAGIC: u32 = u32::MAX - 2;
 
 #[derive(Default, Debug)]
 pub struct PreparedArchiveId {
@@ -1814,7 +1626,9 @@ mod tests {
                 });
 
                 for ty in ENTRY_TYPES {
-                    blocks.add_data(&(block_id, ty).into(), GARBAGE)?;
+                    blocks
+                        .add_block_data_compressed(&(block_id, ty).into(), GARBAGE)
+                        .await?;
                 }
                 for direction in CONNECTION_TYPES {
                     block_connections.store_connection(&handle, direction, &block_id);
@@ -1828,6 +1642,7 @@ mod tests {
         // Remove some blocks
         let stats = remove_blocks(
             blocks.db.clone(),
+            blocks.blob_dbs.clone(),
             None,
             70,
             [(ShardIdent::BASECHAIN, 50)].into(),
@@ -1860,7 +1675,7 @@ mod tests {
 
                 for ty in ENTRY_TYPES {
                     let key = PackageEntryKey::from((block_id, ty));
-                    let stored = blocks.db.package_entries.get(key.to_vec())?;
+                    let stored = blocks.blob_dbs.package_entries.get(&key)?;
                     assert_eq!(stored.is_none(), must_be_removed);
                 }
 
@@ -1874,6 +1689,7 @@ mod tests {
         // Remove single block
         let stats = remove_blocks(
             blocks.db.clone(),
+            blocks.blob_dbs.clone(),
             None,
             71,
             [(ShardIdent::BASECHAIN, 51)].into(),
@@ -1887,6 +1703,7 @@ mod tests {
         // Remove no blocks
         let stats = remove_blocks(
             blocks.db.clone(),
+            blocks.blob_dbs.clone(),
             None,
             71,
             [(ShardIdent::BASECHAIN, 51)].into(),

--- a/storage/src/store/block/package_entry.rs
+++ b/storage/src/store/block/package_entry.rs
@@ -6,7 +6,7 @@ use tycho_block_util::archive::ArchiveEntryType;
 
 use super::{StoredValue, StoredValueBuffer};
 
-#[derive(Debug, Hash, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Hash, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
 pub struct PartialBlockId {
     pub shard: ShardIdent,
     pub seqno: u32,
@@ -88,28 +88,37 @@ impl StoredValue for PartialBlockId {
 }
 
 /// Package entry id.
-#[derive(Debug, Hash, Eq, PartialEq)]
+#[derive(Debug, Hash, Eq, PartialEq, Clone, Ord, PartialOrd)]
 pub struct PackageEntryKey {
     pub block_id: PartialBlockId,
     pub ty: ArchiveEntryType,
 }
 
 impl PackageEntryKey {
-    pub fn block(block_id: &BlockId) -> Self {
+    pub fn block<ID>(block_id: ID) -> Self
+    where
+        ID: Into<PartialBlockId>,
+    {
         Self {
             block_id: block_id.into(),
             ty: ArchiveEntryType::Block,
         }
     }
 
-    pub fn proof(block_id: &BlockId) -> Self {
+    pub fn proof<ID>(block_id: ID) -> Self
+    where
+        ID: Into<PartialBlockId>,
+    {
         Self {
             block_id: block_id.into(),
             ty: ArchiveEntryType::Proof,
         }
     }
 
-    pub fn queue_diff(block_id: &BlockId) -> Self {
+    pub fn queue_diff<ID>(block_id: ID) -> Self
+    where
+        ID: Into<PartialBlockId>,
+    {
         Self {
             block_id: block_id.into(),
             ty: ArchiveEntryType::QueueDiff,

--- a/storage/src/store/block_handle/mod.rs
+++ b/storage/src/store/block_handle/mod.rs
@@ -4,7 +4,6 @@ use everscale_types::models::BlockId;
 use tycho_block_util::block::{BlockStuff, ShardHeights};
 use tycho_util::FastDashMap;
 
-pub(crate) use self::handle::BlockDataGuard;
 pub use self::handle::{BlockHandle, WeakBlockHandle};
 pub use self::meta::{BlockFlags, BlockMeta, LoadedBlockMeta, NewBlockMeta};
 use crate::db::*;

--- a/storage/src/store/node_state/mod.rs
+++ b/storage/src/store/node_state/mod.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use std::sync::Arc;
 
 use everscale_types::models::*;
 use parking_lot::Mutex;
@@ -6,7 +7,9 @@ use parking_lot::Mutex;
 use crate::db::*;
 use crate::util::*;
 
-pub struct NodeStateStorage {
+pub struct NodeStateStorage(Arc<NodeStateStorageInner>);
+
+struct NodeStateStorageInner {
     db: BaseDb,
     last_mc_block_id: BlockIdCache,
     init_mc_block_id: BlockIdCache,
@@ -17,22 +20,28 @@ pub enum NodeSyncState {
     Blocks,
 }
 
+impl Clone for NodeStateStorage {
+    fn clone(&self) -> Self {
+        NodeStateStorage(self.0.clone())
+    }
+}
+
 impl NodeStateStorage {
     pub fn new(db: BaseDb) -> Self {
-        let this = Self {
+        let inner = NodeStateStorageInner {
             db,
             last_mc_block_id: (Default::default(), LAST_MC_BLOCK_ID),
             init_mc_block_id: (Default::default(), INIT_MC_BLOCK_ID),
         };
 
-        let state = &this.db.state;
+        let state = &inner.db.state;
         if state.get(INSTANCE_ID).unwrap().is_none() {
             state
                 .insert(INSTANCE_ID, rand::random::<InstanceId>())
                 .unwrap();
         }
 
-        this
+        Self(Arc::new(inner))
     }
 
     pub fn get_node_sync_state(&self) -> Option<NodeSyncState> {
@@ -47,28 +56,30 @@ impl NodeStateStorage {
     }
 
     pub fn store_last_mc_block_id(&self, id: &BlockId) {
-        self.store_block_id(&self.last_mc_block_id, id);
+        self.store_block_id(&self.0.last_mc_block_id, id);
     }
 
     pub fn load_last_mc_block_id(&self) -> Option<BlockId> {
-        self.load_block_id(&self.last_mc_block_id)
+        self.load_block_id(&self.0.last_mc_block_id)
     }
 
     pub fn store_init_mc_block_id(&self, id: &BlockId) {
-        self.store_block_id(&self.init_mc_block_id, id);
+        self.store_block_id(&self.0.init_mc_block_id, id);
     }
 
     pub fn load_init_mc_block_id(&self) -> Option<BlockId> {
-        self.load_block_id(&self.init_mc_block_id)
+        self.load_block_id(&self.0.init_mc_block_id)
     }
 
     #[inline(always)]
     fn store_block_id(&self, (cache, key): &BlockIdCache, block_id: &BlockId) {
-        let node_states = &self.db.state;
+        let node_states = &self.0.db.state;
+        let mut lock = cache.lock();
+        // to sync with db write ops
         node_states
             .insert(key, write_block_id_le(block_id))
             .unwrap();
-        *cache.lock() = Some(*block_id);
+        *lock = Some(*block_id);
     }
 
     #[inline(always)]
@@ -76,14 +87,13 @@ impl NodeStateStorage {
         if let Some(cached) = &*cache.lock() {
             return Some(*cached);
         }
-
-        let value = read_block_id_le(&self.db.state.get(key).unwrap()?);
+        let value = read_block_id_le(&self.0.db.state.get(key).unwrap()?);
         *cache.lock() = Some(value);
         Some(value)
     }
 
     pub fn load_instance_id(&self) -> InstanceId {
-        let id = self.db.state.get(INSTANCE_ID).unwrap().unwrap();
+        let id = self.0.db.state.get(INSTANCE_ID).unwrap().unwrap();
         InstanceId::from_slice(id.as_ref())
     }
 }


### PR DESCRIPTION
Rocsdkb paired with blobdb results in 5-25 write amplification, which easily saturates write bandwidth and does not offer any improvements compared to the in-house cas based blob storage. Also nvme will die. BADBADNOTGOOD.