### PR TITLE
fix(collator): put router to diff in state

### DIFF
--- a/block-util/src/queue/queue_diff.rs
+++ b/block-util/src/queue/queue_diff.rs
@@ -10,6 +10,7 @@ use tl_proto::TlRead;
 
 use crate::archive::WithArchiveData;
 use crate::queue::proto::{QueueDiff, QueueKey};
+use crate::queue::RouterPartitions;
 
 pub type QueueDiffStuffAug = WithArchiveData<QueueDiffStuff>;
 
@@ -30,6 +31,17 @@ impl QueueDiffStuffBuilder {
 
     pub fn with_processed_to(mut self, processed_to: BTreeMap<ShardIdent, QueueKey>) -> Self {
         self.inner_mut().diff.processed_to = processed_to;
+        self
+    }
+
+    pub fn with_router(
+        mut self,
+        src_router: RouterPartitions,
+        dsc_router: RouterPartitions,
+    ) -> Self {
+        let inner = self.inner_mut();
+        inner.diff.router_partitions_src = src_router;
+        inner.diff.router_partitions_dst = dsc_router;
         self
     }
 

--- a/collator/src/collator/do_collate/finalize.rs
+++ b/collator/src/collator/do_collate/finalize.rs
@@ -203,6 +203,14 @@ impl Phase<FinalizeState> {
             &max_message,
             queue_diff_with_msgs.messages.keys().map(|k| &k.hash),
         )
+        .with_router(
+            queue_diff_with_msgs
+                .partition_router
+                .to_router_partitions_src(),
+            queue_diff_with_msgs
+                .partition_router
+                .to_router_partitions_dst(),
+        )
         .serialize();
 
         self.extra.finalize_metrics.create_queue_diff_elapsed =

--- a/collator/src/collator/tests/messages_reader_tests.rs
+++ b/collator/src/collator/tests/messages_reader_tests.rs
@@ -1045,6 +1045,14 @@ impl<V: InternalMessageValue> TestCollator<V> {
                     &max_message,
                     queue_diff_with_msgs.messages.keys().map(|k| &k.hash),
                 )
+                .with_router(
+                    queue_diff_with_msgs
+                        .partition_router
+                        .to_router_partitions_src(),
+                    queue_diff_with_msgs
+                        .partition_router
+                        .to_router_partitions_dst(),
+                )
                 .serialize();
         let queue_diff_hash = *queue_diff.hash();
 

--- a/collator/src/manager/tests/manager_tests.rs
+++ b/collator/src/manager/tests/manager_tests.rs
@@ -2411,6 +2411,14 @@ impl TestStateNodeAdapter {
                 &max_message,
                 queue_diff_with_msgs.messages.keys().map(|k| &k.hash),
             )
+            .with_router(
+                queue_diff_with_msgs
+                    .partition_router
+                    .to_router_partitions_src(),
+                queue_diff_with_msgs
+                    .partition_router
+                    .to_router_partitions_dst(),
+            )
             .serialize();
         let queue_diff_hash = *queue_diff_serialized.hash();
 


### PR DESCRIPTION
## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

[None]

<!--Describe changes, default values, and rationale.-->
<!--!!! Confirm that the new node version starts correctly with old configuration.-->

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

[None]

<!--Describe changes, default values, and rationale.-->
<!--!!! Confirm that the new node version starts correctly with blockchain state.-->

---

### COMPATIBILITY

<!--Is the new version compatible with the previous state of the node and blockchain? Specify which compatibility-sensitive features were modified. Possible list below. If a feature is not affected, do not list it.-->

Affected features:

- [Queue.Diff] - fully compatible

<!--
For each affected feature specify:
  - Compatibility status: [fully compatible] / [special logic applied] / [incompatible]
  - If not compatible, provide migration instructions
  - If compatibility ensured, describe how. Describe how compatibility was tested.
-->

### SPECIAL DEPLOYMENT ACTIONS

[Required]

Nodes must be updated simultaneously without load (internal queue len should be lower than `par_0_int_msgs_count_limit` param), otherwise new nodes may release a block with a different signature because `queue_diff` will contain additional information when partition 1 is using

<!--
If required:
  - Described safe update steps and timing
  - Described required configuration changes
  - State if nodes will generate invalid blocks until 2/3+1 updated
  - Provided tested update scripts (if applicable)
-->

---

### PERFORMANCE IMPACT

[No impact expected]

<!--
If impact expected:
  - Described expected changes and rationale
  - Describe new added metrics (if any)
  - Attached comparative devnet test results (screenshots, Grafana links)
  - Link separate optimization task (if applicable)
-->

---

### TESTS

#### Unit Tests

[No coverage]

`persistent_queue_state_read_write`

#### Network Tests

1-255
<!--List unit tests that cover changes (if exits). Link tasks to create additional tests (if needed).-->

#### Manual Tests

Test 1-255 with start node 4 with delay

<!--List other tests if used.-->

<!--If a new test was used, describe how to run it.-->
<!--Provide Grafana links to tests runs on devnet. Attach screenshots to highlight notable changes.-->

---

**Notes/Additional Comments:**  
<!-- Add any additional information or context for reviewers here. -->
