### PR TITLE
fix(consensus): preserve `NotFound` statuses when fixing history

### DIFF
--- a/consensus/src/models/point_status.rs
+++ b/consensus/src/models/point_status.rs
@@ -325,7 +325,7 @@ impl PointStatusStored {
         }
     }
     pub fn decode(stored: &[u8]) -> anyhow::Result<Self> {
-        let Some(flags) = StatusFlags::try_from_stored(stored).map_err(anyhow::Error::msg)? else {
+        let Some(flags) = StatusFlags::try_from_stored(stored)? else {
             return Ok(Self::Exists);
         };
         let resolved = if flags.contains(StatusFlags::Found) {

--- a/consensus/src/storage/status_flags.rs
+++ b/consensus/src/storage/status_flags.rs
@@ -32,7 +32,7 @@ impl StatusFlags {
     pub const ILL_FORMED_BYTES: usize = 1;
     pub const NOT_FOUND_BYTES: usize = 1 + 32;
 
-    pub fn try_from_stored(value: &[u8]) -> Result<Option<Self>, String> {
+    pub fn try_from_stored(value: &[u8]) -> anyhow::Result<Option<Self>> {
         if value.is_empty() {
             return Ok(None);
         }
@@ -45,13 +45,8 @@ impl StatusFlags {
         } else {
             len == Self::VALIDATED_BYTES
         };
-        if is_ok {
-            Ok(Some(flags))
-        } else {
-            Err(format!(
-                "unexpected {len} bytes for stored status: {flags:?}",
-            ))
-        }
+        anyhow::ensure!(is_ok, "unexpected {len} bytes for stored status: {flags:?}");
+        Ok(Some(flags))
     }
 }
 

--- a/simulator/src/commands/prepare.rs
+++ b/simulator/src/commands/prepare.rs
@@ -211,6 +211,8 @@ impl Node {
 
         let output = Command::new("cargo")
             .arg("run")
+            .arg("--package")
+            .arg("tycho-network")
             .arg("--example")
             .arg("network-node")
             .arg("--")


### PR DESCRIPTION
Fixes panic at mempool restart, when it tried to load point info that was not stored. Because empty status value represents stored but not yet validated point.

Also a little fix in `simulator` does not deserve a separate MR.

## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

None

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

None

---

### COMPATIBILITY

Full

### SPECIAL DEPLOYMENT ACTIONS

Not Required

---

### PERFORMANCE IMPACT

No impact expected

---

### TESTS

#### Unit Tests

No coverage

#### Network Tests

No coverage

#### Manual Tests

a node successfully recovered during long `transfers20k`