### PR TITLE
fix: don't start `CommitArchiveTask` if archive already exists

### DIFF
--- a/core/src/storage/block/blobs/types.rs
+++ b/core/src/storage/block/blobs/types.rs
@@ -29,17 +29,8 @@ pub struct BlockGcStats {
 pub struct OpenStats {
     pub orphaned_flags_count: u32,
     pub restored_flags_count: u32,
-    pub orphaned_archives_count: u32,
     pub archive_count: usize,
     pub archive_min_id: Option<u32>,
     pub archive_max_id: Option<u32>,
     pub package_entries_count: usize,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ArchiveState {
-    pub committed_archives: std::collections::BTreeSet<u32>,
-    pub building_archives: Vec<u32>,
-    pub current_archive_id: Option<u32>,
-    pub last_committed_id: u32,
 }

--- a/core/src/storage/block/mod.rs
+++ b/core/src/storage/block/mod.rs
@@ -70,9 +70,8 @@ impl BlockStorage {
             block_handle_storage.clone(),
             &config.blobs_root,
             config.blob_db_config.pre_create_cas_tree,
-        )?;
-
-        blob_storage.preload_archive_ids().await?;
+        )
+        .await?;
 
         Ok(Self {
             blocks_cache,
@@ -86,11 +85,6 @@ impl BlockStorage {
 
     pub fn open_stats(&self) -> &OpenStats {
         self.blob_storage.open_stats()
-    }
-
-    /// Iterates over all archives and preloads their ids into memory.
-    pub async fn preload_archive_ids(&self) -> Result<()> {
-        self.blob_storage.preload_archive_ids().await
     }
 
     // === Subscription stuff ===

--- a/core/src/storage/db.rs
+++ b/core/src/storage/db.rs
@@ -64,6 +64,7 @@ weedb::tables! {
     pub struct CoreTables<TableContext> {
         pub state: tables::State,
         pub archive_block_ids: tables::ArchiveBlockIds,
+        pub archive_events: tables::ArchiveEvents,
         pub block_handles: tables::BlockHandles,
         pub key_blocks: tables::KeyBlocks,
         pub full_block_ids: tables::FullBlockIds,

--- a/core/src/storage/tables.rs
+++ b/core/src/storage/tables.rs
@@ -50,6 +50,29 @@ impl ColumnFamilyOptions<TableContext> for ArchiveBlockIds {
     }
 }
 
+/// Stores archive lifetime events.
+/// - Key: `u32 (BE)` (archive id) + `32 (BE)` (event id)
+/// - Value: event data
+pub struct ArchiveEvents;
+
+impl ArchiveEvents {
+    pub const KEY_LEN: usize = 4 + 4;
+}
+
+impl ColumnFamily for ArchiveEvents {
+    const NAME: &'static str = "archive_events";
+
+    fn read_options(opts: &mut rocksdb::ReadOptions) {
+        opts.set_verify_checksums(false);
+    }
+}
+
+impl ColumnFamilyOptions<TableContext> for ArchiveEvents {
+    fn options(opts: &mut rocksdb::Options, ctx: &mut TableContext) {
+        default_block_based_table_factory(opts, ctx);
+    }
+}
+
 /// Maps block root hash to block meta
 /// - Key: `[u8; 32]`
 /// - Value: `BlockMeta`

--- a/util/src/cli/logger.rs
+++ b/util/src/cli/logger.rs
@@ -286,8 +286,6 @@ pub fn init_logger(config: &LoggerConfig, logger_targets: Option<PathBuf>) -> Re
             .unwrap();
     }
 
-    tracing::info!("logger initialized with config: {config:?}");
-
     Ok(())
 }
 


### PR DESCRIPTION
In rocksdb version we 've skiped spawn for already saved archives via magic flags, forgot this check in cas rewrite