### PR TITLE
fix(core): bump cassadilia version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "cassadilia"
-version = "0.2.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416cc3730eb4c98b735b31e4e38f65f9ec838041f7b8487d2e211c6db1e90290"
+checksum = "1ee614b19927e2db9756990de11c1f877a77b863a22c462fa53039ca4507433c"
 dependencies = [
  "ahash",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bumpalo = "3.14.0"
 bumpalo-herd = "0.1.2"
 bytes = "1.9.0"
 bytesize = { version = "1.3.0", features = ["serde"] }
-cassadilia = { version = "0.2.1" }
+cassadilia = { version = "0.4" }
 castaway = "0.2"
 clap = { version = "4.5.3", features = ["derive"] }
 clap-markdown = "0.1.4"

--- a/core/src/storage/block/blobs/mod.rs
+++ b/core/src/storage/block/blobs/mod.rs
@@ -92,7 +92,7 @@ impl BlobStorage {
         let (archive_ids_tx, _) = broadcast::channel(4);
         let config = cassadilia::Config {
             sync_mode: cassadilia::SyncMode::Sync,
-            num_ops_per_wal: 100_000,
+            num_ops_per_wal: std::num::NonZeroU64::new(10_000).unwrap(),
             pre_create_cas_dirs,
             scan_orphans_on_startup: true,   // Clean-up your deads
             verify_blob_integrity: true,     // Better safe than sorry


### PR DESCRIPTION
Db format is incompatible with prev one, but we have no release with prev version anyway.

Everything else is the same, except fixed logic errors in the db