### PR TITLE
Refactor/consensus/download types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "tycho-types"
 version = "0.2.1"
-source = "git+https://github.com/broxus/tycho-types.git?rev=715769a16fc4497a60865948eb15be928f974446#715769a16fc4497a60865948eb15be928f974446"
+source = "git+https://github.com/broxus/tycho-types.git?rev=35fea56d604d00cc0f4b4e967d6326ff0793ef26#35fea56d604d00cc0f4b4e967d6326ff0793ef26"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "tycho-types-abi-proc"
 version = "0.2.0"
-source = "git+https://github.com/broxus/tycho-types.git?rev=715769a16fc4497a60865948eb15be928f974446#715769a16fc4497a60865948eb15be928f974446"
+source = "git+https://github.com/broxus/tycho-types.git?rev=35fea56d604d00cc0f4b4e967d6326ff0793ef26#35fea56d604d00cc0f4b4e967d6326ff0793ef26"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4248,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "tycho-types-proc"
 version = "0.2.0"
-source = "git+https://github.com/broxus/tycho-types.git?rev=715769a16fc4497a60865948eb15be928f974446#715769a16fc4497a60865948eb15be928f974446"
+source = "git+https://github.com/broxus/tycho-types.git?rev=35fea56d604d00cc0f4b4e967d6326ff0793ef26#35fea56d604d00cc0f4b4e967d6326ff0793ef26"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ tycho-wu-tuner = { path = "./wu-tuner", version = "0.2.12" }
 
 [patch.crates-io]
 # patches here
-tycho-types = { git = "https://github.com/broxus/tycho-types.git", rev = "715769a16fc4497a60865948eb15be928f974446" }
+tycho-types = { git = "https://github.com/broxus/tycho-types.git", rev = "35fea56d604d00cc0f4b4e967d6326ff0793ef26" }
 tycho-executor = { git = "https://github.com/broxus/tycho-vm.git", rev = "985a350d83385b9f90e69a77073e6cbb1071fa93" }
 tycho-vm = { git = "https://github.com/broxus/tycho-vm.git", rev = "985a350d83385b9f90e69a77073e6cbb1071fa93" }
 

--- a/cli/src/cmd/tools/gen_zerostate.rs
+++ b/cli/src/cmd/tools/gen_zerostate.rs
@@ -791,18 +791,18 @@ fn make_default_params() -> Result<BlockchainConfigParams> {
 
     // Param 29
     params.set_consensus_config(&ConsensusConfig {
-        clock_skew_millis: 5 * 1000,
-        payload_batch_bytes: 768 * 1024,
-        commit_history_rounds: 20,
+        clock_skew_millis: (5 * 1000).try_into().unwrap(),
+        payload_batch_bytes: (768 * 1024).try_into().unwrap(),
+        commit_history_rounds: 20.try_into().unwrap(),
         deduplicate_rounds: 140,
-        max_consensus_lag_rounds: 210,
-        payload_buffer_bytes: 50 * 1024 * 1024,
-        broadcast_retry_millis: 150,
-        download_retry_millis: 25,
-        download_peers: 2,
-        download_tasks: 260,
-        sync_support_rounds: 840,
-        broadcast_retry_attempts: 2,
+        max_consensus_lag_rounds: 210.try_into().unwrap(),
+        payload_buffer_bytes: (50 * 1024 * 1024).try_into().unwrap(),
+        broadcast_retry_millis: 150.try_into().unwrap(),
+        download_retry_millis: 25.try_into().unwrap(),
+        download_peers: 2.try_into().unwrap(),
+        min_sign_attempts: 3.try_into().unwrap(),
+        download_peer_queries: 10.try_into().unwrap(),
+        sync_support_rounds: 840.try_into().unwrap(),
     })?;
 
     // Param 31

--- a/collator/src/collator/do_collate/finalize.rs
+++ b/collator/src/collator/do_collate/finalize.rs
@@ -593,7 +593,8 @@ impl Phase<FinalizeState> {
                 .mc_data
                 .config
                 .get_consensus_config()?
-                .max_consensus_lag_rounds as u64;
+                .max_consensus_lag_rounds
+                .get() as u64;
             let wu_used_to_import_next_anchor =
                 self.state.collation_config.wu_used_to_import_next_anchor;
             let max_wu_used_limit = max_consensus_lag_rounds
@@ -1007,7 +1008,7 @@ impl Phase<FinalizeState> {
                 // `prev_processed_to_anchor` is a round in the ending session, after which
                 // mempool can create `max_consensus_lag` rounds in DAG until it stops to wait
                 let last_round_to_create = prev_processed_to_anchor
-                    + prev_consensus_config.max_consensus_lag_rounds as u32;
+                    + prev_consensus_config.max_consensus_lag_rounds.get() as u32;
                 // `+1` because it will be the first mempool round in the new session
                 if !is_curr_switch_applied {
                     // just overwrite (skip) outdated v_set preserving prev_* attributes;

--- a/collator/src/collator/mod.rs
+++ b/collator/src/collator/mod.rs
@@ -1476,7 +1476,8 @@ impl CollatorStdImpl {
                 .mc_data
                 .config
                 .get_consensus_config()?
-                .max_consensus_lag_rounds as u32;
+                .max_consensus_lag_rounds
+                .get() as u32;
             while last_imported_chain_time < next_chain_time {
                 // next anchor importing can stuck if mempool paused
                 // so allow to cancel collation here
@@ -1640,7 +1641,8 @@ impl CollatorStdImpl {
                 .mc_data
                 .config
                 .get_consensus_config()?
-                .max_consensus_lag_rounds as u32,
+                .max_consensus_lag_rounds
+                .get() as u32,
         );
 
         let import_anchor_result = tokio::select! {
@@ -1885,7 +1887,8 @@ impl CollatorStdImpl {
                     .mc_data
                     .config
                     .get_consensus_config()?
-                    .max_consensus_lag_rounds as u32;
+                    .max_consensus_lag_rounds
+                    .get() as u32;
 
                 let mut imported_anchors_count = 0;
                 let mut imported_anchors_has_externals = false;

--- a/collator/src/mempool/impls/single_node_impl.rs
+++ b/collator/src/mempool/impls/single_node_impl.rs
@@ -59,8 +59,8 @@ impl MempoolAdapterSingleNodeImpl {
 
         self.input_buffer.apply_config(&merged_conf.conf.consensus);
 
-        let timeout = merged_conf.conf.consensus.broadcast_retry_millis as u64
-            * merged_conf.conf.consensus.broadcast_retry_attempts as u64
+        let timeout = merged_conf.conf.consensus.broadcast_retry_millis.get() as u64
+            * merged_conf.conf.consensus.min_sign_attempts.get() as u64
             * ANCHOR_ID_STEP as u64;
 
         let mut interval = tokio::time::interval(std::time::Duration::from_millis(timeout));

--- a/consensus/src/dag/commit/back.rs
+++ b/consensus/src/dag/commit/back.rs
@@ -407,8 +407,8 @@ impl DagBack {
         }
         // do not commit genesis - we may place some arbitrary payload in it,
         // also mempool adapter does not expect it, and collator cannot use it too
-        let history_limit =
-            (conf.genesis_round.next()).max(anchor.round() - conf.consensus.commit_history_rounds);
+        let history_limit = (conf.genesis_round.next())
+            .max(anchor.round() - conf.consensus.commit_history_rounds.get());
 
         let mut r = array::from_fn::<_, 3, _>(|_| FastHashMap::new()); // [r+0, r-1, r-2]
         extend(&mut r[0], anchor.includes()); // points @ r+0

--- a/consensus/src/dag/commit/mod.rs
+++ b/consensus/src/dag/commit/mod.rs
@@ -50,7 +50,8 @@ impl Committer {
             "already initialized"
         );
         self.dag.init(bottom_round);
-        self.full_history_bottom = bottom_round.round() + conf.consensus.commit_history_rounds;
+        self.full_history_bottom =
+            bottom_round.round() + conf.consensus.commit_history_rounds.get();
         self.full_history_bottom // hidden in other cases
     }
 
@@ -78,7 +79,7 @@ impl Committer {
         let actual_bottom = new_bottom_round.min(self.dag.top().round());
         self.dag.drop_upto(actual_bottom);
         self.anchor_chain.drop_upto(actual_bottom);
-        self.full_history_bottom = actual_bottom + conf.consensus.commit_history_rounds;
+        self.full_history_bottom = actual_bottom + conf.consensus.commit_history_rounds.get();
         if actual_bottom == new_bottom_round {
             Ok(self.full_history_bottom)
         } else {
@@ -195,7 +196,7 @@ impl Committer {
         conf: &MempoolConfig,
     ) -> Result<AnchorData, SyncError> {
         // in case previous anchor was triggered directly - rounds are already dropped
-        (self.dag).drop_upto(next.anchor.round() - conf.consensus.commit_history_rounds);
+        (self.dag).drop_upto(next.anchor.round() - conf.consensus.commit_history_rounds.get());
         let uncommitted =
             match (self.dag).gather_uncommitted(self.full_history_bottom, &next.anchor, conf) {
                 Ok(uncommitted) => uncommitted,

--- a/consensus/src/dag/dag_location.rs
+++ b/consensus/src/dag/dag_location.rs
@@ -354,7 +354,7 @@ impl Signable {
                         return None; // retry later
                     }
                     if self.valid.info().time() - UnixTime::now()
-                        >= UnixTime::from_millis(conf.consensus.clock_skew_millis as _)
+                        >= UnixTime::from_millis(conf.consensus.clock_skew_millis.get() as _)
                     {
                         metrics::counter!(POSTPONED, "kind" => "time").increment(1);
                         return None; // retry later

--- a/consensus/src/dag/threshold.rs
+++ b/consensus/src/dag/threshold.rs
@@ -44,7 +44,7 @@ impl Threshold {
             round,
             target_count,
             count: AtomicU32::new(count.pack()),
-            clock_skew: UnixTime::from_millis(conf.consensus.clock_skew_millis as _),
+            clock_skew: UnixTime::from_millis(conf.consensus.clock_skew_millis.get() as _),
             sender,
             work: Mutex::new(ThresholdWork {
                 is_reached: false,

--- a/consensus/src/dag/verifier.rs
+++ b/consensus/src/dag/verifier.rs
@@ -365,7 +365,7 @@ impl Verifier {
         let anchor_proof_link_id = info.anchor_link_id(AnchorStageRole::Proof);
 
         let max_allowed_dep_time =
-            info.time() + UnixTime::from_millis(conf.consensus.clock_skew_millis as _);
+            info.time() + UnixTime::from_millis(conf.consensus.clock_skew_millis.get() as _);
 
         while let Some(task_result) = deps_and_prev.next().await {
             let Some(dag_point) = task_result? else {
@@ -650,7 +650,7 @@ impl Verifier {
                 return Some(IllFormedReason::AnchorTime);
             }
         } else {
-            if info.payload_bytes() > conf.consensus.payload_batch_bytes {
+            if info.payload_bytes() > conf.consensus.payload_batch_bytes.get() {
                 return Some(IllFormedReason::TooLargePayload(info.payload_bytes()));
             }
             // leader must maintain its chain of proofs,

--- a/consensus/src/engine/committer_task.rs
+++ b/consensus/src/engine/committer_task.rs
@@ -25,7 +25,7 @@ enum Inner {
 impl CommitterTask {
     pub fn new(committer: Committer, conf: &MempoolConfig) -> Self {
         let mut interval = tokio::time::interval(Duration::from_millis(
-            conf.consensus.broadcast_retry_millis as _,
+            conf.consensus.broadcast_retry_millis.get() as _,
         ));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 

--- a/consensus/src/engine/consensus_config_ext.rs
+++ b/consensus/src/engine/consensus_config_ext.rs
@@ -51,11 +51,11 @@ impl ConsensusConfigExt for ConsensusConfig {
         // notice that procedure happens at round start, before new local point's dependencies
         // finished their validation, a new 'next' dag round will appear and so no `-1` below
         3 // new current, includes and witness rounds to validate
-            + self.commit_history_rounds as u32 // all committable history for every point
+            + self.commit_history_rounds.get() as u32 // all committable history for every point
     }
 
     fn replay_anchor_rounds(&self) -> u32 {
-        self.commit_history_rounds as u32 // to take full first anchor history
+        self.commit_history_rounds.get() as u32 // to take full first anchor history
             + self.deduplicate_rounds as u32 // to discard full anchor history after restart
             + 2 // bottommost includes and witness may not have dag round, so dependers are invalid
             + 2 // invalid but certified dependers are not eligible to be committed
@@ -64,8 +64,8 @@ impl ConsensusConfigExt for ConsensusConfig {
     fn reset_rounds(&self) -> u32 {
         // we could `-1` to use both top and bottom as inclusive range bounds for lag rounds,
         // but collator may re-request TKA from collator, not only the next one
-        self.max_consensus_lag_rounds as u32 // assumed to contain at least one TKA
-            + self.commit_history_rounds as u32 // to take full first anchor history
+        self.max_consensus_lag_rounds.get() as u32 // assumed to contain at least one TKA
+            + self.commit_history_rounds.get() as u32 // to take full first anchor history
             + self.deduplicate_rounds as u32 // to discard full anchor history after restart
             + 2 // includes and witness will not have dag round, so dependers are invalid
             + 2 // invalid but certified dependers are not eligible to be committed
@@ -75,9 +75,9 @@ impl ConsensusConfigExt for ConsensusConfig {
         // we could `-1` to use both top and bottom as inclusive range bounds for lag rounds,
         // but collator may re-request TKA from collator, not only the next one;
         // next `2 + 2` is for dropped rounds as in methods above, just implementation detail
-        (self.sync_support_rounds as u32).max(2 + 2) // to follow consensus during sync
-            + self.max_consensus_lag_rounds as u32 // assumed to contain at least one TKA
-            + self.commit_history_rounds as u32 // to take full first anchor history
+        (self.sync_support_rounds.get() as u32).max(2 + 2) // to follow consensus during sync
+            + self.max_consensus_lag_rounds.get() as u32 // assumed to contain at least one TKA
+            + self.commit_history_rounds.get() as u32 // to take full first anchor history
             + self.deduplicate_rounds as u32 // to discard full anchor history after restart
     }
 }

--- a/consensus/src/engine/impl_.rs
+++ b/consensus/src/engine/impl_.rs
@@ -81,7 +81,7 @@ impl Engine {
             &net.peer_schedule,
             &round_ctx,
         );
-        let committer_run = CommitterTask::new(committer, engine_ctx.conf());
+        let committer_run = CommitterTask::new(committer, conf);
 
         let init_task = engine_ctx.task().spawn_blocking({
             let store = store.clone();
@@ -93,7 +93,7 @@ impl Engine {
             }
         });
 
-        let round_task = RoundTaskReady::new(&store, bind, &consensus_round, net);
+        let round_task = RoundTaskReady::new(&store, bind, &consensus_round, net, conf);
 
         let peer_schedule_updater = engine_ctx.task().spawn({
             let peer_schedule = net.peer_schedule.clone();

--- a/consensus/src/engine/input_buffer.rs
+++ b/consensus/src/engine/input_buffer.rs
@@ -63,11 +63,11 @@ impl InputBufferInner for InputBufferData {
     }
 
     fn apply_config(&mut self, consensus_config: &ConsensusConfig) {
-        self.payload_buffer_bytes = consensus_config.payload_buffer_bytes as usize;
-        self.payload_batch_bytes = consensus_config.payload_batch_bytes as usize;
+        self.payload_buffer_bytes = consensus_config.payload_buffer_bytes.get() as usize;
+        self.payload_batch_bytes = consensus_config.payload_batch_bytes.get() as usize;
         tracing::info!(
-            payload_batch_bytes = consensus_config.payload_batch_bytes,
-            payload_buffer_bytes = consensus_config.payload_buffer_bytes,
+            payload_batch_bytes = consensus_config.payload_batch_bytes.get(),
+            payload_buffer_bytes = consensus_config.payload_buffer_bytes.get(),
             "input buffer config applied"
         );
     }
@@ -206,7 +206,7 @@ mod stub {
                 fetch_count: NonZeroUsize::MIN,
                 steps_until_full,
                 payload_step,
-                payload_batch_bytes: consensus_config.payload_batch_bytes as usize,
+                payload_batch_bytes: consensus_config.payload_batch_bytes.get() as usize,
             })))
         }
     }

--- a/consensus/src/engine/mempool_config.rs
+++ b/consensus/src/engine/mempool_config.rs
@@ -137,13 +137,13 @@ impl MempoolConfigBuilder {
         // unaligned `genesis_info.start_round` is not used
         hasher.update(&(genesis_round.0 as u128).to_be_bytes());
         hasher.update(&(genesis_info.genesis_millis as u128).to_be_bytes());
-        hasher.update(&(consensus.clock_skew_millis as u128).to_be_bytes());
-        hasher.update(&(consensus.payload_batch_bytes as u128).to_be_bytes());
-        hasher.update(&(consensus.commit_history_rounds as u128).to_be_bytes());
+        hasher.update(&(consensus.clock_skew_millis.get() as u128).to_be_bytes());
+        hasher.update(&(consensus.payload_batch_bytes.get() as u128).to_be_bytes());
+        hasher.update(&(consensus.commit_history_rounds.get() as u128).to_be_bytes());
         hasher.update(&(consensus.deduplicate_rounds as u128).to_be_bytes());
-        hasher.update(&(consensus.max_consensus_lag_rounds as u128).to_be_bytes());
-        // TODO add comment in tycho-types
-        hasher.update(&(consensus.sync_support_rounds as u128).to_be_bytes());
+        hasher.update(&(consensus.max_consensus_lag_rounds.get() as u128).to_be_bytes());
+        hasher.update(&(consensus.download_peer_queries.get() as u128).to_be_bytes());
+        hasher.update(&(consensus.sync_support_rounds.get() as u128).to_be_bytes());
 
         let overlay_id = OverlayId(hasher.finalize().into());
 
@@ -178,16 +178,20 @@ pub struct MempoolNodeConfig {
 
     /// Max simultaneous point search tasks fulfilling download request
     pub max_upload_tasks: NonZeroU8,
+
+    /// Limits amount of unique points being simultaneously downloaded from all peers.
+    pub max_download_tasks: NonZeroU16,
 }
 
 impl Default for MempoolNodeConfig {
     fn default() -> Self {
         Self {
             log_truncate_long_values: true,
-            clean_db_period_rounds: NonZeroU16::new(105).unwrap(),
+            clean_db_period_rounds: 105.try_into().unwrap(),
             cache_future_broadcasts_rounds: 105,
-            max_blocking_tasks: NonZeroU16::new(250).unwrap(),
-            max_upload_tasks: NonZeroU8::new(50).unwrap(),
+            max_blocking_tasks: 250.try_into().unwrap(),
+            max_upload_tasks: 50.try_into().unwrap(),
+            max_download_tasks: 250.try_into().unwrap(),
         }
     }
 }

--- a/consensus/src/engine/round_task.rs
+++ b/consensus/src/engine/round_task.rs
@@ -9,6 +9,7 @@ use crate::dag::{
     DagHead, LastOwnPoint, ProduceError, Producer, ValidateResult, Verifier, WeakDagRound,
 };
 use crate::effects::{AltFormat, CollectCtx, Ctx, RoundCtx, Task, TaskResult, ValidateCtx};
+use crate::engine::MempoolConfig;
 use crate::engine::input_buffer::InputBuffer;
 use crate::engine::lifecycle::{EngineBinding, EngineNetwork};
 use crate::engine::round_watch::{Consensus, RoundWatch, TopKnownAnchor};
@@ -46,12 +47,14 @@ impl RoundTaskReady {
         bind: &EngineBinding,
         consensus_round: &RoundWatch<Consensus>,
         net: &EngineNetwork,
+        conf: &MempoolConfig,
     ) -> Self {
         let broadcast_filter = BroadcastFilter::new(&net.peer_schedule, consensus_round);
         let downloader = Downloader::new(
             &net.dispatcher,
             &net.peer_schedule,
             consensus_round.receiver(),
+            conf,
         );
         Self {
             state: RoundTaskState {

--- a/consensus/src/intercom/broadcast/broadcaster.rs
+++ b/consensus/src/intercom/broadcast/broadcaster.rs
@@ -168,7 +168,7 @@ impl Broadcaster {
         self.ctx = BroadcastCtx::new(round_ctx, &self.point);
 
         let mut retry_interval = tokio::time::interval(Duration::from_millis(
-            self.ctx.conf().consensus.broadcast_retry_millis as _,
+            self.ctx.conf().consensus.broadcast_retry_millis.get() as _,
         ));
         retry_interval.reset(); // query signatures after time passes, just to resend broadcast
         retry_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
@@ -216,7 +216,7 @@ impl Broadcaster {
                     };
                     true
                 } else {
-                    if self.attempt > self.ctx.conf().consensus.broadcast_retry_attempts // artificial delay for stable point rate
+                    if self.attempt >= self.ctx.conf().consensus.min_sign_attempts.get()
                         && self.signatures.len() >= self.signers_count.majority_of_others()
                         && let Some(sender) = mem::take(&mut self.bcaster_signal)
                     {

--- a/consensus/src/intercom/broadcast/collector.rs
+++ b/consensus/src/intercom/broadcast/collector.rs
@@ -74,7 +74,7 @@ impl CollectorTask {
         mut bcaster_signal: oneshot::Receiver<BroadcasterSignal>,
     ) -> TaskResult<()> {
         let mut retry_interval = tokio::time::interval(Duration::from_millis(
-            self.ctx.conf().consensus.broadcast_retry_millis as _,
+            self.ctx.conf().consensus.broadcast_retry_millis.get() as _,
         ));
         // no `interval.reset()` as may receive bcaster_signal after jump immediately
         retry_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);

--- a/consensus/src/models/point/impl_.rs
+++ b/consensus/src/models/point/impl_.rs
@@ -46,7 +46,7 @@ impl Point {
         let min_ext_msg_boc_size: usize = 48;
 
         let max_payload_size: usize = tl_proto::bytes_max_size_hint(min_ext_msg_boc_size)
-            * (1 + (consensus_config.payload_batch_bytes as usize / min_ext_msg_boc_size));
+            * (1 + (consensus_config.payload_batch_bytes.get() as usize / min_ext_msg_boc_size));
 
         4 + max_payload_size + PointInfo::MAX_BYTE_SIZE
     }
@@ -204,7 +204,7 @@ pub mod test_point {
     }
 
     pub fn payload(conf: &MempoolConfig) -> Vec<Bytes> {
-        let msg_count = conf.consensus.payload_batch_bytes as usize / MSG_BYTES;
+        let msg_count = conf.consensus.payload_batch_bytes.get() as usize / MSG_BYTES;
         let mut payload = Vec::with_capacity(msg_count);
         let mut bytes = vec![0; MSG_BYTES];
         for _ in 0..msg_count {

--- a/consensus/src/test_utils/bootstrap.rs
+++ b/consensus/src/test_utils/bootstrap.rs
@@ -12,18 +12,18 @@ use crate::engine::{MempoolConfigBuilder, MempoolMergedConfig, MempoolNodeConfig
 
 pub fn default_test_config() -> MempoolMergedConfig {
     let consensus_config = ConsensusConfig {
-        clock_skew_millis: 5 * 1000,
-        payload_batch_bytes: 768 * 1024,
-        commit_history_rounds: 20,
+        clock_skew_millis: (5 * 1000).try_into().unwrap(),
+        payload_batch_bytes: (768 * 1024).try_into().unwrap(),
+        commit_history_rounds: 20.try_into().unwrap(),
         deduplicate_rounds: 20,
-        max_consensus_lag_rounds: 20,
-        payload_buffer_bytes: 50 * 1024 * 1024,
-        broadcast_retry_millis: 150,
-        download_retry_millis: 25,
-        download_peers: 2,
-        download_tasks: 1,
-        sync_support_rounds: 15,
-        broadcast_retry_attempts: 2,
+        max_consensus_lag_rounds: 20.try_into().unwrap(),
+        payload_buffer_bytes: (50 * 1024 * 1024).try_into().unwrap(),
+        broadcast_retry_millis: 150.try_into().unwrap(),
+        download_retry_millis: 25.try_into().unwrap(),
+        download_peers: 2.try_into().unwrap(),
+        min_sign_attempts: 3.try_into().unwrap(),
+        download_peer_queries: 1.try_into().unwrap(),
+        sync_support_rounds: 15.try_into().unwrap(),
     };
 
     let node_config = MempoolNodeConfig {

--- a/consensus/src/test_utils/dag.rs
+++ b/consensus/src/test_utils/dag.rs
@@ -49,8 +49,12 @@ pub fn make_engine_parts<const PEER_COUNT: usize>(
     peer_schedule.init(&merged_conf, &init_peers);
 
     let stub_consensus_round = RoundWatch::<Consensus>::default();
-    let stub_downloader =
-        Downloader::new(&dispatcher, &peer_schedule, stub_consensus_round.receiver());
+    let stub_downloader = Downloader::new(
+        &dispatcher,
+        &peer_schedule,
+        stub_consensus_round.receiver(),
+        conf,
+    );
 
     (peer_schedule, stub_downloader, genesis, engine_ctx)
 }


### PR DESCRIPTION
usage of updated consensus config https://github.com/broxus/tycho-types/pull/55

## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

Yes

Consensus config param `download_tasks: u16` moved to mempool node config param `max_download_tasks: u16`. New default value 250 replaces previous 260.

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

Consensus config (param 29) field `download_tasks: u16` was replaced with `min_sign_attempts: u8` and `download_peer_queries: u8` . Compared to v0.2.12, config value stays of the same size, as `broadcast_retry_attempts` was removed from the end of the struct (was added in https://github.com/broxus/tycho/pull/867 with new tag which is also removed)

---

### COMPATIBILITY

Affected features:

- State. Blockchain Config
- Mempool. Consensus Config

### SPECIAL DEPLOYMENT ACTIONS

New genesis round and time __must__ be applied to global config, because `download_peer_queries` affects overlay id, and new overlay id does not support history from the old genesis.

At least a couple of minutes before network upgrade, consensus config param `download_tasks` should be set to 778, so that it will be parsed as `min_sign_attempts` = 3 and `download_peer_queries` = 10 by new version. Outdated nodes should not experience high load before upgrade, so that amount of simultaneous download tasks stays low and does not hit 778.  
Also config may be changed after network upgrade: until then, `download_tasks` = 260 will be parsed into  `min_sign_attempts` = 1 and `download_peer_queries` = 4. It is a valid and operable config, but a rounds rate will be a bit higher than desirable, and high load should be avoided too before config change.

### PERFORMANCE IMPACT

No impact expected

---

### TESTS

#### Unit Tests

Covered by config serde in `tycho-types`

#### Network Tests

No special coverage

#### Manual Tests

transfers-30k
network upgrade