### PR TITLE
feat: use panic=abort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,10 @@ proc-macro2 = "1.0"
 prost = "0.14.1"
 prost-build = "0.14.1"
 quick_cache = "0.6.0"
-quinn = { version = "0.11.8", default-features = false, features = ["runtime-tokio", "rustls"] }
+quinn = { version = "0.11.8", default-features = false, features = [
+    "runtime-tokio",
+    "rustls",
+] }
 quote = "1.0"
 rand = "0.9"
 rand_pcg = { version = "0.9" }
@@ -111,7 +114,9 @@ tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"] }
 tl-proto = "0.5.1"
 tokio = { version = "1", default-features = false }
 tokio-stream = "0.1.15"
-tokio-util = { version = "0.7.10", default-features = false, features = ["codec"] }
+tokio-util = { version = "0.7.10", default-features = false, features = [
+    "codec",
+] }
 tower = "0.5"
 tower-http = "0.6"
 tracing = "0.1"
@@ -226,11 +231,13 @@ zero_sized_map_values = "warn"
 lto = "thin"
 codegen-units = 1
 debug = true
+panic = "abort"
 
 [profile.release_check]
 inherits = "release"
 debug-assertions = true
 overflow-checks = true
+panic = "abort"
 
 [profile.dev.package.hex]
 opt-level = 3


### PR DESCRIPTION
It will allow us to capture core-dumps in case if something is totally fucked up (eg panic in tokio). It doesn't change any semantics - we haven't relied on panic unwinds anywhere. Code size reduces from 38 to 34 mb - can affect some inlining decisions.

Also it works even without flush, so maybe it's a bad example.


```rs
use std::panic;

fn main() {
    tracing_subscriber::fmt::init();

    std::panic::set_hook(Box::new(|info| {
        use std::io::Write;
        let backtrace = std::backtrace::Backtrace::capture();

        tracing::error!("{info}\n{backtrace}");
        std::io::stderr().flush().ok();
        std::io::stdout().flush().ok();
    }));

    tracing::info!("Starting app");
    panic!("Oh no!");
}
```

```toml
[package]
name = "rkfk3"
version = "0.1.0"
edition = "2024"

[dependencies]
tracing = "0.1.41"
tracing-subscriber = "0.3.19"

[profile.release]
panic = "abort"
```

without abort:
```
2025-07-16T12:16:32.334717Z  INFO rkfk3: Starting app
2025-07-16T12:16:32.334726Z ERROR rkfk3: panicked at src/main.rs:19:5:
Oh no!
disabled backtrace
```

with abort:
```
2025-07-16T12:16:47.235329Z  INFO rkfk3: Starting app
2025-07-16T12:16:47.235339Z ERROR rkfk3: panicked at src/main.rs:19:5:
Oh no!
disabled backtrace
fish: Job 1, 'cargo run -r' terminated by signal SIGABRT (Abort)
```

Need to perf test, but don't expect any differences.
