### PR TITLE
fix(consensus): drop unresolved dag points with their rounds

### DIFF
--- a/network/src/dht/query.rs
+++ b/network/src/dht/query.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use futures_util::stream::FuturesUnordered;
 use futures_util::{Future, StreamExt};
 use tokio::sync::Semaphore;
-use tycho_util::futures::{JoinTask, Shared, WeakShared};
+use tycho_util::futures::{JoinTask, Shared, WeakSharedHandle};
 use tycho_util::sync::{rayon_run, yield_on_complex};
 use tycho_util::time::now_sec;
 use tycho_util::{FastDashMap, FastHashMap, FastHashSet};
@@ -107,7 +107,7 @@ impl<R> Default for QueryCache<R> {
     }
 }
 
-type WeakSpawnedFut<T> = WeakShared<JoinTask<T>>;
+type WeakSpawnedFut<T> = WeakSharedHandle<JoinTask<T>>;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum DhtQueryMode {

--- a/util/src/futures/shared.rs
+++ b/util/src/futures/shared.rs
@@ -42,10 +42,18 @@ impl<Fut: Future> Shared<Fut> {
         }
     }
 
-    pub fn downgrade(&self) -> Option<WeakShared<Fut>> {
+    pub fn weak_future(&self) -> Option<WeakShared<Fut>> {
+        self.inner.as_ref().map(|inner| WeakShared {
+            inner: Some(Arc::downgrade(inner)),
+            permit_fut: None,
+            permit: None,
+        })
+    }
+
+    pub fn downgrade(&self) -> Option<WeakSharedHandle<Fut>> {
         self.inner
             .as_ref()
-            .map(|inner| WeakShared(Arc::downgrade(inner)))
+            .map(|inner| WeakSharedHandle(Arc::downgrade(inner)))
     }
 
     /// Drops the future, returning whether it was the last instance.
@@ -57,6 +65,127 @@ impl<Fut: Future> Shared<Fut> {
     }
 }
 
+fn poll_impl<'cx, Fut>(
+    this_inner: &mut Option<Arc<Inner<Fut>>>,
+    this_permit_fut: &mut Option<SyncBoxFuture<Result<OwnedSemaphorePermit, AcquireError>>>,
+    this_permit: &mut Option<OwnedSemaphorePermit>,
+    cx: &mut Context<'cx>,
+) -> Poll<(Fut::Output, bool)>
+where
+    Fut: Future,
+    Fut::Output: Clone,
+{
+    let inner = this_inner
+        .take()
+        .expect("Shared future polled again after completion");
+
+    // Fast path for when the wrapped future has already completed
+    if inner.state.load(Ordering::Acquire) == COMPLETE {
+        // Safety: We're in the COMPLETE state
+        return unsafe { Poll::Ready(inner.take_or_clone_output()) };
+    }
+
+    if this_permit.is_none() {
+        *this_permit = Some('permit: {
+            // Poll semaphore future
+            let permit_fut = if let Some(fut) = this_permit_fut.as_mut() {
+                fut
+            } else {
+                // Avoid allocations completely if we can grab a permit immediately
+                match Arc::clone(&inner.semaphore).try_acquire_owned() {
+                    Ok(permit) => break 'permit permit,
+                    Err(TryAcquireError::NoPermits) => {}
+                    // NOTE: We don't expect the semaphore to be closed
+                    Err(TryAcquireError::Closed) => unreachable!(),
+                }
+
+                let next_fut = Arc::clone(&inner.semaphore).acquire_owned();
+                this_permit_fut.get_or_insert(Box::pin(next_fut))
+            };
+
+            // Acquire a permit to poll the inner future
+            match permit_fut.as_mut().poll(cx) {
+                Poll::Pending => {
+                    *this_inner = Some(inner);
+                    return Poll::Pending;
+                }
+                Poll::Ready(Ok(permit)) => {
+                    // Reset the permit future as we don't need it anymore
+                    *this_permit_fut = None;
+                    permit
+                }
+                // NOTE: We don't expect the semaphore to be closed
+                Poll::Ready(Err(_e)) => unreachable!(),
+            }
+        });
+    }
+
+    assert!(this_permit_fut.is_none(), "permit already acquired");
+
+    match inner.state.load(Ordering::Acquire) {
+        COMPLETE => {
+            // SAFETY: We're in the COMPLETE state
+            return unsafe { Poll::Ready(inner.take_or_clone_output()) };
+        }
+        POISONED => panic!("inner future panicked during poll"),
+        _ => {}
+    }
+
+    // Create poison guard
+    struct Reset<'a> {
+        state: &'a AtomicUsize,
+        did_not_panic: bool,
+    }
+
+    impl Drop for Reset<'_> {
+        fn drop(&mut self) {
+            if !self.did_not_panic {
+                self.state.store(POISONED, Ordering::Release);
+            }
+        }
+    }
+
+    let mut reset = Reset {
+        state: &inner.state,
+        did_not_panic: false,
+    };
+
+    let output = {
+        // SAFETY: We are now a sole owner of the permit to poll the inner future
+        let future = unsafe {
+            match &mut *inner.future_or_output.get() {
+                FutureOrOutput::Future(fut) => Pin::new_unchecked(fut),
+                FutureOrOutput::Output(_) => unreachable!(),
+            }
+        };
+
+        let poll_result = future.poll(cx);
+        reset.did_not_panic = true;
+
+        match poll_result {
+            Poll::Pending => {
+                drop(reset); // Make borrow checker happy
+                *this_inner = Some(inner);
+                return Poll::Pending;
+            }
+            Poll::Ready(output) => output,
+        }
+    };
+
+    unsafe {
+        *inner.future_or_output.get() = FutureOrOutput::Output(output);
+    }
+
+    inner.state.store(COMPLETE, Ordering::Release);
+
+    drop(reset); // Make borrow checker happy
+
+    // permit gets dropped because this future is consumed in exchange for result
+
+    // SAFETY: We're in the COMPLETE state
+    unsafe { Poll::Ready(inner.take_or_clone_output()) }
+}
+
 impl<Fut> Future for Shared<Fut>
 where
     Fut: Future,
@@ -65,125 +194,63 @@ where
     type Output = (Fut::Output, bool);
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = &mut *self;
+        let Shared {
+            inner,
+            permit_fut,
+            permit,
+        } = &mut *self;
 
-        let inner = this
-            .inner
-            .take()
-            .expect("Shared future polled again after completion");
-
-        // Fast path for when the wrapped future has already completed
-        if inner.state.load(Ordering::Acquire) == COMPLETE {
-            // Safety: We're in the COMPLETE state
-            return unsafe { Poll::Ready(inner.take_or_clone_output()) };
-        }
-
-        if this.permit.is_none() {
-            this.permit = Some('permit: {
-                // Poll semaphore future
-                let permit_fut = if let Some(fut) = this.permit_fut.as_mut() {
-                    fut
-                } else {
-                    // Avoid allocations completely if we can grab a permit immediately
-                    match Arc::clone(&inner.semaphore).try_acquire_owned() {
-                        Ok(permit) => break 'permit permit,
-                        Err(TryAcquireError::NoPermits) => {}
-                        // NOTE: We don't expect the semaphore to be closed
-                        Err(TryAcquireError::Closed) => unreachable!(),
-                    }
-
-                    let next_fut = Arc::clone(&inner.semaphore).acquire_owned();
-                    this.permit_fut.get_or_insert(Box::pin(next_fut))
-                };
-
-                // Acquire a permit to poll the inner future
-                match Pin::new(permit_fut).poll(cx) {
-                    Poll::Pending => {
-                        this.inner = Some(inner);
-                        return Poll::Pending;
-                    }
-                    Poll::Ready(Ok(permit)) => {
-                        // Reset the permit future as we don't need it anymore
-                        this.permit_fut = None;
-                        permit
-                    }
-                    // NOTE: We don't expect the semaphore to be closed
-                    Poll::Ready(Err(_e)) => unreachable!(),
-                }
-            });
-        }
-
-        match inner.state.load(Ordering::Acquire) {
-            COMPLETE => {
-                // SAFETY: We're in the COMPLETE state
-                return unsafe { Poll::Ready(inner.take_or_clone_output()) };
-            }
-            POISONED => panic!("inner future panicked during poll"),
-            _ => {}
-        }
-
-        // Create poison guard
-        struct Reset<'a> {
-            state: &'a AtomicUsize,
-            did_not_panic: bool,
-        }
-
-        impl Drop for Reset<'_> {
-            fn drop(&mut self) {
-                if !self.did_not_panic {
-                    self.state.store(POISONED, Ordering::Release);
-                }
-            }
-        }
-
-        let mut reset = Reset {
-            state: &inner.state,
-            did_not_panic: false,
-        };
-
-        let output = {
-            // SAFETY: We are now a sole owner of the permit to poll the inner future
-            let future = unsafe {
-                match &mut *inner.future_or_output.get() {
-                    FutureOrOutput::Future(fut) => Pin::new_unchecked(fut),
-                    FutureOrOutput::Output(_) => unreachable!(),
-                }
-            };
-
-            let poll_result = future.poll(cx);
-            reset.did_not_panic = true;
-
-            match poll_result {
-                Poll::Pending => {
-                    drop(reset); // Make borrow checker happy
-                    this.inner = Some(inner);
-                    return Poll::Pending;
-                }
-                Poll::Ready(output) => output,
-            }
-        };
-
-        unsafe {
-            *inner.future_or_output.get() = FutureOrOutput::Output(output);
-        }
-
-        inner.state.store(COMPLETE, Ordering::Release);
-
-        drop(reset); // Make borrow checker happy
-
-        // Reset permits
-        self.permit_fut = None;
-        self.permit = None;
-
-        // SAFETY: We're in the COMPLETE state
-        unsafe { Poll::Ready(inner.take_or_clone_output()) }
+        poll_impl(inner, permit_fut, permit, cx)
     }
 }
 
-#[repr(transparent)]
-pub struct WeakShared<Fut: Future>(Weak<Inner<Fut>>);
+/// A future that preserves its place in wait queue but does not own a shared future.
+/// Use [`WeakSharedHandle`] if you want to poll an upgraded future and only pass a weak ref around.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct WeakShared<Fut: Future> {
+    inner: Option<Weak<Inner<Fut>>>,
+    permit_fut: Option<SyncBoxFuture<Result<OwnedSemaphorePermit, AcquireError>>>,
+    permit: Option<OwnedSemaphorePermit>,
+}
 
-impl<Fut: Future> WeakShared<Fut> {
+impl<Fut> Future for WeakShared<Fut>
+where
+    Fut: Future,
+    Fut::Output: Clone,
+{
+    type Output = Option<(Fut::Output, bool)>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let WeakShared {
+            inner,
+            permit_fut,
+            permit,
+        } = &mut *self;
+
+        let weak_inner = inner
+            .take()
+            .expect("Weak shared future polled again after completion");
+
+        let mut strong_inner = weak_inner.upgrade();
+
+        if strong_inner.is_none() {
+            return Poll::Ready(None);
+        };
+
+        let poll_result = poll_impl(&mut strong_inner, permit_fut, permit, cx);
+
+        *inner = strong_inner.is_some().then_some(weak_inner);
+
+        poll_result.map(Some)
+    }
+}
+
+/// A handle can be upgraded to a shared future, but cannot be directly awaited.
+/// Use [`WeakShared`] if you want to poll without an upgrade.
+#[repr(transparent)]
+pub struct WeakSharedHandle<Fut: Future>(Weak<Inner<Fut>>);
+
+impl<Fut: Future> WeakSharedHandle<Fut> {
     pub fn upgrade(&self) -> Option<Shared<Fut>> {
         self.0.upgrade().map(|inner| Shared {
             inner: Some(inner),

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -20,7 +20,7 @@ pub mod tl;
 pub mod futures {
     pub use self::box_future_or_noop::BoxFutureOrNoop;
     pub use self::join_task::JoinTask;
-    pub use self::shared::{Shared, WeakShared};
+    pub use self::shared::{Shared, WeakShared, WeakSharedHandle};
 
     mod box_future_or_noop;
     mod join_task;


### PR DESCRIPTION
Point validation now uses weak references to its dependency points, while the single guaranteed strong ref is held by DagRound. So drop of DagRound will lead to drop of points as it is intended.

## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

None

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

None
---

### COMPATIBILITY

Full

### SPECIAL DEPLOYMENT ACTIONS

Not Required

---

### PERFORMANCE IMPACT

No impact expected in general. 
Nodes that fail to sync several times in a row may accomplish it faster. 

---

### TESTS

No coverage

#### Network Tests

No specific coverage, but every network test with mempool uses this change.

#### Manual Tests

transfers-30k for 7 hours, simulator