### PR TITLE
feature(collator): new block limits by items

### DIFF
--- a/collator/src/collator/do_collate/execute.rs
+++ b/collator/src/collator/do_collate/execute.rs
@@ -126,13 +126,13 @@ impl Phase<ExecuteState> {
                 executed_groups_count += 1;
                 let group_tx_count = group_result.items.len();
                 self.state.collation_data.tx_count += group_tx_count as u64;
-                // Increment touched accounts only for first-time-seen accounts in this block
+                // Track first-time-seen accounts in this block
                 for acc in group_result.touched_account_ids {
                     if self.state.collation_data.touched_accounts.insert(acc) {
                         self.state
                             .collation_data
                             .block_limit
-                            .total_items
+                            .total_accounts
                             .saturating_add_assign(1);
                     }
                 }

--- a/collator/src/collator/do_collate/execution_wrapper.rs
+++ b/collator/src/collator/do_collate/execution_wrapper.rs
@@ -432,7 +432,6 @@ fn process_in_message(
                     exported_value,
                     new_tx: None,
                 });
-
             }
             collation_data.int_dequeue_count += 1;
 

--- a/collator/src/collator/do_collate/execution_wrapper.rs
+++ b/collator/src/collator/do_collate/execution_wrapper.rs
@@ -249,8 +249,10 @@ fn new_transaction(
     // Update collation data.
     collation_data.execute_count_all += 1;
 
-    let gas_used = &mut collation_data.block_limit.gas_used;
-    *gas_used = gas_used.saturating_add(executed.gas_used);
+    collation_data
+        .block_limit
+        .gas_used
+        .saturating_add_assign(executed.gas_used);
 
     assert!(
         shard_id.is_masterchain() || executed.burned.is_zero(),

--- a/collator/src/collator/do_collate/execution_wrapper.rs
+++ b/collator/src/collator/do_collate/execution_wrapper.rs
@@ -17,7 +17,7 @@ use crate::collator::types::{
 };
 use crate::internal_queue::types::EnqueuedMessage;
 use crate::tracing_targets;
-use crate::types::ShardIdentExt;
+use crate::types::{SaturatingAddAssign, ShardIdentExt};
 
 pub struct ExecutorWrapper {
     pub executor: MessagesExecutor,
@@ -336,6 +336,11 @@ fn new_transaction(
         }
     }
 
+    collation_data
+        .block_limit
+        .total_items
+        .saturating_add_assign(1);
+
     Ok(out_messages)
 }
 
@@ -425,6 +430,7 @@ fn process_in_message(
                     exported_value,
                     new_tx: None,
                 });
+
             }
             collation_data.int_dequeue_count += 1;
 
@@ -480,6 +486,11 @@ fn process_in_message(
             )
         }
     };
+
+    collation_data
+        .block_limit
+        .total_items
+        .saturating_add_assign(1);
 
     collation_data.in_msgs.insert(in_msg_hash, PreparedInMsg {
         in_msg,

--- a/collator/src/collator/do_collate/mod.rs
+++ b/collator/src/collator/do_collate/mod.rs
@@ -1047,6 +1047,18 @@ impl CollatorStdImpl {
         metrics::gauge!("tycho_do_collate_block_diff_tail_len", &labels)
             .set(collation_data.diff_tail_len);
 
+        // Report total_items limits (current value vs configured soft/hard limits)
+        let lt_delta = &collation_data.block_limit.block_limits.lt_delta;
+        let BlockParamLimits {
+            soft_limit,
+            hard_limit,
+            ..
+        } = lt_delta;
+        metrics::gauge!("tycho_do_collate_total_items_current", &labels)
+            .set(collation_data.block_limit.total_items as f64);
+        metrics::gauge!("tycho_do_collate_total_items_soft_limit", &labels).set(*soft_limit as f64);
+        metrics::gauge!("tycho_do_collate_total_items_hard_limit", &labels).set(*hard_limit as f64);
+
         labels.push(("src", "03_collated".to_string()));
         metrics::gauge!("tycho_last_block_seqno", &labels).set(collation_data.block_id_short.seqno);
     }

--- a/collator/src/collator/do_collate/mod.rs
+++ b/collator/src/collator/do_collate/mod.rs
@@ -1059,6 +1059,20 @@ impl CollatorStdImpl {
         metrics::gauge!("tycho_do_collate_total_items_soft_limit", &labels).set(*soft_limit as f64);
         metrics::gauge!("tycho_do_collate_total_items_hard_limit", &labels).set(*hard_limit as f64);
 
+        // Report total_accounts limits (bytes: current value vs configured soft/hard limits)
+        let bytes = &collation_data.block_limit.block_limits.bytes;
+        let BlockParamLimits {
+            soft_limit,
+            hard_limit,
+            ..
+        } = bytes;
+        metrics::gauge!("tycho_do_collate_total_accounts_current", &labels)
+            .set(collation_data.block_limit.total_accounts as f64);
+        metrics::gauge!("tycho_do_collate_total_accounts_soft_limit", &labels)
+            .set(*soft_limit as f64);
+        metrics::gauge!("tycho_do_collate_total_accounts_hard_limit", &labels)
+            .set(*hard_limit as f64);
+
         labels.push(("src", "03_collated".to_string()));
         metrics::gauge!("tycho_last_block_seqno", &labels).set(collation_data.block_id_short.seqno);
     }

--- a/collator/src/collator/messages_buffer.rs
+++ b/collator/src/collator/messages_buffer.rs
@@ -7,7 +7,7 @@ use tycho_types::models::{ExtInMsgInfo, IntMsgInfo, MsgInfo};
 use tycho_util::{FastHashMap, FastHashSet};
 
 use super::types::ParsedMessage;
-use crate::types::{DebugIter, DisplayIter};
+use crate::types::{DebugIter, DisplayIter, SaturatingAddAssign};
 
 #[cfg(test)]
 #[path = "tests/messages_buffer_tests.rs"]
@@ -591,20 +591,6 @@ impl MessageFilter for SkipExpiredExternals<'_> {
     }
 }
 
-pub trait SaturatingAddAssign {
-    fn saturating_add_assign(&mut self, rhs: Self);
-}
-impl SaturatingAddAssign for u64 {
-    fn saturating_add_assign(&mut self, rhs: Self) {
-        *self = self.saturating_add(rhs);
-    }
-}
-impl SaturatingAddAssign for usize {
-    fn saturating_add_assign(&mut self, rhs: Self) {
-        *self = self.saturating_add(rhs);
-    }
-}
-
 #[cfg(test)]
 pub(super) struct DebugMessagesBuffer<'a>(pub &'a MessagesBuffer);
 #[cfg(test)]
@@ -706,6 +692,10 @@ impl MessageGroup {
 
     pub fn accounts_count(&self) -> usize {
         self.msgs.len()
+    }
+
+    pub fn account_ids(&self) -> impl Iterator<Item = &HashBytes> {
+        self.msgs.keys()
     }
 
     pub fn messages_count(&self) -> usize {

--- a/collator/src/collator/messages_reader/externals_reader.rs
+++ b/collator/src/collator/messages_reader/externals_reader.rs
@@ -12,7 +12,7 @@ use super::{
 };
 use crate::collator::messages_buffer::{
     BufferFillStateByCount, BufferFillStateBySlots, FillMessageGroupResult, MessageGroup,
-    MessagesBufferLimits, SaturatingAddAssign, SkipExpiredExternals,
+    MessagesBufferLimits, SkipExpiredExternals,
 };
 use crate::collator::messages_reader::{DebugInternalsRangeReaderState, InternalsRangeReaderKind};
 use crate::collator::types::{
@@ -20,8 +20,8 @@ use crate::collator::types::{
 };
 use crate::internal_queue::types::{InternalMessageValue, PartitionRouter};
 use crate::tracing_targets;
-use crate::types::DebugIter;
 use crate::types::processed_upto::BlockSeqno;
+use crate::types::{DebugIter, SaturatingAddAssign};
 
 #[cfg(test)]
 #[path = "../tests/externals_reader_tests.rs"]

--- a/collator/src/collator/messages_reader/internals_reader.rs
+++ b/collator/src/collator/messages_reader/internals_reader.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::collator::error::CollatorError;
 use crate::collator::messages_buffer::{
     BufferFillStateByCount, BufferFillStateBySlots, FillMessageGroupResult, IncludeAllMessages,
-    MessageGroup, MessagesBuffer, MessagesBufferLimits, SaturatingAddAssign,
+    MessageGroup, MessagesBuffer, MessagesBufferLimits,
 };
 use crate::collator::types::{
     ConcurrentQueueStatistics, MsgsExecutionParamsExtension, MsgsExecutionParamsStuff,
@@ -22,8 +22,8 @@ use crate::internal_queue::iterator::QueueIterator;
 use crate::internal_queue::types::{Bound, DiffZone, InternalMessageValue, QueueShardBoundedRange};
 use crate::queue_adapter::MessageQueueAdapter;
 use crate::tracing_targets;
-use crate::types::DebugIter;
 use crate::types::processed_upto::{BlockSeqno, Lt};
+use crate::types::{DebugIter, SaturatingAddAssign};
 
 //=========
 // INTERNALS READER

--- a/collator/src/collator/messages_reader/new_messages.rs
+++ b/collator/src/collator/messages_reader/new_messages.rs
@@ -13,16 +13,14 @@ use super::{
     DebugInternalsRangeReaderState, InternalsRangeReaderState, MessagesReaderMetrics,
     ShardReaderState,
 };
-use crate::collator::messages_buffer::{
-    BufferFillStateByCount, BufferFillStateBySlots, SaturatingAddAssign,
-};
+use crate::collator::messages_buffer::{BufferFillStateByCount, BufferFillStateBySlots};
 use crate::collator::types::ParsedMessage;
 use crate::internal_queue::state::state_iterator::MessageExt;
 use crate::internal_queue::types::{
     AccountStatistics, InternalMessageValue, PartitionRouter, QueueDiffWithMessages,
 };
 use crate::tracing_targets;
-use crate::types::ProcessedTo;
+use crate::types::{ProcessedTo, SaturatingAddAssign};
 
 //=========
 // NEW MESSAGES

--- a/collator/src/collator/types.rs
+++ b/collator/src/collator/types.rs
@@ -327,6 +327,7 @@ impl BlockCollationDataBuilder {
             start_lt,
             next_lt: start_lt + 1,
             tx_count: 0,
+            touched_accounts: Default::default(),
             shard_accounts_count: 0,
             updated_accounts_count: 0,
             added_accounts_count: 0,
@@ -366,6 +367,7 @@ pub(super) struct BlockCollationData {
     pub gen_utime_ms: u16,
 
     pub tx_count: u64,
+    pub touched_accounts: FastHashSet<HashBytes>,
 
     pub shard_accounts_count: u64,
     pub updated_accounts_count: u64,
@@ -507,8 +509,8 @@ pub struct PartialValueFlow {
 pub struct BlockLimitStats {
     pub gas_used: u64,
     pub lt_current: u64,
-    pub lt_start: u64,
     pub cells_bits: u32,
+    pub total_items: u32,
     pub block_limits: BlockLimits,
 }
 
@@ -517,8 +519,8 @@ impl BlockLimitStats {
         Self {
             gas_used: 0,
             lt_current: lt_start,
-            lt_start,
             cells_bits: 0,
+            total_items: 0,
             block_limits,
         }
     }
@@ -563,11 +565,11 @@ impl BlockLimitStats {
             ..
         } = lt_delta;
 
-        let delta_lt = u32::try_from(self.lt_current - self.lt_start).unwrap_or(u32::MAX);
-        if delta_lt >= *hard_limit {
+        // touched accounts + created transactions + created out messages
+        if self.total_items >= *hard_limit {
             return true;
         }
-        if delta_lt >= *soft_limit && level == BlockLimitsLevel::Soft {
+        if self.total_items >= *soft_limit && level == BlockLimitsLevel::Soft {
             return true;
         }
         false

--- a/collator/src/collator/types.rs
+++ b/collator/src/collator/types.rs
@@ -509,7 +509,7 @@ pub struct PartialValueFlow {
 pub struct BlockLimitStats {
     pub gas_used: u64,
     pub lt_current: u64,
-    pub cells_bits: u32,
+    pub total_accounts: u32,
     pub total_items: u32,
     pub block_limits: BlockLimits,
 }
@@ -519,7 +519,7 @@ impl BlockLimitStats {
         Self {
             gas_used: 0,
             lt_current: lt_start,
-            cells_bits: 0,
+            total_accounts: 0,
             total_items: 0,
             block_limits,
         }
@@ -538,11 +538,10 @@ impl BlockLimitStats {
             ..
         } = bytes;
 
-        let cells_bytes = self.cells_bits / 8;
-        if cells_bytes >= *hard_limit {
+        if self.total_accounts >= *hard_limit {
             return true;
         }
-        if cells_bytes >= *soft_limit && level == BlockLimitsLevel::Soft {
+        if self.total_accounts >= *soft_limit && level == BlockLimitsLevel::Soft {
             return true;
         }
 
@@ -565,7 +564,7 @@ impl BlockLimitStats {
             ..
         } = lt_delta;
 
-        // touched accounts + created transactions + created out messages
+        // created transactions + created out messages
         if self.total_items >= *hard_limit {
             return true;
         }

--- a/collator/src/types.rs
+++ b/collator/src/types.rs
@@ -666,3 +666,21 @@ impl ShardIdentExt for ShardIdent {
         false
     }
 }
+
+pub trait SaturatingAddAssign {
+    fn saturating_add_assign(&mut self, rhs: Self);
+}
+
+macro_rules! impl_saturating_add_assign {
+    ($($t:ty),+ $(,)?) => {
+        $(
+            impl SaturatingAddAssign for $t {
+                fn saturating_add_assign(&mut self, rhs: Self) {
+                    *self = self.saturating_add(rhs);
+                }
+            }
+        )+
+    };
+}
+
+impl_saturating_add_assign!(u32, u64, usize);

--- a/scripts/gen-dashboard.py
+++ b/scripts/gen-dashboard.py
@@ -1319,6 +1319,33 @@ def collation_metrics() -> RowPanel:
             title="Total items vs limits",
             unit=UNITS.NUMBER_FORMAT,
         ),
+        timeseries_panel(
+            targets=[
+                target(
+                    Expr(
+                        metric="tycho_do_collate_total_accounts_current",
+                        label_selectors=['workchain=~"$workchain"'],
+                    ),
+                    legend_format="current",
+                ),
+                target(
+                    Expr(
+                        metric="tycho_do_collate_total_accounts_soft_limit",
+                        label_selectors=['workchain=~"$workchain"'],
+                    ),
+                    legend_format="soft limit",
+                ),
+                target(
+                    Expr(
+                        metric="tycho_do_collate_total_accounts_hard_limit",
+                        label_selectors=['workchain=~"$workchain"'],
+                    ),
+                    legend_format="hard limit",
+                ),
+            ],
+            title="Total accounts vs limits",
+            unit=UNITS.NUMBER_FORMAT,
+        ),
         create_gauge_panel(
             "tycho_blocks_count_in_collation_manager_cache",
             "Blocks count in collation manager cache",

--- a/scripts/gen-dashboard.py
+++ b/scripts/gen-dashboard.py
@@ -1346,6 +1346,33 @@ def collation_metrics() -> RowPanel:
             title="Total accounts vs limits",
             unit=UNITS.NUMBER_FORMAT,
         ),
+        timeseries_panel(
+            targets=[
+                target(
+                    Expr(
+                        metric="tycho_do_collate_lt_progress_current",
+                        label_selectors=['workchain=~"$workchain"'],
+                    ),
+                    legend_format="current progress",
+                ),
+                target(
+                    Expr(
+                        metric="tycho_do_collate_lt_progress_window_size",
+                        label_selectors=['workchain=~"$workchain"'],
+                    ),
+                    legend_format="LT window size",
+                ),
+                target(
+                    Expr(
+                        metric="tycho_do_collate_lt_progress_guard_threshold",
+                        label_selectors=['workchain=~"$workchain"'],
+                    ),
+                    legend_format="guard threshold",
+                ),
+            ],
+            title="LT progress vs next block LT",
+            unit=UNITS.NUMBER_FORMAT,
+        ),
         create_gauge_panel(
             "tycho_blocks_count_in_collation_manager_cache",
             "Blocks count in collation manager cache",

--- a/scripts/gen-dashboard.py
+++ b/scripts/gen-dashboard.py
@@ -1292,6 +1292,33 @@ def collation_metrics() -> RowPanel:
             "Diff tail length",
             labels=['workchain=~"$workchain"'],
         ),
+        timeseries_panel(
+            targets=[
+                target(
+                    Expr(
+                        metric="tycho_do_collate_total_items_current",
+                        label_selectors=['workchain=~"$workchain"'],
+                    ),
+                    legend_format="current",
+                ),
+                target(
+                    Expr(
+                        metric="tycho_do_collate_total_items_soft_limit",
+                        label_selectors=['workchain=~"$workchain"'],
+                    ),
+                    legend_format="soft limit",
+                ),
+                target(
+                    Expr(
+                        metric="tycho_do_collate_total_items_hard_limit",
+                        label_selectors=['workchain=~"$workchain"'],
+                    ),
+                    legend_format="hard limit",
+                ),
+            ],
+            title="Total items vs limits",
+            unit=UNITS.NUMBER_FORMAT,
+        ),
         create_gauge_panel(
             "tycho_blocks_count_in_collation_manager_cache",
             "Blocks count in collation manager cache",

--- a/scripts/gen-dashboard.py
+++ b/scripts/gen-dashboard.py
@@ -1299,21 +1299,21 @@ def collation_metrics() -> RowPanel:
                         metric="tycho_do_collate_total_items_current",
                         label_selectors=['workchain=~"$workchain"'],
                     ),
-                    legend_format="current",
+                    legend_format="{{workchain}} current",
                 ),
                 target(
                     Expr(
                         metric="tycho_do_collate_total_items_soft_limit",
                         label_selectors=['workchain=~"$workchain"'],
                     ),
-                    legend_format="soft limit",
+                    legend_format="{{workchain}} soft limit",
                 ),
                 target(
                     Expr(
                         metric="tycho_do_collate_total_items_hard_limit",
                         label_selectors=['workchain=~"$workchain"'],
                     ),
-                    legend_format="hard limit",
+                    legend_format="{{workchain}} hard limit",
                 ),
             ],
             title="Total items vs limits",
@@ -1326,21 +1326,21 @@ def collation_metrics() -> RowPanel:
                         metric="tycho_do_collate_total_accounts_current",
                         label_selectors=['workchain=~"$workchain"'],
                     ),
-                    legend_format="current",
+                    legend_format="{{workchain}} current",
                 ),
                 target(
                     Expr(
                         metric="tycho_do_collate_total_accounts_soft_limit",
                         label_selectors=['workchain=~"$workchain"'],
                     ),
-                    legend_format="soft limit",
+                    legend_format="{{workchain}} soft limit",
                 ),
                 target(
                     Expr(
                         metric="tycho_do_collate_total_accounts_hard_limit",
                         label_selectors=['workchain=~"$workchain"'],
                     ),
-                    legend_format="hard limit",
+                    legend_format="{{workchain}} hard limit",
                 ),
             ],
             title="Total accounts vs limits",
@@ -1353,21 +1353,21 @@ def collation_metrics() -> RowPanel:
                         metric="tycho_do_collate_lt_progress_current",
                         label_selectors=['workchain=~"$workchain"'],
                     ),
-                    legend_format="current progress",
+                    legend_format="{{workchain}} current progress",
                 ),
                 target(
                     Expr(
                         metric="tycho_do_collate_lt_progress_window_size",
                         label_selectors=['workchain=~"$workchain"'],
                     ),
-                    legend_format="LT window size",
+                    legend_format="{{workchain}} LT window size",
                 ),
                 target(
                     Expr(
                         metric="tycho_do_collate_lt_progress_guard_threshold",
                         label_selectors=['workchain=~"$workchain"'],
                     ),
-                    legend_format="guard threshold",
+                    legend_format="{{workchain}} guard threshold",
                 ),
             ],
             title="LT progress vs next block LT",

--- a/scripts/gen-dashboard.py
+++ b/scripts/gen-dashboard.py
@@ -1246,11 +1246,6 @@ def collation_metrics() -> RowPanel:
             "Number of transactions over time",
             labels_selectors=['workchain=~"$workchain"'],
         ),
-        create_counter_panel(
-            "tycho_do_collate_blocks_with_limits_reached_count",
-            "Number of blocks with limits reached",
-            labels_selectors=['workchain=~"$workchain"'],
-        ),
         create_gauge_panel(
             "tycho_do_collate_tx_per_block",
             "Number of transactions per block",
@@ -1291,6 +1286,19 @@ def collation_metrics() -> RowPanel:
             "tycho_do_collate_block_diff_tail_len",
             "Diff tail length",
             labels=['workchain=~"$workchain"'],
+        ),
+        timeseries_panel(
+            targets=[
+                target(
+                    Expr(
+                        metric="tycho_do_collate_blocks_with_limit_reached",
+                        label_selectors=['workchain=~"$workchain"'],
+                    ),
+                    legend_format="{{workchain}} {{limit_type}}",
+                ),
+            ],
+            title="Block limits reached by type",
+            unit=UNITS.NUMBER_FORMAT,
         ),
         timeseries_panel(
             targets=[


### PR DESCRIPTION
## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

None

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

None

### COMPATIBILITY

Block may contain different data compared to old logic when the limit is reached. Nodes should be updated without load 

### SPECIAL DEPLOYMENT ACTIONS

Nodes should be updated without load 
Required to define the appropriate limit and make changes in zerostate `22` and `23`

```{
  "bytes": {
    ...
    "hard_limit": 20000
  },
  "lt_delta": {
    ...
    "hard_limit": 50000
  }
}
```


### PERFORMANCE IMPACT

The node stops producing blocks with a huge number of accounts

### TESTS

#### Unit Tests

No coverage

#### Network Tests

#### Manual Tests

### master
- [transfers 20k master](https://grafana.broxus.com/d/cdlaji62a1b0gb/tycho-node-metrics?orgId=1&from=2025-09-10T10:51:53.566Z&to=2025-09-10T11:56:53.566Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet6-validator2&var-instance=tycho-devnet6-validator3&var-instance=tycho-devnet6-validator13&var-instance=tycho-devnet6-validator10&var-instance=tycho-devnet6-validator11&var-instance=tycho-devnet6-validator12&var-instance=tycho-devnet6-validator1&var-instance=tycho-devnet6-validator4&var-instance=tycho-devnet6-validator5&var-instance=tycho-devnet6-validator6&var-instance=tycho-devnet6-validator7&var-instance=tycho-devnet6-validator9&var-instance=tycho-devnet6-validator8&var-workchain=$__all&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)
- [dex 1500 master](https://grafana.broxus.com/d/cdlaji62a1b0gb/tycho-node-metrics?orgId=1&from=2025-09-10T12:01:38.202Z&to=2025-09-10T13:37:38.202Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet6-validator2&var-instance=tycho-devnet6-validator3&var-instance=tycho-devnet6-validator13&var-instance=tycho-devnet6-validator10&var-instance=tycho-devnet6-validator11&var-instance=tycho-devnet6-validator12&var-instance=tycho-devnet6-validator1&var-instance=tycho-devnet6-validator4&var-instance=tycho-devnet6-validator5&var-instance=tycho-devnet6-validator6&var-instance=tycho-devnet6-validator7&var-instance=tycho-devnet6-validator9&var-instance=tycho-devnet6-validator8&var-workchain=$__all&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)
- [1m accounts + transfers20k master](https://grafana.broxus.com/d/cdlaji62a1b0gb/tycho-node-metrics?orgId=1&from=2025-09-10T13:55:03.840Z&to=2025-09-10T14:43:30.507Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet6-validator9&var-instance=tycho-devnet6-validator8&var-instance=tycho-devnet6-validator7&var-instance=tycho-devnet6-validator6&var-instance=tycho-devnet6-validator5&var-instance=tycho-devnet6-validator4&var-instance=tycho-devnet6-validator3&var-instance=tycho-devnet6-validator2&var-instance=tycho-devnet6-validator13&var-instance=tycho-devnet6-validator12&var-instance=tycho-devnet6-validator11&var-instance=tycho-devnet6-validator10&var-instance=tycho-devnet6-validator1&var-workchain=$__all&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)
- [1m accounts + dex1400 master](https://grafana.broxus.com/d/cdlaji62a1b0gb/tycho-node-metrics?orgId=1&from=2025-09-10T14:46:55.722Z&to=2025-09-10T15:29:42.389Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet6-validator9&var-instance=tycho-devnet6-validator8&var-instance=tycho-devnet6-validator7&var-instance=tycho-devnet6-validator6&var-instance=tycho-devnet6-validator5&var-instance=tycho-devnet6-validator4&var-instance=tycho-devnet6-validator3&var-instance=tycho-devnet6-validator2&var-instance=tycho-devnet6-validator13&var-instance=tycho-devnet6-validator12&var-instance=tycho-devnet6-validator11&var-instance=tycho-devnet6-validator10&var-instance=tycho-devnet6-validator1&var-workchain=$__all&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)

### feature tests
**accounts limit 15k; items limit 50k**
- [tranfers 20k](https://grafana.broxus.com/d/cdlaji62a1b0gb/tycho-node-metrics?orgId=1&from=2025-09-10T16:51:12.026Z&to=2025-09-10T17:09:45.360Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet6-validator9&var-instance=tycho-devnet6-validator8&var-instance=tycho-devnet6-validator7&var-instance=tycho-devnet6-validator6&var-instance=tycho-devnet6-validator5&var-instance=tycho-devnet6-validator4&var-instance=tycho-devnet6-validator3&var-instance=tycho-devnet6-validator2&var-instance=tycho-devnet6-validator13&var-instance=tycho-devnet6-validator12&var-instance=tycho-devnet6-validator11&var-instance=tycho-devnet6-validator10&var-instance=tycho-devnet6-validator1&var-workchain=$__all&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)
<img width="2242" height="534" alt="image" src="https://github.com/user-attachments/assets/ff800bc9-0ae5-4375-888a-52112c1af532" />

- [dex 1500](https://grafana.broxus.com/d/cdlaji62a1b0gb/tycho-node-metrics?orgId=1&from=2025-09-10T17:18:18.470Z&to=2025-09-10T17:30:12.264Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet6-validator2&var-instance=tycho-devnet6-validator3&var-instance=tycho-devnet6-validator13&var-instance=tycho-devnet6-validator10&var-instance=tycho-devnet6-validator11&var-instance=tycho-devnet6-validator12&var-instance=tycho-devnet6-validator1&var-instance=tycho-devnet6-validator4&var-instance=tycho-devnet6-validator5&var-instance=tycho-devnet6-validator6&var-instance=tycho-devnet6-validator7&var-instance=tycho-devnet6-validator9&var-instance=tycho-devnet6-validator8&var-workchain=$__all&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)
<img width="2238" height="541" alt="image" src="https://github.com/user-attachments/assets/89856c72-4c33-4689-8769-1695e11a8409" />

- [1m accounts + transfers20k](https://grafana.broxus.com/d/cdlaji62a1b0gb/tycho-node-metrics?orgId=1&from=2025-09-10T18:18:53.626Z&to=2025-09-10T20:23:29.251Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet6-validator9&var-instance=tycho-devnet6-validator8&var-instance=tycho-devnet6-validator7&var-instance=tycho-devnet6-validator6&var-instance=tycho-devnet6-validator5&var-instance=tycho-devnet6-validator4&var-instance=tycho-devnet6-validator3&var-instance=tycho-devnet6-validator2&var-instance=tycho-devnet6-validator13&var-instance=tycho-devnet6-validator12&var-instance=tycho-devnet6-validator11&var-instance=tycho-devnet6-validator10&var-instance=tycho-devnet6-validator1&var-workchain=$__all&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)
<img width="1944" height="534" alt="image" src="https://github.com/user-attachments/assets/83738606-6bb7-43d0-9e9c-9154b088555c" />

- [1m accounts + dex1400](https://grafana.broxus.com/d/cdlaji62a1b0gb/tycho-node-metrics?orgId=1&from=2025-09-10T20:30:19.254Z&to=2025-09-10T21:47:39.035Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet6-validator9&var-instance=tycho-devnet6-validator8&var-instance=tycho-devnet6-validator7&var-instance=tycho-devnet6-validator6&var-instance=tycho-devnet6-validator5&var-instance=tycho-devnet6-validator4&var-instance=tycho-devnet6-validator3&var-instance=tycho-devnet6-validator2&var-instance=tycho-devnet6-validator13&var-instance=tycho-devnet6-validator12&var-instance=tycho-devnet6-validator11&var-instance=tycho-devnet6-validator10&var-instance=tycho-devnet6-validator1&var-workchain=$__all&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)

- [deploy 10kk acc limits 20k](https://grafana.broxus.com/d/cdlaji62a1b0gb/tycho-node-metrics?orgId=1&from=2025-09-11T08:32:30.100Z&to=2025-09-11T08:38:23.391Z&timezone=browser&var-source=ced0ihciqrn5sb&var-instance=tycho-devnet6-validator9&var-instance=tycho-devnet6-validator8&var-instance=tycho-devnet6-validator7&var-instance=tycho-devnet6-validator6&var-instance=tycho-devnet6-validator5&var-instance=tycho-devnet6-validator4&var-instance=tycho-devnet6-validator3&var-instance=tycho-devnet6-validator2&var-instance=tycho-devnet6-validator13&var-instance=tycho-devnet6-validator12&var-instance=tycho-devnet6-validator11&var-instance=tycho-devnet6-validator10&var-instance=tycho-devnet6-validator1&var-workchain=$__all&var-partition=$__all&var-kind=$__all&var-method=$__all&var-peer_id=$__all&var-remote_addr=$__all&refresh=30s)
<img width="2236" height="536" alt="image" src="https://github.com/user-attachments/assets/c3c71844-235e-4b96-a0da-e97ae9c2f337" />

### Tests conclusion

The feature with limits of `15,000` accounts and`50,000` items does not reach its limits and works the same as the master in the `transfers20k` and `dex1500 tests`.

The limits are reached in the `deploy10kk` test (it places `18,000` accounts in a block).
Therefore, it is proposed to set limits. 

**20k accounts
50k items**



