### PR TITLE
detailed wu price

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,7 +48,7 @@ Affected features:
 For each affected feature specify:
   - Compatibility status: [fully compatible] / [special logic applied] / [incompatible]
   - If not compatible, provide migration instructions
-  - If compatibility ensured, describe how. Describe how compatability was tested.
+  - If compatibility ensured, describe how. Describe how compatibility was tested.
 -->
 
 ### SPECIAL DEPLOYMENT ACTIONS
@@ -83,13 +83,13 @@ If impact expected:
 
 #### Unit Tests
 
-[Covered by:] / [No covarage]
+[Covered by:] / [No coverage]
 
 <!--List unit tests that cover changes (if exits). Link tasks to create additional tests (if needed).-->
 
 #### Network Tests
 
-[Covered by:] / [No covarage]
+[Covered by:] / [No coverage]
 
 <!--List unit tests that cover changes (if exits). Link tasks to create additional tests (if needed).-->
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3694,7 +3694,7 @@ dependencies = [
 [[package]]
 name = "tycho-executor"
 version = "0.1.0"
-source = "git+https://github.com/broxus/tycho-vm.git?rev=f45e047044f6dd054ea8e27905b1b7485fbf3227#f45e047044f6dd054ea8e27905b1b7485fbf3227"
+source = "git+https://github.com/broxus/tycho-vm.git?rev=60b5db42f650654e09d1a703b1ce2cdc60d9379b#60b5db42f650654e09d1a703b1ce2cdc60d9379b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3896,7 +3896,7 @@ dependencies = [
 [[package]]
 name = "tycho-vm"
 version = "0.1.0"
-source = "git+https://github.com/broxus/tycho-vm.git?rev=f45e047044f6dd054ea8e27905b1b7485fbf3227#f45e047044f6dd054ea8e27905b1b7485fbf3227"
+source = "git+https://github.com/broxus/tycho-vm.git?rev=60b5db42f650654e09d1a703b1ce2cdc60d9379b#60b5db42f650654e09d1a703b1ce2cdc60d9379b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3917,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "tycho-vm-proc"
 version = "0.1.0"
-source = "git+https://github.com/broxus/tycho-vm.git?rev=f45e047044f6dd054ea8e27905b1b7485fbf3227#f45e047044f6dd054ea8e27905b1b7485fbf3227"
+source = "git+https://github.com/broxus/tycho-vm.git?rev=60b5db42f650654e09d1a703b1ce2cdc60d9379b#60b5db42f650654e09d1a703b1ce2cdc60d9379b"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,8 +121,8 @@ weedb = "0.4.5"
 zstd-safe = "7.2"
 zstd-sys = "2.0"
 
-tycho-executor = { git = "https://github.com/broxus/tycho-vm.git", rev = "f45e047044f6dd054ea8e27905b1b7485fbf3227" }
-tycho-vm = { git = "https://github.com/broxus/tycho-vm.git", rev = "f45e047044f6dd054ea8e27905b1b7485fbf3227" }
+tycho-executor = { git = "https://github.com/broxus/tycho-vm.git", rev = "60b5db42f650654e09d1a703b1ce2cdc60d9379b" }
+tycho-vm = { git = "https://github.com/broxus/tycho-vm.git", rev = "60b5db42f650654e09d1a703b1ce2cdc60d9379b" }
 
 # local deps
 tycho-block-util = { path = "./block-util", version = "0.2.10" }

--- a/collator/src/collator/do_collate/prepare.rs
+++ b/collator/src/collator/do_collate/prepare.rs
@@ -181,8 +181,11 @@ impl Phase<PrepareState> {
         Ok(Phase::<ExecuteState> {
             extra: ExecuteState {
                 messages_reader,
-                execute_result: None,
                 executor: ExecutorWrapper::new(executor, self.state.shard_id),
+                msgs_reader_metrics: None,
+                prepare_msg_groups_wu: None,
+                execute_metrics: Default::default(),
+                execute_wu: Default::default(),
             },
             state: self.state,
         })

--- a/collator/src/collator/do_collate/work_units.rs
+++ b/collator/src/collator/do_collate/work_units.rs
@@ -351,12 +351,13 @@ impl FinalizeWu {
         // TODO: should use accounts count in state to calc wu for merkle update
 
         // calc build state update
-        //  * calc update of all updated accounts in (accounts_count)*log(state_accounts_count)
+        //  * calc update of all updated accounts in parallel in (accounts_count)*log(state_accounts_count)/(threads_count)
         //  * use min value if calculated is less
         self.build_state_update_wu = std::cmp::max(
             state_update_min as u64,
             accounts_count
                 .saturating_mul(accounts_count_log)
+                .saturating_div(threads_count)
                 .saturating_mul(state_update_accounts as u64),
         );
 

--- a/collator/src/collator/do_collate/work_units.rs
+++ b/collator/src/collator/do_collate/work_units.rs
@@ -1,8 +1,12 @@
 use std::time::Duration;
 
-use everscale_types::models::WorkUnitsParamsPrepare;
+use everscale_types::models::{
+    WorkUnitsParamsExecute, WorkUnitsParamsFinalize, WorkUnitsParamsPrepare,
+};
 
+use crate::collator::execution_manager::ExecutedGroup;
 use crate::collator::messages_reader::MessagesReaderMetrics;
+use crate::collator::types::{BlockCollationData, ExecuteMetrics, FinalizeMetrics};
 use crate::tracing_targets;
 
 pub struct PrepareMsgGroupsWu {
@@ -79,7 +83,7 @@ impl PrepareMsgGroupsWu {
         };
 
         tracing::debug!(target: tracing_targets::COLLATOR,
-            "prepare_msg_groups_wu: total: (wu={}, elapsed={}, price={}), \
+            "read_msg_groups_wu: total: (wu={}, elapsed={}, price={}), \
             read_ext_msgs: (count={}, param={}, wu={}, elapsed={}, price={}), \
             read_existing_int_msgs: (count={}, param={}, wu={}, elapsed={}, price={}), \
             read_new_int_msgs: (count={}, param={}, wu={}, elapsed={}, price={}), \
@@ -128,5 +132,360 @@ impl PrepareMsgGroupsWu {
             return 0.0;
         }
         self.add_msgs_to_groups_elapsed.as_nanos() as f64 / self.add_msgs_to_groups_wu as f64
+    }
+}
+
+#[derive(Default)]
+pub struct ExecuteWu {
+    pub execute_groups_vm_only_wu: u64,
+    pub execute_groups_vm_only_elapsed: Duration,
+
+    pub process_txs_wu: u64,
+    pub process_txs_elapsed: Duration,
+}
+impl ExecuteWu {
+    pub fn append_executed_group(
+        &mut self,
+        wu_params_execute: &WorkUnitsParamsExecute,
+        executed_group: &ExecutedGroup,
+    ) {
+        self.execute_groups_vm_only_wu = self
+            .execute_groups_vm_only_wu
+            .saturating_add(executed_group.total_exec_wu)
+            .saturating_add(
+                executed_group
+                    .ext_msgs_error_count
+                    .saturating_mul(wu_params_execute.execute_err as u64),
+            );
+    }
+
+    pub fn calculate(
+        &mut self,
+        wu_params_execute: &WorkUnitsParamsExecute,
+        execute_metrics: &ExecuteMetrics,
+        collation_data: &BlockCollationData,
+    ) {
+        let &WorkUnitsParamsExecute {
+            serialize_enqueue: insert_in_msgs,
+            serialize_dequeue: insert_out_msgs,
+            insert_new_msgs,
+            ..
+        } = wu_params_execute;
+
+        let in_msgs_len = collation_data.in_msgs.len();
+        let in_msgs_len_log = in_msgs_len.checked_ilog2().unwrap_or_default() as usize;
+        let out_msgs_len = collation_data.out_msgs.len();
+        let out_msgs_len_log = out_msgs_len.checked_ilog2().unwrap_or_default() as usize;
+        let inserted_new_msgs_count_log = collation_data
+            .inserted_new_msgs_count
+            .checked_ilog2()
+            .unwrap_or_default() as usize;
+
+        self.process_txs_wu = in_msgs_len
+            .saturating_mul(in_msgs_len_log)
+            .saturating_mul(insert_in_msgs as usize)
+            .saturating_add(
+                out_msgs_len
+                    .saturating_mul(out_msgs_len_log)
+                    .saturating_mul(insert_out_msgs as usize),
+            )
+            .saturating_add(
+                (collation_data.inserted_new_msgs_count as usize)
+                    .saturating_mul(inserted_new_msgs_count_log)
+                    .saturating_mul(insert_new_msgs as usize),
+            ) as u64;
+
+        self.execute_groups_vm_only_elapsed =
+            execute_metrics.execute_groups_vm_only_timer.total_elapsed;
+        self.process_txs_elapsed = execute_metrics.process_txs_timer.total_elapsed;
+    }
+
+    pub fn total_wu(&self) -> u64 {
+        self.execute_groups_vm_only_wu
+            .saturating_add(self.process_txs_wu)
+    }
+    pub fn total_elapsed(&self) -> Duration {
+        self.execute_groups_vm_only_elapsed
+            .saturating_add(self.process_txs_elapsed)
+    }
+    pub fn total_wu_price(&self) -> f64 {
+        let total_wu = self.total_wu();
+        if total_wu == 0 {
+            return 0.0;
+        }
+        self.total_elapsed().as_nanos() as f64 / total_wu as f64
+    }
+
+    pub fn execute_groups_vm_only_wu_price(&self) -> f64 {
+        if self.execute_groups_vm_only_wu == 0 {
+            return 0.0;
+        }
+        self.execute_groups_vm_only_elapsed.as_nanos() as f64
+            / self.execute_groups_vm_only_wu as f64
+    }
+
+    pub fn process_txs_wu_price(&self) -> f64 {
+        if self.process_txs_wu == 0 {
+            return 0.0;
+        }
+        self.process_txs_elapsed.as_nanos() as f64 / self.process_txs_wu as f64
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct FinalizeWu {
+    pub create_queue_diff_wu: u64,
+    pub create_queue_diff_elapsed: Duration,
+
+    pub apply_queue_diff_wu: u64,
+    pub apply_queue_diff_elapsed: Duration,
+
+    pub build_shard_accounts_wu: u64,
+    pub build_accounts_blocks_wu: u64,
+    pub build_accounts_elapsed: Duration,
+
+    pub build_in_msgs_wu: u64,
+    pub build_in_msgs_elapsed: Duration,
+
+    pub build_out_msgs_wu: u64,
+    pub build_out_msgs_elapsed: Duration,
+
+    pub build_accounts_and_messages_in_parallel_elased: Duration,
+
+    pub build_state_update_wu: u64,
+    pub build_state_update_elapsed: Duration,
+
+    pub build_block_wu: u64,
+    pub build_block_elapsed: Duration,
+
+    pub finalize_block_elapsed: Duration,
+
+    pub total_elapsed: Duration,
+}
+impl FinalizeWu {
+    pub fn calculate_queue_diff_wu(
+        &mut self,
+        wu_params_finalize: &WorkUnitsParamsFinalize,
+        diff_msgs_count: u64,
+    ) {
+        let &WorkUnitsParamsFinalize {
+            create_diff,
+            apply_diff,
+            ..
+        } = wu_params_finalize;
+
+        self.create_queue_diff_wu = diff_msgs_count.saturating_mul(create_diff as u64);
+        self.apply_queue_diff_wu = diff_msgs_count.saturating_mul(apply_diff as u64);
+    }
+
+    pub fn calculate_finalize_block_wu(
+        &mut self,
+        wu_params_finalize: &WorkUnitsParamsFinalize,
+        wu_params_execute: &WorkUnitsParamsExecute,
+        accounts_count: u64,
+        in_msgs_len: u64,
+        out_msgs_len: u64,
+    ) {
+        let &WorkUnitsParamsFinalize {
+            build_accounts,
+            build_transactions,
+            build_in_msg,
+            build_out_msg,
+            serialize_min,
+            serialize_accounts,
+            serialize_msg,
+            state_update_min,
+            state_update_accounts,
+            ..
+        } = wu_params_finalize;
+
+        let &WorkUnitsParamsExecute {
+            subgroup_size: max_threads_count,
+            ..
+        } = wu_params_execute;
+
+        let threads_count = (max_threads_count as u64).min(accounts_count).max(1);
+
+        let accounts_count_log = accounts_count.checked_ilog2().unwrap_or_default() as u64;
+        let in_msgs_len_log = in_msgs_len.checked_ilog2().unwrap_or_default() as u64;
+        let out_msgs_len_log = out_msgs_len.checked_ilog2().unwrap_or_default() as u64;
+
+        // TODO: should use accounts count in state to calc wu for updating shards accounts map
+
+        // calc update shard accounts:
+        //  * prepare account modifications in (accounts_count)
+        //  * then update map of shard accounts in parallel in (accounts_count)*log(state_accounts_count)/(threads_count)
+        self.build_shard_accounts_wu = accounts_count
+            .saturating_add(
+                accounts_count
+                    .saturating_mul(accounts_count_log)
+                    .saturating_div(threads_count),
+            )
+            .saturating_mul(build_accounts as u64);
+
+        // calc build account blocks:
+        //  * build maps of transactions by accounts in parallel in (txs_count)*log(txs_count/threads_count)/(threads_count)
+        //  * then build AugDict of accounts blocks in (accounts_count)*log(accounts_count)
+        let in_msgs_len_div_threads_count_log = in_msgs_len
+            .saturating_div(threads_count)
+            .checked_ilog2()
+            .unwrap_or_default() as u64;
+        self.build_accounts_blocks_wu = in_msgs_len
+            .saturating_mul(in_msgs_len_div_threads_count_log)
+            .saturating_div(threads_count)
+            .saturating_add(accounts_count.saturating_mul(accounts_count_log))
+            .saturating_mul(build_transactions as u64);
+
+        // calc build in msgs:
+        //  * build AugDict of in msgs in (in_msgs_len)*log(in_msgs_len)
+        self.build_in_msgs_wu = in_msgs_len
+            .saturating_mul(in_msgs_len_log)
+            .saturating_mul(build_in_msg as u64);
+
+        // calc build out msgs:
+        //  * build AugDict of out msgs in (out_msgs_len)*log(out_msgs_len)
+        self.build_out_msgs_wu = out_msgs_len
+            .saturating_mul(out_msgs_len_log)
+            .saturating_mul(build_out_msg as u64);
+
+        // TODO: should use accounts count in state to calc wu for merkle update
+
+        // calc build state update
+        //  * calc update of all updated accounts in (accounts_count)*log(state_accounts_count)
+        //  * use min value if calculated is less
+        self.build_state_update_wu = std::cmp::max(
+            state_update_min as u64,
+            accounts_count
+                .saturating_mul(accounts_count_log)
+                .saturating_mul(state_update_accounts as u64),
+        );
+
+        // calc build block
+        //  * serialize each account block in (accounts_count) and use min value if calculated is less
+        //  * serialize in msgs and out msgs in (in_msgs_len + out_msgs_len)
+        self.build_block_wu = std::cmp::max(
+            serialize_min as u64,
+            accounts_count.saturating_mul(serialize_accounts as u64),
+        )
+        .saturating_add((in_msgs_len + out_msgs_len).saturating_mul(serialize_msg as u64));
+    }
+
+    pub fn append_elapsed_timings(&mut self, finalize_metrics: &FinalizeMetrics) {
+        self.create_queue_diff_elapsed = finalize_metrics.create_queue_diff_elapsed;
+        self.apply_queue_diff_elapsed = finalize_metrics.apply_queue_diff_elapsed;
+
+        self.build_accounts_elapsed = finalize_metrics.build_accounts_elapsed;
+        self.build_in_msgs_elapsed = finalize_metrics.build_in_msgs_elapsed;
+        self.build_out_msgs_elapsed = finalize_metrics.build_out_msgs_elapsed;
+
+        self.build_accounts_and_messages_in_parallel_elased =
+            finalize_metrics.build_accounts_and_messages_in_parallel_elased;
+
+        self.build_state_update_elapsed = finalize_metrics.build_state_update_elapsed;
+        self.build_block_elapsed = finalize_metrics.build_block_elapsed;
+
+        self.finalize_block_elapsed = finalize_metrics.finalize_block_elapsed;
+
+        self.total_elapsed = finalize_metrics.total_timer.total_elapsed;
+    }
+
+    pub fn build_accounts_wu(&self) -> u64 {
+        self.build_shard_accounts_wu + self.build_accounts_blocks_wu
+    }
+
+    pub fn build_accounts_wu_price(&self) -> f64 {
+        let build_accounts_wu = self.build_accounts_wu();
+        if build_accounts_wu == 0 {
+            return 0.0;
+        }
+        self.build_accounts_elapsed.as_nanos() as f64 / build_accounts_wu as f64
+    }
+
+    pub fn build_in_msgs_wu_price(&self) -> f64 {
+        if self.build_in_msgs_wu == 0 {
+            return 0.0;
+        }
+        self.build_in_msgs_elapsed.as_nanos() as f64 / self.build_in_msgs_wu as f64
+    }
+
+    pub fn build_out_msgs_wu_price(&self) -> f64 {
+        if self.build_out_msgs_wu == 0 {
+            return 0.0;
+        }
+        self.build_out_msgs_elapsed.as_nanos() as f64 / self.build_out_msgs_wu as f64
+    }
+
+    pub fn max_accounts_in_out_msgs_wu(&self) -> u64 {
+        self.build_accounts_wu()
+            .max(self.build_in_msgs_wu)
+            .max(self.build_out_msgs_wu)
+    }
+
+    pub fn build_accounts_and_messages_in_parallel_wu_price(&self) -> f64 {
+        let max_wu = self.max_accounts_in_out_msgs_wu();
+        if max_wu == 0 {
+            return 0.0;
+        }
+        self.build_accounts_and_messages_in_parallel_elased
+            .as_nanos() as f64
+            / max_wu as f64
+    }
+
+    pub fn build_state_update_wu_price(&self) -> f64 {
+        if self.build_state_update_wu == 0 {
+            return 0.0;
+        }
+        self.build_state_update_elapsed.as_nanos() as f64 / self.build_state_update_wu as f64
+    }
+
+    pub fn build_block_wu_price(&self) -> f64 {
+        if self.build_block_wu == 0 {
+            return 0.0;
+        }
+        self.build_block_elapsed.as_nanos() as f64 / self.build_block_wu as f64
+    }
+
+    pub fn finalize_block_wu(&self) -> u64 {
+        self.max_accounts_in_out_msgs_wu()
+            .saturating_add(self.build_state_update_wu)
+            .saturating_add(self.build_block_wu)
+    }
+
+    pub fn finalize_block_wu_price(&self) -> f64 {
+        let finalize_block_wu = self.finalize_block_wu();
+        if finalize_block_wu == 0 {
+            return 0.0;
+        }
+        self.finalize_block_elapsed.as_nanos() as f64 / finalize_block_wu as f64
+    }
+
+    pub fn create_queue_diff_wu_price(&self) -> f64 {
+        if self.create_queue_diff_wu == 0 {
+            return 0.0;
+        }
+        self.create_queue_diff_elapsed.as_nanos() as f64 / self.create_queue_diff_wu as f64
+    }
+
+    pub fn apply_queue_diff_wu_price(&self) -> f64 {
+        if self.apply_queue_diff_wu == 0 {
+            return 0.0;
+        }
+        self.apply_queue_diff_elapsed.as_nanos() as f64 / self.apply_queue_diff_wu as f64
+    }
+
+    pub fn total_wu(&self) -> u64 {
+        // take max from finalize block and apply diff
+        // and sum with create diff
+        self.finalize_block_wu()
+            .max(self.apply_queue_diff_wu)
+            .saturating_add(self.create_queue_diff_wu)
+    }
+
+    pub fn total_wu_price(&self) -> f64 {
+        let total_wu = self.total_wu();
+        if total_wu == 0 {
+            return 0.0;
+        }
+        self.total_elapsed.as_nanos() as f64 / total_wu as f64
     }
 }

--- a/collator/src/collator/do_collate/work_units.rs
+++ b/collator/src/collator/do_collate/work_units.rs
@@ -146,17 +146,12 @@ pub struct ExecuteWu {
 impl ExecuteWu {
     pub fn append_executed_group(
         &mut self,
-        wu_params_execute: &WorkUnitsParamsExecute,
+        _wu_params_execute: &WorkUnitsParamsExecute,
         executed_group: &ExecutedGroup,
     ) {
         self.execute_groups_vm_only_wu = self
             .execute_groups_vm_only_wu
-            .saturating_add(executed_group.total_exec_wu)
-            .saturating_add(
-                executed_group
-                    .ext_msgs_error_count
-                    .saturating_mul(wu_params_execute.execute_err as u64),
-            );
+            .saturating_add(executed_group.total_exec_wu);
     }
 
     pub fn calculate(

--- a/collator/src/collator/execution_manager.rs
+++ b/collator/src/collator/execution_manager.rs
@@ -13,7 +13,9 @@ use tycho_util::metrics::HistogramGuard;
 use tycho_util::FastHashMap;
 
 use super::messages_buffer::MessageGroup;
-use super::types::{AccountId, ExecutedTransaction, ParsedMessage, ShardAccountStuff};
+use super::types::{
+    AccountId, ExecutedTransaction, ParsedMessage, ShardAccountStuff, SkippedTransaction,
+};
 use crate::tracing_targets;
 
 pub(super) struct MessagesExecutor {
@@ -221,38 +223,43 @@ impl MessagesExecutor {
         *ext_msgs_skipped += executed.ext_msgs_skipped;
 
         let mut current_wu = 0u64;
+        let mut consume_gas_wu = |total_gas: u64| {
+            current_wu = current_wu
+                .saturating_add(self.wu_params_execute.prepare as u64)
+                .saturating_add(
+                    total_gas
+                        .saturating_mul(self.wu_params_execute.execute as u64)
+                        .saturating_div(self.wu_params_execute.execute_delimiter as u64),
+                );
+        };
 
         *max_account_msgs_exec_time = (*max_account_msgs_exec_time).max(executed.exec_time);
         *total_exec_time += executed.exec_time;
         *group_max_vert_size = cmp::max(*group_max_vert_size, executed.transactions.len());
 
         for tx in executed.transactions {
-            let Some(executed) = tx.result else {
-                tracing::trace!(
-                    target: tracing_targets::EXEC_MANAGER,
-                    account_addr = %executed.account_state.account_addr,
-                    message_hash = %tx.in_message.cell.repr_hash(),
-                    "skipped external message",
-                );
-                *ext_msgs_error_count += 1;
-                continue;
-            };
+            match tx.result {
+                TransactionResult::Executed(executed) => {
+                    self.min_next_lt = cmp::max(self.min_next_lt, executed.next_lt);
+                    consume_gas_wu(executed.gas_used);
 
-            self.min_next_lt = cmp::max(self.min_next_lt, executed.next_lt);
+                    items.push(ExecutedTickItem {
+                        in_message: tx.in_message,
+                        executed,
+                    });
+                }
+                TransactionResult::Skipped(skipped) => {
+                    tracing::trace!(
+                        target: tracing_targets::EXEC_MANAGER,
+                        account_addr = %executed.account_state.account_addr,
+                        message_hash = %tx.in_message.cell.repr_hash(),
+                        "skipped external message",
+                    );
 
-            current_wu = current_wu
-                .saturating_add(self.wu_params_execute.prepare as u64)
-                .saturating_add(
-                    executed
-                        .gas_used
-                        .saturating_mul(self.wu_params_execute.execute as u64)
-                        .saturating_div(self.wu_params_execute.execute_delimiter as u64),
-                );
-
-            items.push(ExecutedTickItem {
-                in_message: tx.in_message,
-                executed,
-            });
+                    consume_gas_wu(skipped.gas_used);
+                    *ext_msgs_error_count += 1;
+                }
+            }
         }
 
         self.accounts_cache
@@ -318,7 +325,7 @@ impl MessagesExecutor {
         )
         .map(|executed| (account_stuff, executed))?;
 
-        if let Some(tx) = &executed.result {
+        if let TransactionResult::Executed(tx) = &executed.result {
             self.min_next_lt = cmp::max(min_next_lt, tx.next_lt);
         }
         self.accounts_cache.add_account_stuff(account_stuff);
@@ -330,25 +337,25 @@ impl MessagesExecutor {
         &mut self,
         mut account_stuff: Box<ShardAccountStuff>,
         tick_tock: TickTock,
-    ) -> Result<Option<ExecutedTransaction>> {
+    ) -> Result<TransactionResult> {
         let min_next_lt = self.min_next_lt;
         let config = self.config.clone();
         let params = self.params.clone();
 
-        let Some(executed) = execute_ticktock_transaction(
+        let executed = execute_ticktock_transaction(
             &mut account_stuff,
             tick_tock,
             min_next_lt,
             &config,
             &params,
-        )?
-        else {
-            return Ok(None);
-        };
+        )?;
 
-        self.min_next_lt = cmp::max(min_next_lt, executed.next_lt);
+        if let TransactionResult::Executed(tx) = &executed {
+            self.min_next_lt = cmp::max(min_next_lt, tx.next_lt);
+        }
+
         self.accounts_cache.add_account_stuff(account_stuff);
-        Ok(Some(executed))
+        Ok(executed)
     }
 }
 
@@ -435,8 +442,13 @@ pub struct ExecutedTransactions {
 }
 
 pub struct ExecutedOrdinaryTransaction {
-    pub result: Option<ExecutedTransaction>,
+    pub result: TransactionResult,
     pub in_message: Box<ParsedMessage>,
+}
+
+pub enum TransactionResult {
+    Executed(ExecutedTransaction),
+    Skipped(SkippedTransaction),
 }
 
 fn execute_ordinary_transaction_impl(
@@ -474,7 +486,9 @@ fn execute_ordinary_transaction_impl(
         // TODO: Export `inspector.exit_code` to metrics.
         Err(TxError::Skipped) if is_external => {
             return Ok(ExecutedOrdinaryTransaction {
-                result: None,
+                result: TransactionResult::Skipped(SkippedTransaction {
+                    gas_used: inspector.total_gas_used,
+                }),
                 in_message,
             })
         }
@@ -490,10 +504,10 @@ fn execute_ordinary_transaction_impl(
     );
 
     Ok(ExecutedOrdinaryTransaction {
-        result: Some(ExecutedTransaction {
+        result: TransactionResult::Executed(ExecutedTransaction {
             transaction: output.transaction,
             out_msgs: output.transaction_meta.out_msgs,
-            gas_used: output.transaction_meta.gas_used,
+            gas_used: inspector.total_gas_used,
             next_lt: output.transaction_meta.next_lt,
             burned: output.burned,
         }),
@@ -507,7 +521,7 @@ fn execute_ticktock_transaction(
     min_lt: u64,
     config: &ParsedConfig,
     params: &ExecutorParams,
-) -> Result<Option<ExecutedTransaction>> {
+) -> Result<TransactionResult> {
     tracing::trace!(
         target: tracing_targets::EXEC_MANAGER,
         account_addr = %account_stuff.account_addr,
@@ -529,7 +543,11 @@ fn execute_ticktock_transaction(
 
     let output = match uncommited {
         Ok(uncommited) => uncommited.commit()?,
-        Err(TxError::Skipped) => return Ok(None),
+        Err(TxError::Skipped) => {
+            return Ok(TransactionResult::Skipped(SkippedTransaction {
+                gas_used: inspector.total_gas_used,
+            }))
+        }
         Err(TxError::Fatal(e)) => return Err(e),
     };
 
@@ -541,10 +559,10 @@ fn execute_ticktock_transaction(
         inspector.public_libs_diff,
     );
 
-    Ok(Some(ExecutedTransaction {
+    Ok(TransactionResult::Executed(ExecutedTransaction {
         transaction: output.transaction,
         out_msgs: output.transaction_meta.out_msgs,
-        gas_used: output.transaction_meta.gas_used,
+        gas_used: inspector.total_gas_used,
         next_lt: output.transaction_meta.next_lt,
         burned: output.burned,
     }))

--- a/collator/src/collator/messages_buffer.rs
+++ b/collator/src/collator/messages_buffer.rs
@@ -687,6 +687,10 @@ impl MessageGroup {
         self.slots_info.slots.len()
     }
 
+    pub fn accounts_count(&self) -> usize {
+        self.msgs.len()
+    }
+
     pub fn messages_count(&self) -> usize {
         self.slots_info.msgs_count()
     }

--- a/collator/src/collator/mod.rs
+++ b/collator/src/collator/mod.rs
@@ -1777,6 +1777,22 @@ impl CollatorStdImpl {
                 let force_import_anchor_by_used_wu =
                     wu_used_from_last_anchor > wu_used_to_import_next_anchor;
 
+                // report wu used related metrics
+                metrics::gauge!("tycho_collator_wu_used_from_last_anchor", &[(
+                    "type",
+                    "wu_one_anchor"
+                ),])
+                .set(wu_used_to_import_next_anchor as f64);
+                metrics::gauge!("tycho_collator_wu_used_from_last_anchor", &[(
+                    "type",
+                    "wu_used_sum"
+                ),])
+                .set(wu_used_from_last_anchor as f64);
+                let can_import_anchors_count =
+                    wu_used_from_last_anchor.saturating_div(wu_used_to_import_next_anchor);
+                metrics::gauge!("tycho_collator_can_import_anchors_count")
+                    .set(can_import_anchors_count as f64);
+
                 // decide if should import anchors
                 let (last_imported_anchor_id, last_imported_chain_time) = self
                     .anchors_cache

--- a/collator/src/collator/types.rs
+++ b/collator/src/collator/types.rs
@@ -1062,6 +1062,11 @@ pub struct ExecutedTransaction {
     pub burned: Tokens,
 }
 
+#[derive(Clone, Debug)]
+pub struct SkippedTransaction {
+    pub gas_used: u64,
+}
+
 pub struct ParsedMessage {
     pub info: MsgInfo,
     pub dst_in_current_shard: bool,

--- a/scripts/gen-dashboard.py
+++ b/scripts/gen-dashboard.py
@@ -460,6 +460,26 @@ def core_bc() -> RowPanel:
             "Out/In message ratio per block",
             quantile="0.999",
         ),
+        create_gauge_panel(
+            "tycho_shard_accounts_count",
+            "Number of accounts in state",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_accounts_per_block",
+            "Number of accounts per block",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_added_accounts_count",
+            "Number of added accounts in block",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_removed_accounts_count",
+            "Number of removed accounts in block",
+            labels=['workchain=~"$workchain"'],
+        ),
         create_heatmap_quantile_panel(
             "tycho_bc_out_msg_acc_ratio",
             "Out message/Account ratio per block",
@@ -1004,6 +1024,11 @@ def collator_finalize_block() -> RowPanel:
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
+            "tycho_collator_finalize_build_mc_state_extra_time_high",
+            "Build McStateExtra",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_heatmap_panel(
             "tycho_collator_finalize_build_accounts_and_msgs_time_high",
             "Build in parallel accounts, InMsgDescr, OutMsgDescr",
             labels=['workchain=~"$workchain"'],
@@ -1014,6 +1039,16 @@ def collator_finalize_block() -> RowPanel:
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
+            "tycho_collator_finalize_update_shard_accounts_time_high",
+            "incl. Update Shard Accounts",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_heatmap_panel(
+            "tycho_collator_finalize_build_accounts_blocks_time_high",
+            "incl. Build Accounts Blocks",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_heatmap_panel(
             "tycho_collator_finalize_build_in_msgs_time_high",
             "only Build InMsgDescr",
             labels=['workchain=~"$workchain"'],
@@ -1021,11 +1056,6 @@ def collator_finalize_block() -> RowPanel:
         create_heatmap_panel(
             "tycho_collator_finalize_build_out_msgs_time_high",
             "only Build OutMsgDescr",
-            labels=['workchain=~"$workchain"'],
-        ),
-        create_heatmap_panel(
-            "tycho_collator_finalize_build_mc_state_extra_time_high",
-            "Build McStateExtra",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
@@ -1722,13 +1752,23 @@ def collator_wu_metrics() -> RowPanel:
             unit_format=UNITS.NANO_SECONDS,
         ),
         create_gauge_panel(
-            "tycho_do_collate_wu_on_build_shard_accounts",
-            "Wu spent on build and update shard accounts",
+            "tycho_do_collate_wu_on_update_shard_accounts",
+            "Wu spent on update shard accounts",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_price_on_update_shard_accounts",
+            "Wu price on update shard accounts",
             labels=['workchain=~"$workchain"'],
         ),
         create_gauge_panel(
             "tycho_do_collate_wu_on_build_accounts_blocks",
             "Wu spent on build accounts blocks description",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_price_on_build_accounts_blocks",
+            "Wu price on build accounts blocks description",
             labels=['workchain=~"$workchain"'],
         ),
         create_gauge_panel(

--- a/scripts/gen-dashboard.py
+++ b/scripts/gen-dashboard.py
@@ -1004,13 +1004,13 @@ def collator_finalize_block() -> RowPanel:
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_finalize_build_account_blocks_and_msgs_time_high",
-            "Build in parallel account blocks, InMsgDescr, OutMsgDescr",
+            "tycho_collator_finalize_build_accounts_and_msgs_time_high",
+            "Build in parallel accounts, InMsgDescr, OutMsgDescr",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_finalize_build_account_blocks_time_high",
-            "only Build account blocks",
+            "tycho_collator_finalize_build_accounts_time_high",
+            "only Build accounts",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
@@ -1024,7 +1024,7 @@ def collator_finalize_block() -> RowPanel:
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
-            "tycho_collator_finish_build_mc_state_extra_time_high",
+            "tycho_collator_finalize_build_mc_state_extra_time_high",
             "Build McStateExtra",
             labels=['workchain=~"$workchain"'],
         ),
@@ -1038,6 +1038,11 @@ def collator_finalize_block() -> RowPanel:
             "inc. Create MerkleUpdate",
             labels=['workchain=~"$workchain"'],
         ),
+        create_heatmap_panel(
+            "tycho_collator_finalize_build_block_time_high",
+            "Build Block",
+            labels=['workchain=~"$workchain"'],
+        ),
         create_gauge_panel(
             "tycho_collator_boc_cache_rev_indices_capacity",
             "BOC Cache rev_indices capacity",
@@ -1046,11 +1051,6 @@ def collator_finalize_block() -> RowPanel:
         create_gauge_panel(
             "tycho_collator_boc_cache_rev_cells_capacity",
             "BOC Cache rev_cells capacity",
-            labels=['workchain=~"$workchain"'],
-        ),
-        create_heatmap_panel(
-            "tycho_collator_finalize_build_block_time_high",
-            "Build Block",
             labels=['workchain=~"$workchain"'],
         ),
     ]
@@ -1588,9 +1588,14 @@ def collator_wu_metrics() -> RowPanel:
         ),
         create_gauge_panel(
             "tycho_do_collate_wu_price_on_execute",
-            "Wu price on execute total",
+            "Wu price on execute",
             labels=['workchain=~"$workchain"'],
             unit_format=UNITS.NANO_SECONDS,
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_on_execute_txs",
+            "Wu spent on execute in vm",
+            labels=['workchain=~"$workchain"'],
         ),
         create_gauge_panel(
             "tycho_do_collate_wu_price_on_execute_txs",
@@ -1599,19 +1604,133 @@ def collator_wu_metrics() -> RowPanel:
             unit_format=UNITS.NANO_SECONDS,
         ),
         create_gauge_panel(
+            "tycho_do_collate_wu_on_process_txs",
+            "Wu spent on process executed txs",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
             "tycho_do_collate_wu_price_on_process_txs",
             "Wu price on process executed txs",
             labels=['workchain=~"$workchain"'],
             unit_format=UNITS.NANO_SECONDS,
         ),
         create_gauge_panel(
-            "tycho_do_collate_wu_on_finalize",
-            "Wu spent on finalize",
+            "tycho_do_collate_wu_on_create_queue_diff",
+            "Wu spent on create queue diff",
             labels=['workchain=~"$workchain"'],
         ),
         create_gauge_panel(
-            "tycho_do_collate_wu_price_on_finalize",
-            "Wu price on finalize",
+            "tycho_do_collate_wu_price_on_create_queue_diff",
+            "Wu price on create queue diff",
+            labels=['workchain=~"$workchain"'],
+            unit_format=UNITS.NANO_SECONDS,
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_on_apply_queue_diff",
+            "Wu spent on apply queue diff",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_price_on_apply_queue_diff",
+            "Wu price on apply queue diff",
+            labels=['workchain=~"$workchain"'],
+            unit_format=UNITS.NANO_SECONDS,
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_on_finalize_total",
+            "Wu spent on finalize (total)",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_price_on_finalize_total",
+            "Wu price on finalize (total)",
+            labels=['workchain=~"$workchain"'],
+            unit_format=UNITS.NANO_SECONDS,
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_on_finalize_block",
+            "Wu spent on finalize block",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_price_on_finalize_block",
+            "Wu price on finalize block",
+            labels=['workchain=~"$workchain"'],
+            unit_format=UNITS.NANO_SECONDS,
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_on_build_block",
+            "Wu spent on build block",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_price_on_build_block",
+            "Wu price on build block",
+            labels=['workchain=~"$workchain"'],
+            unit_format=UNITS.NANO_SECONDS,
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_on_build_state_update",
+            "Wu spent on build state update (Merkle)",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_price_on_build_state_update",
+            "Wu price on build state update (Merkle)",
+            labels=['workchain=~"$workchain"'],
+            unit_format=UNITS.NANO_SECONDS,
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_on_build_accounts_and_messages",
+            "Wu spent on build accounts and messages in parallel",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_price_on_build_accounts_and_messages",
+            "Wu price on build accounts and messages in parallel",
+            labels=['workchain=~"$workchain"'],
+            unit_format=UNITS.NANO_SECONDS,
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_on_build_in_msgs",
+            "Wu spent on build in messages description",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_price_on_build_in_msgs",
+            "Wu price on build in messages description",
+            labels=['workchain=~"$workchain"'],
+            unit_format=UNITS.NANO_SECONDS,
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_on_build_out_msgs",
+            "Wu spent on build out messages description",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_price_on_build_out_msgs",
+            "Wu price on build out messages description",
+            labels=['workchain=~"$workchain"'],
+            unit_format=UNITS.NANO_SECONDS,
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_on_build_shard_accounts",
+            "Wu spent on build and update shard accounts",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_on_build_accounts_blocks",
+            "Wu spent on build accounts blocks description",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_on_build_accounts",
+            "Wu spent on build accounts",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_gauge_panel(
+            "tycho_do_collate_wu_price_on_build_accounts",
+            "Wu price on build accounts",
             labels=['workchain=~"$workchain"'],
             unit_format=UNITS.NANO_SECONDS,
         ),
@@ -1758,12 +1877,17 @@ def collator_special_transactions_metrics() -> RowPanel:
     metrics = [
         create_heatmap_panel(
             "tycho_do_collate_execute_tick_time",
-            "Execute Tick special transactions",
+            "Execute Tick transactions",
             labels=['workchain=~"$workchain"'],
         ),
         create_heatmap_panel(
             "tycho_do_collate_execute_tock_time",
-            "Execute Tock special transactions",
+            "Execute Tock transactions",
+            labels=['workchain=~"$workchain"'],
+        ),
+        create_heatmap_panel(
+            "tycho_do_collate_execute_special_time",
+            "Execute Special transactions",
             labels=['workchain=~"$workchain"'],
         ),
     ]

--- a/scripts/gen-dashboard.py
+++ b/scripts/gen-dashboard.py
@@ -1176,18 +1176,26 @@ def collation_metrics() -> RowPanel:
             "Number of accounts per block",
             labels=['workchain=~"$workchain"'],
         ),
+        create_counter_panel(
+            "tycho_collator_anchor_import_cancelled_count",
+            "Number of anchor import cancelled",
+            labels_selectors=['workchain=~"$workchain"'],
+        ),
         create_gauge_panel(
             "tycho_collator_shard_blocks_count_btw_anchors",
             "Number of Shard Blocks before import next anchor",
         ),
         create_gauge_panel(
+            "tycho_collator_wu_used_from_last_anchor",
+            "Wu used from last anchor and wu used to import one anchor",
+        ),
+        create_gauge_panel(
+            "tycho_collator_can_import_anchors_count",
+            "Number of anchors that can be imported by wu used",
+        ),
+        create_gauge_panel(
             "tycho_collator_import_next_anchor_count",
             "Number of imported anchors per tick",
-        ),
-        create_counter_panel(
-            "tycho_collator_anchor_import_cancelled_count",
-            "Number of anchor import cancelled",
-            labels_selectors=['workchain=~"$workchain"'],
         ),
         create_counter_panel(
             "tycho_collator_anchor_import_skipped_count",


### PR DESCRIPTION
## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES
None
### BLOCKCHAIN CONFIGURATION MODEL CHANGES
None

---

### COMPATIBILITY

Affected features:
- State - special logic applied
- Collator. Work Units Calculation - special logic applied

Field `ShardStateUnsplit.underload_history` is used to track shard accounts count in state. After node update this field will be 0. In this case actual accounts count will be read from `ShardAccounts` dict only once. All next times it will be updated each block by added and removed accounts.

Compatibility was tested manually. Previous node version was deployed, then 20k accounts were deployed. After that nodes were updated to the latest version.
[metrics](https://grafana.broxus.com/d/cdlaji62a1b0gb1/tycho-node-metrics-high-times?orgId=1&from=2025-06-23T13:54:53.882Z&to=2025-06-23T14:24:50.879Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet2-validator1&var-instance=tycho-devnet2-validator10&var-instance=tycho-devnet2-validator11&var-instance=tycho-devnet2-validator12&var-instance=tycho-devnet2-validator13&var-instance=tycho-devnet2-validator14&var-instance=tycho-devnet2-validator15&var-instance=tycho-devnet2-validator16&var-instance=tycho-devnet2-validator17&var-instance=tycho-devnet2-validator18&var-instance=tycho-devnet2-validator19&var-instance=tycho-devnet2-validator9&var-instance=tycho-devnet2-validator8&var-instance=tycho-devnet2-validator7&var-instance=tycho-devnet2-validator6&var-instance=tycho-devnet2-validator5&var-instance=tycho-devnet2-validator3&var-instance=tycho-devnet2-validator2&var-instance=tycho-devnet2-validator4&var-workchain=0&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)
![image](https://github.com/user-attachments/assets/12363c86-049f-4837-b165-b6a566ce1094)

### SPECIAL DEPLOYMENT ACTIONS
Required

Updated nodes will produce mismatched blocks due to the filling of the `ShardStateUnsplit.underload_history` field and changed wu calculation formula. So it needs to update 2/3+1 nodes (by stake) to make the network go forward.

Then needs to set up blockchain config param 28 after update
```
{
    "shuffle_mc_validators": true,
    "mc_block_min_interval_ms": 2500,
    "empty_sc_block_interval_ms": 60000,
    "max_uncommitted_chain_length": 31,
    "wu_used_to_import_next_anchor": 1200000000,
    "msgs_exec_params": {
      "buffer_limit": 10000,
      "group_limit": 100,
      "group_vert_size": 10,
      "externals_expire_timeout": 58,
      "open_ranges_limit": 20,
      "par_0_int_msgs_count_limit": 10000000,
      "par_0_ext_msgs_count_limit": 10000000,
      "group_slots_fractions": {
        "0": 80,
        "1": 10
      },
      "range_messages_limit": 10000
    },
    "work_units_params": {
      "prepare": {
        "fixed_part": 1000000,
        "msgs_stats": 0,
        "remaning_msgs_stats": 0,
        "read_ext_msgs": 500,
        "read_int_msgs": 3000,
        "read_new_msgs": 1000,
        "add_to_msg_groups": 150
      },
      "execute": {
        "prepare": 57000,
        "execute": 10000,
        "execute_err": 0,
        "execute_delimiter": 1000,
        "serialize_enqueue": 80,
        "serialize_dequeue": 80,
        "insert_new_msgs": 80,
        "subgroup_size": 16
      },
      "finalize": {
        "build_transactions": 200,
        "build_accounts": 1500,
        "build_in_msg": 150,
        "build_out_msg": 150,
        "serialize_min": 2500000,
        "serialize_accounts": 3000,
        "serialize_msg": 3000,
        "state_update_min": 1000000,
        "state_update_accounts": 4000,
        "state_update_msg": 0,
        "create_diff": 1000,
        "serialize_diff": 0,
        "apply_diff": 2000,
        "diff_tail_len": 0
      }
    }
  }
```

---

### PERFORMANCE IMPACT
Expected impact

More stable results on the growing shard state. But still needs to tune the State update wu calculation formula. It will be done in a separate task - needs to add one more power coefficient.

---

### TESTS

#### Unit Tests
No coverage

#### Network Tests
No coverage

#### Manual Tests

1. 20k transfers
2. then 1700 swaps
3. then deploy 1kk accounts
4. then destroyable-1k.sh
5. then 10k transfers
6. then 20k transfers
7. then 1500 swaps
8. then deploy 10kk accounts

[metrics](https://grafana.broxus.com/d/cdlaji62a1b0gb1/tycho-node-metrics-high-times?orgId=1&from=2025-06-24T09:14:53.314Z&to=2025-06-24T10:30:38.488Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet2-validator1&var-instance=tycho-devnet2-validator10&var-instance=tycho-devnet2-validator11&var-instance=tycho-devnet2-validator12&var-instance=tycho-devnet2-validator13&var-instance=tycho-devnet2-validator14&var-instance=tycho-devnet2-validator15&var-instance=tycho-devnet2-validator16&var-instance=tycho-devnet2-validator17&var-instance=tycho-devnet2-validator18&var-instance=tycho-devnet2-validator19&var-instance=tycho-devnet2-validator9&var-instance=tycho-devnet2-validator8&var-instance=tycho-devnet2-validator7&var-instance=tycho-devnet2-validator6&var-instance=tycho-devnet2-validator5&var-instance=tycho-devnet2-validator3&var-instance=tycho-devnet2-validator2&var-instance=tycho-devnet2-validator4&var-workchain=0&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)

![image](https://github.com/user-attachments/assets/f67c926d-f73e-4cde-9859-3d590dfc54b3)
![image](https://github.com/user-attachments/assets/b4dee504-7117-4975-a941-5cc4ea7c914d)
![image](https://github.com/user-attachments/assets/2f0e32b2-34b5-4021-b331-b5fb26b697e2)
![image](https://github.com/user-attachments/assets/936dd2de-e292-4019-b463-615c71f517af)
![image](https://github.com/user-attachments/assets/dfd65394-f101-4119-9d45-ba08f8991b94)
![image](https://github.com/user-attachments/assets/3ea67022-723f-426f-a8bb-d6d7e36f0503)

Comparation with master. New wu formula and params on the left, master on the right.
[metrics](https://grafana.broxus.com/d/cdlaji62a1b0gb1/tycho-node-metrics-high-times?orgId=1&from=2025-06-24T09:15:00.000Z&to=2025-06-24T12:00:00.000Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet2-validator1&var-instance=tycho-devnet2-validator10&var-instance=tycho-devnet2-validator11&var-instance=tycho-devnet2-validator12&var-instance=tycho-devnet2-validator13&var-instance=tycho-devnet2-validator14&var-instance=tycho-devnet2-validator15&var-instance=tycho-devnet2-validator16&var-instance=tycho-devnet2-validator17&var-instance=tycho-devnet2-validator18&var-instance=tycho-devnet2-validator19&var-instance=tycho-devnet2-validator9&var-instance=tycho-devnet2-validator8&var-instance=tycho-devnet2-validator7&var-instance=tycho-devnet2-validator6&var-instance=tycho-devnet2-validator5&var-instance=tycho-devnet2-validator3&var-instance=tycho-devnet2-validator2&var-instance=tycho-devnet2-validator4&var-workchain=0&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)

![image](https://github.com/user-attachments/assets/b9b8c35f-89b4-40aa-992e-e67602ad34c5)
![image](https://github.com/user-attachments/assets/b31bd5ab-6dbd-4bf7-ac87-749e7c8c1238)
![image](https://github.com/user-attachments/assets/ea560bdb-a607-467b-b301-a06b1745ead2)
![image](https://github.com/user-attachments/assets/46a2f727-84f8-424d-a8e3-0abaef41ed45)
![image](https://github.com/user-attachments/assets/0e07bfa5-758d-41a7-bd12-d7fc44f4920a)