### PR TITLE
feat(network): use `Bbr` as the default congestion control algorithm

### DIFF
--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -5,9 +5,10 @@ pub use dht::{
     xor_distance,
 };
 pub use network::{
-    BindError, Connection, ConnectionError, KnownPeerHandle, KnownPeers, KnownPeersError, Network,
-    NetworkBuilder, NetworkConfig, Peer, PeerBannedError, QuicConfig, RecvStream, SendStream,
-    ToSocket, WeakKnownPeerHandle, WeakNetwork,
+    BindError, CongestionAlgorithm, Connection, ConnectionError, ConnectionMetricsLevel,
+    KnownPeerHandle, KnownPeers, KnownPeersError, Network, NetworkBuilder, NetworkConfig, Peer,
+    PeerBannedError, QuicConfig, RecvStream, SendStream, ToSocket, WeakKnownPeerHandle,
+    WeakNetwork,
 };
 pub use quinn;
 pub use types::{

--- a/network/src/network/config.rs
+++ b/network/src/network/config.rs
@@ -163,8 +163,8 @@ pub struct QuicConfig {
     /// Default: auto.
     pub initial_mtu: Option<u16>,
 
-    /// Default: auto.
-    pub congestion_algorithm: Option<CongestionAlgorithm>,
+    /// Default: `Bbr`.
+    pub congestion_algorithm: CongestionAlgorithm,
 }
 
 impl Default for QuicConfig {
@@ -181,7 +181,7 @@ impl Default for QuicConfig {
             socket_recv_buffer_size: None,
             use_pmtu: true,
             initial_mtu: None,
-            congestion_algorithm: None,
+            congestion_algorithm: CongestionAlgorithm::Bbr,
         }
     }
 }
@@ -219,9 +219,7 @@ impl QuicConfig {
             config.initial_mtu(mtu);
         }
 
-        if let Some(algorithm) = self.congestion_algorithm {
-            config.congestion_controller_factory(algorithm.build());
-        }
+        config.congestion_controller_factory(self.congestion_algorithm.build());
 
         config
     }

--- a/network/src/network/mod.rs
+++ b/network/src/network/mod.rs
@@ -8,7 +8,7 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 use tycho_crypto::ed25519;
 
 use self::config::EndpointConfig;
-pub use self::config::{NetworkConfig, QuicConfig};
+pub use self::config::{CongestionAlgorithm, ConnectionMetricsLevel, NetworkConfig, QuicConfig};
 pub use self::connection::{Connection, RecvStream, SendStream};
 use self::connection_manager::{ActivePeers, ConnectionManager, ConnectionManagerRequest};
 pub use self::connection_manager::{


### PR DESCRIPTION
Despite `Bbr` being experimental it behaves better than the default `Cubic`. We mostly use good 1gbit links for our networks and these are exactly the conditions for which `Bbr` is designed. 

Btw, even in the office network this algorithm behaves better than the default.

## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

None

<!--Describe changes, default values, and rationale.-->
<!--!!! Confirm that the new node version starts correctly with old configuration.-->

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

None

<!--Describe changes, default values, and rationale.-->
<!--!!! Confirm that the new node version starts correctly with blockchain state.-->

---

### COMPATIBILITY

Fully compatible

### SPECIAL DEPLOYMENT ACTIONS

Not Required

---

### PERFORMANCE IMPACT

Expected impact: network will utilize channel resources better (at least for mempool).

---

### TESTS

#### Manual Tests

Mostly mempool related when running too many nodes on too little servers. With `Bbr` algorithm they no longer fall out of sync.

<img width="1146" height="292" alt="image" src="https://github.com/user-attachments/assets/f26e0a57-759e-4a5b-a22c-19fe1da00ad2" />

<img width="1136" height="289" alt="image" src="https://github.com/user-attachments/assets/9368c7cf-184e-4b37-9dcb-48ac0076d726" />

