### PR TITLE
feat(cli): add `--cold-boot` flag to cli to allow changing cold boot …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3989,6 +3989,7 @@ dependencies = [
  "bytesize",
  "cassadilia",
  "castaway",
+ "clap",
  "crc32c",
  "dashmap",
  "futures-util",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,13 +1,7 @@
 [package]
 name = "tycho-cli"
 description = "Node CLI."
-include = [
-    "src/**/*.rs",
-    "res/**/*.boc",
-    "./LICENSE-*",
-    "./README.md",
-    "build.rs",
-]
+include = ["src/**/*.rs", "res/**/*.boc", "./LICENSE-*", "./README.md", "build.rs"]
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
@@ -60,7 +54,7 @@ weedb = { workspace = true }
 tycho-block-util = { workspace = true }
 tycho-collator = { workspace = true }
 tycho-control = { workspace = true, features = ["full"] }
-tycho-core = { workspace = true }
+tycho-core = { workspace = true, features = ["cli"] }
 tycho-network = { workspace = true }
 tycho-rpc = { workspace = true, features = ["http2"] }
 tycho-storage = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,8 +35,9 @@ bumpalo = { workspace = true }
 bumpalo-herd = { workspace = true }
 bytes = { workspace = true, features = ["serde"] }
 bytesize = { workspace = true }
-castaway = { workspace = true }
 cassadilia = { workspace = true }
+castaway = { workspace = true }
+clap = { workspace = true, optional = true }
 crc32c = { workspace = true }
 dashmap = { workspace = true }
 futures-util = { workspace = true }
@@ -80,6 +81,7 @@ similar-asserts = { workspace = true }
 
 [features]
 test = []
+cli = ["dep:clap", "clap/derive"]
 
 [lints]
 workspace = true

--- a/core/src/block_strider/starter/mod.rs
+++ b/core/src/block_strider/starter/mod.rs
@@ -160,6 +160,8 @@ impl Starter {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum ColdBootType {
     Genesis,
     LatestPersistent,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -188,6 +188,10 @@ Run a Tycho node
 * `--logger-config <LOGGER_CONFIG>` — Path to the logger config
 * `--import-zerostate <IMPORT_ZEROSTATE>` — List of zerostate files to import
 * `--wu-tuner-config <WU_TUNER_CONFIG>` — Path to the work units tuner config
+* `--cold-boot <COLD_BOOT>` — Overwrite cold boot type. Default: `latest-persistent`
+
+  Possible values: `genesis`, `latest-persistent`
+
 
 
 


### PR DESCRIPTION
- Fixes initial node state when `ColdBootType::Genesis` mode was used;
- Adds a new flag to the node cli to overwrite the default cold boot type (can be used for testing).