### PR TITLE
do not wait state update on resume after master block

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -83,13 +83,13 @@ If impact expected:
 
 #### Unit Tests
 
-[Covered by:] / [No covarage]
+[Covered by:] / [No coverage]
 
 <!--List unit tests that cover changes (if exits). Link tasks to create additional tests (if needed).-->
 
 #### Network Tests
 
-[Covered by:] / [No covarage]
+[Covered by:] / [No coverage]
 
 <!--List unit tests that cover changes (if exits). Link tasks to create additional tests (if needed).-->
 

--- a/collator/src/collator/do_collate/finalize.rs
+++ b/collator/src/collator/do_collate/finalize.rs
@@ -797,6 +797,7 @@ impl Phase<FinalizeState> {
                 collation_data: self.state.collation_data,
                 block_candidate,
                 mc_data: new_mc_data,
+                state_update,
                 new_state_root,
                 new_observable_state,
                 finalize_wu_total,

--- a/collator/src/collator/do_collate/mod.rs
+++ b/collator/src/collator/do_collate/mod.rs
@@ -904,16 +904,11 @@ impl CollatorStdImpl {
                 ref_by_mc_seqno: finalized.block_candidate.ref_by_mc_seqno,
             };
             let adapter = self.state_node_adapter.clone();
-            let labels = labels.clone();
             let new_state_root = finalized.new_state_root.clone();
             let hint = StoreStateHint {
                 block_data_size: Some(finalized.block_candidate.block.data_size()),
             };
             async move {
-                let _histogram = HistogramGuard::begin_with_labels(
-                    "tycho_collator_build_new_state_time_high",
-                    &labels,
-                );
                 adapter
                     .store_state_root(&block_id, meta, new_state_root, hint)
                     .await
@@ -953,6 +948,7 @@ impl CollatorStdImpl {
                 block_id,
                 finalized.new_observable_state,
                 finalized.new_state_root,
+                finalized.state_update,
                 store_new_state_task,
                 new_queue_diff_hash,
                 new_mc_data,

--- a/collator/src/collator/mod.rs
+++ b/collator/src/collator/mod.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use do_collate::is_first_block_after_prev_master;
 use error::CollatorError;
 use everscale_types::cell::{Cell, HashBytes};
+use everscale_types::merkle::MerkleUpdate;
 use everscale_types::models::*;
 use futures_util::future::Future;
 use messages_reader::{
@@ -229,8 +230,11 @@ pub struct CollatorStdImpl {
     mpool_adapter: Arc<dyn MempoolAdapter>,
     state_node_adapter: Arc<dyn StateNodeAdapter>,
     shard_id: ShardIdent,
+
     delayed_working_state: DelayedWorkingState,
-    store_new_state_tasks: Vec<JoinTask<Result<bool>>>,
+    store_new_state_tasks: Vec<StateUpdateContext>,
+    background_store_new_state_tx: std::sync::mpsc::Sender<StateUpdateContext>,
+
     anchors_cache: AnchorsCache,
     block_serializer_cache: BlockSerializerCache,
     stats: CollatorStats,
@@ -270,6 +274,9 @@ impl CollatorStdImpl {
 
         let (working_state_tx, working_state_rx) = oneshot::channel::<Result<Box<WorkingState>>>();
 
+        let (background_store_new_state_tx, background_store_new_state_rx) =
+            std::sync::mpsc::channel::<StateUpdateContext>();
+
         let processor = Self {
             next_block_info,
             config,
@@ -286,6 +293,7 @@ impl CollatorStdImpl {
                 }
             }),
             store_new_state_tasks: Default::default(),
+            background_store_new_state_tx,
             anchors_cache: Default::default(),
             block_serializer_cache: BlockSerializerCache::with_capacity(BLOCK_CELL_COUNT_BASELINE),
             stats: Default::default(),
@@ -295,6 +303,17 @@ impl CollatorStdImpl {
             mempool_config_override,
             cancel_collation,
         };
+
+        // finalize new state store tasks in background
+        tokio::spawn(async move {
+            while let Ok(cx) = background_store_new_state_rx.recv() {
+                if let Err(err) = cx.store_new_state_task.await {
+                    tracing::error!(target: tracing_targets::COLLATOR,
+                        "Error when store new state: {:?}", err,
+                    );
+                }
+            }
+        });
 
         // create dispatcher for own async tasks queue
         let dispatcher =
@@ -592,16 +611,6 @@ impl CollatorStdImpl {
         // update collation session info to refer to a correct subset in collated block
         self.collation_session = collation_session;
 
-        // previously wait when all state store tasks finished
-        if !self.store_new_state_tasks.is_empty() {
-            tracing::debug!(target: tracing_targets::COLLATOR,
-                "awaiting when all state store tasks finished...",
-            );
-            for task in self.store_new_state_tasks.drain(..) {
-                task.await?;
-            }
-        }
-
         let working_state = if !reset {
             let mut working_state = self.delayed_working_state.wait().await?;
 
@@ -615,10 +624,51 @@ impl CollatorStdImpl {
                 }
 
                 // and only for shard collator
-                // reload prev states from storage to drop usage tree
-                if !self.shard_id.is_masterchain() && working_state.next_block_id_short.seqno != 0 {
-                    Self::reload_prev_data(&mut working_state, self.state_node_adapter.clone())
-                        .await?;
+                // update prev states to drop usage tree
+                if !self.shard_id.is_masterchain()
+                    && self.store_new_state_tasks.len()
+                        > self.config.untrack_prev_state_after as usize
+                {
+                    // get last store task
+                    let last_task = self.store_new_state_tasks.pop().unwrap();
+
+                    // if it is finished then we can just reload prev state
+                    if last_task.store_new_state_task.is_finished() {
+                        last_task.store_new_state_task.await?;
+
+                        // and reload pure prev state in working state
+                        Self::reload_prev_data(&mut working_state, self.state_node_adapter.clone())
+                            .await?;
+                    } else {
+                        // if it is not finished then wait for the previous one and apply merkle update
+                        let prev_task = self.store_new_state_tasks.pop().unwrap();
+                        prev_task.store_new_state_task.await?;
+
+                        // load stored state
+                        let mut pure_state_root = self
+                            .state_node_adapter
+                            .load_state_root(&prev_task.block_id)
+                            .await?;
+
+                        // apply state update from last task
+                        let histogram_apply_merkles = HistogramGuard::begin_with_labels(
+                            "tycho_collator_resume_collation_apply_merkles_time_high",
+                            &labels,
+                        );
+                        pure_state_root = last_task.state_update.apply(&pure_state_root)?;
+                        drop(histogram_apply_merkles);
+
+                        // finalize last store task in background
+                        self.background_store_new_state_tx.send(last_task)?;
+
+                        // and update pure prev state in working state
+                        Self::update_prev_data(&mut working_state, pure_state_root).await?;
+                    }
+
+                    // finalize all remaining state store tasks in background
+                    for cx in self.store_new_state_tasks.drain(..) {
+                        self.background_store_new_state_tx.send(cx)?;
+                    }
                 }
             }
 
@@ -629,6 +679,11 @@ impl CollatorStdImpl {
 
             working_state
         } else {
+            // finalize all remaining state store tasks in background
+            for cx in self.store_new_state_tasks.drain(..) {
+                self.background_store_new_state_tx.send(cx)?;
+            }
+
             // reset any delayed working state because we will init a new one
             self.delayed_working_state.reset();
 
@@ -775,6 +830,39 @@ impl CollatorStdImpl {
         Self::build_and_validate_init_working_state(mc_data, prev_states, prev_queue_diff_hashes)
     }
 
+    async fn update_prev_data(
+        working_state: &mut WorkingState,
+        pure_state_root: Cell,
+    ) -> Result<()> {
+        // drop prev shard data and usage tree
+        let prev_queue_diff_hashes;
+        let prev_blocks_ids;
+        let tracker;
+        {
+            working_state.usage_tree.take();
+
+            let prev_shard_data = working_state.prev_shard_data.take().unwrap();
+            prev_queue_diff_hashes = prev_shard_data.prev_queue_diff_hashes().clone();
+            prev_blocks_ids = prev_shard_data.blocks_ids().clone();
+            tracker = prev_shard_data.ref_mc_state_handle().tracker().clone();
+        }
+
+        let prev_state =
+            ShardStateStuff::from_root(&prev_blocks_ids[0], pure_state_root, &tracker)?;
+        let prev_states = vec![prev_state];
+
+        // update working state
+        tracing::debug!(target: tracing_targets::COLLATOR, "updating prev data in working state from built pure state root...");
+
+        let (prev_shard_data, usage_tree) = PrevData::build(prev_states, prev_queue_diff_hashes)?;
+
+        // set new prev shard data and usage tree
+        working_state.prev_shard_data = Some(prev_shard_data);
+        working_state.usage_tree = Some(usage_tree);
+
+        Ok(())
+    }
+
     async fn reload_prev_data(
         working_state: &mut WorkingState,
         state_node_adapter: Arc<dyn StateNodeAdapter>,
@@ -798,7 +886,7 @@ impl CollatorStdImpl {
             Self::load_prev_states(state_node_adapter.as_ref(), &prev_blocks_ids).await?;
 
         // update working state
-        tracing::debug!(target: tracing_targets::COLLATOR, "updating working state...");
+        tracing::debug!(target: tracing_targets::COLLATOR, "updating prev data in working state from reloaded state root...");
 
         let (prev_shard_data, usage_tree) = PrevData::build(prev_states, prev_queue_diff_hashes)?;
 
@@ -815,7 +903,8 @@ impl CollatorStdImpl {
         &mut self,
         block_id: BlockId,
         new_observable_state: Box<ShardStateUnsplit>,
-        new_state_root: Cell,
+        new_observable_state_root: Cell,
+        state_update: MerkleUpdate,
         store_new_state_task: JoinTask<Result<bool>>,
         new_queue_diff_hash: HashBytes,
         new_mc_data: Arc<McData>,
@@ -824,18 +913,12 @@ impl CollatorStdImpl {
         reader_state: ReaderState,
         tracker: MinRefMcStateTracker,
     ) -> Result<()> {
-        let labels = [("workchain", self.shard_id.workchain().to_string())];
-        let _histogram = HistogramGuard::begin_with_labels(
-            "tycho_collator_prepare_working_state_update_time_high",
-            &labels,
-        );
-
         enum GetNewShardStateStuff {
             ReloadFromStorage(JoinTask<Result<bool>>),
             BuildFromNewObservable {
                 block_id: BlockId,
-                shard_state: Box<ShardStateUnsplit>,
-                root: Cell,
+                new_observable_state: Box<ShardStateUnsplit>,
+                new_observable_state_root: Cell,
                 tracker: MinRefMcStateTracker,
             },
         }
@@ -845,13 +928,17 @@ impl CollatorStdImpl {
                 GetNewShardStateStuff::ReloadFromStorage(store_new_state_task)
             } else {
                 // append new store task
-                self.store_new_state_tasks.push(store_new_state_task);
+                self.store_new_state_tasks.push(StateUpdateContext {
+                    block_id,
+                    store_new_state_task,
+                    state_update,
+                });
 
                 // build state stuff from new observable state after collation
                 GetNewShardStateStuff::BuildFromNewObservable {
                     block_id,
-                    shard_state: new_observable_state,
-                    root: new_state_root,
+                    new_observable_state,
+                    new_observable_state_root,
                     tracker,
                 }
             }
@@ -859,14 +946,25 @@ impl CollatorStdImpl {
 
         let state_node_adapter = self.state_node_adapter.clone();
 
+        let labels = [("workchain", self.shard_id.workchain().to_string())];
         self.delayed_working_state.future = Some(Box::pin(async move {
+            let _histogram = HistogramGuard::begin_with_labels(
+                "tycho_collator_build_new_state_time_high",
+                &labels,
+            );
+
             let new_state_stuff = match get_new_state_stuff {
                 GetNewShardStateStuff::BuildFromNewObservable {
                     block_id,
-                    shard_state,
-                    root,
+                    new_observable_state,
+                    new_observable_state_root,
                     tracker,
-                } => ShardStateStuff::from_state_and_root(&block_id, shard_state, root, &tracker)?,
+                } => ShardStateStuff::from_state_and_root(
+                    &block_id,
+                    new_observable_state,
+                    new_observable_state_root,
+                    &tracker,
+                )?,
                 GetNewShardStateStuff::ReloadFromStorage(store_new_state_task) => {
                     store_new_state_task.await?;
                     let load_task = JoinTask::new({
@@ -2078,6 +2176,12 @@ impl DelayedWorkingState {
         self.unused = None;
         self.future = None;
     }
+}
+
+struct StateUpdateContext {
+    block_id: BlockId,
+    store_new_state_task: JoinTask<Result<bool>>,
+    state_update: MerkleUpdate,
 }
 
 struct AnchorsProcessingInfo {

--- a/collator/src/collator/types.rs
+++ b/collator/src/collator/types.rs
@@ -7,6 +7,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use everscale_types::boc;
 use everscale_types::cell::{Cell, CellFamily, HashBytes, Lazy, UsageTree, UsageTreeMode};
 use everscale_types::dict::{self, Dict};
+use everscale_types::merkle::MerkleUpdate;
 use everscale_types::models::{
     AccountBlocks, AccountState, BlockId, BlockIdShort, BlockInfo, BlockLimits, BlockParamLimits,
     BlockRef, BlockchainConfig, CollationConfig, CurrencyCollection, HashUpdate, ImportFees, InMsg,
@@ -1200,6 +1201,7 @@ pub struct FinalizeBlockResult {
     pub block_candidate: Box<BlockCandidate>,
     pub mc_data: Option<Arc<McData>>,
     pub old_mc_data: Arc<McData>,
+    pub state_update: MerkleUpdate,
     pub new_state_root: Cell,
     pub new_observable_state: Box<ShardStateUnsplit>,
     pub finalize_wu_total: u64,

--- a/collator/src/manager/tests/manager_tests.rs
+++ b/collator/src/manager/tests/manager_tests.rs
@@ -2735,6 +2735,11 @@ impl StateNodeAdapter for TestStateNodeAdapter {
         res.ok_or_else(|| anyhow!("state not found for mc block {}", block_id.as_short_id()))
     }
 
+    async fn load_state_root(&self, block_id: &BlockId) -> Result<Cell> {
+        let res = self.load_state(block_id).await;
+        res.map(|s| s.root_cell().clone())
+    }
+
     fn load_last_applied_mc_block_id(&self) -> Result<BlockId> {
         unreachable!()
     }

--- a/collator/src/state_node.rs
+++ b/collator/src/state_node.rs
@@ -214,7 +214,11 @@ impl StateNodeAdapter for StateNodeAdapterStdImpl {
         state_root: Cell,
         hint: StoreStateHint,
     ) -> Result<bool> {
-        let _histogram = HistogramGuard::begin("tycho_collator_state_store_state_root_time");
+        let labels = [("workchain", block_id.shard.workchain().to_string())];
+        let _histogram = HistogramGuard::begin_with_labels(
+            "tycho_collator_state_store_state_root_time_high",
+            &labels,
+        );
 
         tracing::debug!(target: tracing_targets::STATE_NODE_ADAPTER, "Store state root: {}", block_id.as_short_id());
 
@@ -460,7 +464,7 @@ impl StateNodeAdapterStdImpl {
         .await;
 
         let _histogram =
-            HistogramGuard::begin("tycho_collator_state_adapter_save_block_proof_time");
+            HistogramGuard::begin("tycho_collator_state_adapter_save_block_proof_time_high");
 
         let block_storage = self.storage.block_storage();
         let result = block_storage

--- a/collator/src/types.rs
+++ b/collator/src/types.rs
@@ -30,6 +30,7 @@ pub struct CollatorConfig {
     pub check_value_flow: bool,
     pub validate_config: bool,
     pub fast_sync: bool,
+    pub untrack_prev_state_after: u8,
 }
 
 impl Default for CollatorConfig {
@@ -41,12 +42,17 @@ impl Default for CollatorConfig {
             check_value_flow: false,
             validate_config: true,
             fast_sync: true,
+            untrack_prev_state_after: default_5(),
         }
     }
 }
 
 fn default_true() -> bool {
     true
+}
+
+fn default_5() -> u8 {
+    5
 }
 
 #[derive(Serialize, Deserialize)]
@@ -56,6 +62,8 @@ struct PartialCollatorConfig {
     validate_config: bool,
     #[serde(default = "default_true")]
     fast_sync: bool,
+    #[serde(default = "default_5")]
+    untrack_prev_state_after: u8,
 }
 
 impl<'de> serde::Deserialize<'de> for CollatorConfig {
@@ -70,6 +78,7 @@ impl<'de> serde::Deserialize<'de> for CollatorConfig {
             check_value_flow: partial.check_value_flow,
             validate_config: partial.validate_config,
             fast_sync: partial.fast_sync,
+            untrack_prev_state_after: partial.untrack_prev_state_after,
             ..Default::default()
         })
     }
@@ -85,6 +94,7 @@ impl serde::Serialize for CollatorConfig {
             check_value_flow: self.check_value_flow,
             validate_config: self.validate_config,
             fast_sync: self.fast_sync,
+            untrack_prev_state_after: self.untrack_prev_state_after,
         }
         .serialize(serializer)
     }

--- a/collator/tests/collation_tests.rs
+++ b/collator/tests/collation_tests.rs
@@ -89,6 +89,7 @@ async fn test_collation_process_on_stubs() {
         check_value_flow: false,
         validate_config: true,
         fast_sync: false,
+        untrack_prev_state_after: 5,
     };
 
     tracing::info!("Trying to start CollationManager");

--- a/core/src/block_strider/state_applier.rs
+++ b/core/src/block_strider/state_applier.rs
@@ -161,7 +161,9 @@ where
         handle: &BlockHandle,
         prev_root: Cell,
     ) -> Result<ShardStateStuff> {
-        let _histogram = HistogramGuard::begin("tycho_core_apply_block_time");
+        let labels = [("workchain", block.id().shard.workchain().to_string())];
+        let _histogram =
+            HistogramGuard::begin_with_labels("tycho_core_apply_block_time_high", &labels);
 
         let update = block
             .as_ref()

--- a/scripts/gen-dashboard.py
+++ b/scripts/gen-dashboard.py
@@ -1486,6 +1486,11 @@ def collator_time_metrics() -> RowPanel:
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
+            "tycho_collator_build_new_state_time_high",
+            "Build State for next collation",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_heatmap_panel(
             "tycho_collator_resume_collation_time_high",
             "Resume collation",
             labels=['workchain=~"$workchain"'],
@@ -1496,13 +1501,13 @@ def collator_time_metrics() -> RowPanel:
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_build_new_state_time_high",
-            "Build State for next collation",
+            "tycho_collator_wait_for_working_state_time_high",
+            "Wait for updated WorkingState",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_wait_for_working_state_time_high",
-            "Wait for updated WorkingState",
+            "tycho_collator_import_next_anchor_time_high",
+            "Import next anchor time",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
@@ -1512,11 +1517,6 @@ def collator_time_metrics() -> RowPanel:
         create_heatmap_panel(
             "tycho_collator_try_collate_next_shard_block_time",
             "Try collate next shard block",
-        ),
-        create_heatmap_panel(
-            "tycho_collator_import_next_anchor_time_high",
-            "Import next anchor time",
-            labels=['workchain=~"$workchain"'],
         ),
     ]
     return create_row("collator: Time diffs", metrics)
@@ -1796,14 +1796,16 @@ def collator_state_adapter_metrics() -> RowPanel:
             "Prepare block proof",
         ),
         create_heatmap_panel(
-            "tycho_collator_state_adapter_save_block_proof_time", "Save block proof"
+            "tycho_collator_state_adapter_save_block_proof_time_high", "Save block proof"
         ),
         create_heatmap_panel(
-            "tycho_collator_state_store_state_root_time", "Store state root"
+            "tycho_collator_state_store_state_root_time_high",
+            "Store state root",
+            labels=['workchain=~"$workchain"'],
         ),
+        create_heatmap_panel("tycho_collator_state_load_block_time", "Load block"),
         create_heatmap_panel("tycho_collator_state_load_state_time", "Load state"),
         create_heatmap_panel("tycho_collator_state_load_state_root_time", "Load state root"),
-        create_heatmap_panel("tycho_collator_state_load_block_time", "Load block"),
         create_heatmap_panel(
             "tycho_collator_state_load_queue_diff_time", "Load queue diff"
         ),

--- a/scripts/gen-dashboard.py
+++ b/scripts/gen-dashboard.py
@@ -763,8 +763,9 @@ def core_block_strider() -> RowPanel:
             "Total time to handle archive by all subscribers",
         ),
         create_heatmap_panel(
-            "tycho_core_apply_block_time",
+            "tycho_core_apply_block_time_high",
             "Time to apply and save block state",
+            labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
             "tycho_core_metrics_subscriber_handle_block_time",

--- a/scripts/gen-dashboard.py
+++ b/scripts/gen-dashboard.py
@@ -1486,18 +1486,18 @@ def collator_time_metrics() -> RowPanel:
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_prepare_working_state_update_time_high",
-            "Prepare WorkingState update",
-            labels=['workchain=~"$workchain"'],
-        ),
-        create_heatmap_panel(
             "tycho_collator_resume_collation_time_high",
             "Resume collation",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
+            "tycho_collator_resume_collation_apply_merkles_time_high",
+            "inc. apply Merkle Updates",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_heatmap_panel(
             "tycho_collator_build_new_state_time_high",
-            "Build Pure State for next collation",
+            "Build State for next collation",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
@@ -1802,6 +1802,7 @@ def collator_state_adapter_metrics() -> RowPanel:
             "tycho_collator_state_store_state_root_time", "Store state root"
         ),
         create_heatmap_panel("tycho_collator_state_load_state_time", "Load state"),
+        create_heatmap_panel("tycho_collator_state_load_state_root_time", "Load state root"),
         create_heatmap_panel("tycho_collator_state_load_block_time", "Load block"),
         create_heatmap_panel(
             "tycho_collator_state_load_queue_diff_time", "Load queue diff"

--- a/storage/src/store/persistent_state/mod.rs
+++ b/storage/src/store/persistent_state/mod.rs
@@ -332,7 +332,7 @@ impl PersistentStateStorage {
             // NOTE: Ensure that the tracker handle will outlive the state writer.
             let _tracker_handle = tracker_handle;
 
-            let root_hash = this.shard_states.load_state_root(handle.id())?;
+            let root_hash = this.shard_states.load_state_root_hash(handle.id())?;
 
             let states_dir = this.prepare_persistent_states_dir(mc_seqno)?;
 

--- a/storage/src/store/shard_state/mod.rs
+++ b/storage/src/store/shard_state/mod.rs
@@ -95,6 +95,8 @@ impl ShardStateStorage {
         root_cell: Cell,
         hint: StoreStateHint,
     ) -> Result<bool> {
+        metrics::counter!("tycho_storage_store_state_root_count").increment(1);
+
         if handle.has_state() {
             return Ok(false);
         }

--- a/storage/src/store/shard_state/mod.rs
+++ b/storage/src/store/shard_state/mod.rs
@@ -181,10 +181,16 @@ impl ShardStateStorage {
     }
 
     pub async fn load_state(&self, block_id: &BlockId) -> Result<ShardStateStuff> {
-        let cell_id = self.load_state_root(block_id)?;
+        let cell = self.load_state_root(block_id)?;
+
+        ShardStateStuff::from_root(block_id, cell, &self.min_ref_mc_state)
+    }
+
+    pub fn load_state_root(&self, block_id: &BlockId) -> Result<Cell> {
+        let cell_id = self.load_state_root_hash(block_id)?;
         let cell = self.cell_storage.load_cell(cell_id)?;
 
-        ShardStateStuff::from_root(block_id, Cell::from(cell as Arc<_>), &self.min_ref_mc_state)
+        Ok(Cell::from(cell))
     }
 
     #[tracing::instrument(skip(self))]
@@ -348,7 +354,7 @@ impl ShardStateStorage {
             .map(Some)
     }
 
-    pub fn load_state_root(&self, block_id: &BlockId) -> Result<HashBytes> {
+    pub fn load_state_root_hash(&self, block_id: &BlockId) -> Result<HashBytes> {
         let shard_states = &self.db.shard_states;
         let shard_state = shard_states.get(block_id.to_vec())?;
         match shard_state {


### PR DESCRIPTION
Finally this feature does not get perf improvement in comparison with perf/mt-cells-store. Will postpone it until the parallel Merkle apply is implemented.

## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES
Yes
Added `.collator.untrack_prev_state_after: u16` with default value `5`. Do not need to update config when deploy new version.

### BLOCKCHAIN CONFIGURATION MODEL CHANGES
None

---

### COMPATIBILITY
fully compatible

### SPECIAL DEPLOYMENT ACTIONS
Not Required

---

### PERFORMANCE IMPACT
Expected impact

TPS should grow a bit. Time diff should reduce on heavy load. The average resume collation time should decrease.

---

### TESTS

#### Unit Tests
No coverage

#### Network Tests
No coverage

#### Manual Tests
##### Comparison with master
Deploy 1M accounts then run 10k transfers
(master is on the right) [grafana](https://grafana.broxus.com/d/cdlaji62a1b0gb1/tycho-node-metrics-high-times?orgId=1&refresh=30s&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet2-validator1&var-instance=tycho-devnet2-validator2&var-instance=tycho-devnet2-validator3&var-instance=tycho-devnet2-validator4&var-instance=tycho-devnet2-validator5&var-instance=tycho-devnet2-validator6&var-instance=tycho-devnet2-validator7&var-instance=tycho-devnet2-validator8&var-instance=tycho-devnet2-validator9&var-instance=tycho-devnet2-validator10&var-instance=tycho-devnet2-validator11&var-instance=tycho-devnet2-validator12&var-instance=tycho-devnet2-validator13&var-instance=tycho-devnet2-validator14&var-instance=tycho-devnet2-validator15&var-instance=tycho-devnet2-validator16&var-instance=tycho-devnet2-validator17&var-instance=tycho-devnet2-validator18&var-instance=tycho-devnet2-validator19&var-workchain=0&var-kind=$__all&var-method=$__all&from=2025-05-29T19:31:11.111Z&to=2025-05-29T20:35:45.402Z&timezone=browser&var-partition=$__all&var-peer_id=$__all&var-remote_addr=$__all)

![image](https://github.com/user-attachments/assets/4b834c2f-eb70-4d78-aefe-86e64946549d)
![image](https://github.com/user-attachments/assets/dfbe9af6-4e35-4132-835f-43a2b0362fec)

##### Comparison with perf/mt-cells-store
Deploy 1M accounts then run 10k transfers - no affect
(perf/mt-cells-store is on the right) [grafana](https://grafana.broxus.com/d/cdlaji62a1b0gb1/tycho-node-metrics-high-times?orgId=1&from=2025-06-04T20:12:42.205Z&to=2025-06-04T20:47:06.298Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet2-validator1&var-instance=tycho-devnet2-validator10&var-instance=tycho-devnet2-validator11&var-instance=tycho-devnet2-validator12&var-instance=tycho-devnet2-validator13&var-instance=tycho-devnet2-validator14&var-instance=tycho-devnet2-validator15&var-instance=tycho-devnet2-validator16&var-instance=tycho-devnet2-validator17&var-instance=tycho-devnet2-validator18&var-instance=tycho-devnet2-validator19&var-instance=tycho-devnet2-validator9&var-instance=tycho-devnet2-validator8&var-instance=tycho-devnet2-validator7&var-instance=tycho-devnet2-validator6&var-instance=tycho-devnet2-validator5&var-instance=tycho-devnet2-validator3&var-instance=tycho-devnet2-validator2&var-instance=tycho-devnet2-validator4&var-workchain=$__all&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)

![image](https://github.com/user-attachments/assets/c87f1d76-e2c5-4c58-86f2-2170b65f5a35)
![image](https://github.com/user-attachments/assets/059eab45-5579-4906-9767-367c5375097f)

Deploy 10M accounts then run 10k transfers - current branch shows little bit worse results
(perf/mt-cells-store is on the right) [grafana](https://grafana.broxus.com/d/cdlaji62a1b0gb1/tycho-node-metrics-high-times?orgId=1&from=2025-06-04T20:52:14.000Z&to=2025-06-04T22:45:28.257Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet2-validator1&var-instance=tycho-devnet2-validator10&var-instance=tycho-devnet2-validator11&var-instance=tycho-devnet2-validator12&var-instance=tycho-devnet2-validator13&var-instance=tycho-devnet2-validator14&var-instance=tycho-devnet2-validator15&var-instance=tycho-devnet2-validator16&var-instance=tycho-devnet2-validator17&var-instance=tycho-devnet2-validator18&var-instance=tycho-devnet2-validator19&var-instance=tycho-devnet2-validator9&var-instance=tycho-devnet2-validator8&var-instance=tycho-devnet2-validator7&var-instance=tycho-devnet2-validator6&var-instance=tycho-devnet2-validator5&var-instance=tycho-devnet2-validator3&var-instance=tycho-devnet2-validator2&var-instance=tycho-devnet2-validator4&var-workchain=$__all&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)

![image](https://github.com/user-attachments/assets/1acd2975-0614-4ee1-8001-09a8c9c4bc3a)
![image](https://github.com/user-attachments/assets/adebeb85-b281-4af0-856c-cef9e82477b6)
![image](https://github.com/user-attachments/assets/9acaf3d2-cec6-41c1-9a08-4f7141829e5a)

Run 10k transfers on zero state - no affect
(perf/mt-cells-store is on the right) [grafana](https://grafana.broxus.com/d/cdlaji62a1b0gb1/tycho-node-metrics-high-times?orgId=1&from=2025-06-05T08:48:56.026Z&to=2025-06-05T10:06:25.447Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet2-validator1&var-instance=tycho-devnet2-validator10&var-instance=tycho-devnet2-validator11&var-instance=tycho-devnet2-validator12&var-instance=tycho-devnet2-validator13&var-instance=tycho-devnet2-validator14&var-instance=tycho-devnet2-validator15&var-instance=tycho-devnet2-validator16&var-instance=tycho-devnet2-validator17&var-instance=tycho-devnet2-validator18&var-instance=tycho-devnet2-validator19&var-instance=tycho-devnet2-validator9&var-instance=tycho-devnet2-validator8&var-instance=tycho-devnet2-validator7&var-instance=tycho-devnet2-validator6&var-instance=tycho-devnet2-validator5&var-instance=tycho-devnet2-validator3&var-instance=tycho-devnet2-validator2&var-instance=tycho-devnet2-validator4&var-workchain=0&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)

Run 20k transfers on zero state - current branch shows little bit worse results
(perf/mt-cells-store is on the right) [grafana](https://grafana.broxus.com/d/cdlaji62a1b0gb1/tycho-node-metrics-high-times?orgId=1&from=2025-06-05T10:16:44.100Z&to=2025-06-05T10:54:22.787Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet2-validator1&var-instance=tycho-devnet2-validator10&var-instance=tycho-devnet2-validator11&var-instance=tycho-devnet2-validator12&var-instance=tycho-devnet2-validator13&var-instance=tycho-devnet2-validator14&var-instance=tycho-devnet2-validator15&var-instance=tycho-devnet2-validator16&var-instance=tycho-devnet2-validator17&var-instance=tycho-devnet2-validator18&var-instance=tycho-devnet2-validator19&var-instance=tycho-devnet2-validator9&var-instance=tycho-devnet2-validator8&var-instance=tycho-devnet2-validator7&var-instance=tycho-devnet2-validator6&var-instance=tycho-devnet2-validator5&var-instance=tycho-devnet2-validator3&var-instance=tycho-devnet2-validator2&var-instance=tycho-devnet2-validator4&var-workchain=0&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)