### PR TITLE
Use separate rocksdb for cells 

### DIFF
--- a/core/src/storage/db.rs
+++ b/core/src/storage/db.rs
@@ -7,6 +7,7 @@ use weedb::{MigrationError, Semver, VersionProvider, WeeDb};
 use super::tables;
 
 pub type CoreDb = WeeDb<CoreTables>;
+pub type CellsDb = WeeDb<CellsTables>;
 
 pub trait CoreDbExt {
     fn normalize_version(&self) -> anyhow::Result<()>;
@@ -33,14 +34,40 @@ impl CoreDbExt for CoreDb {
         }
 
         // Set the initial version
-        tracing::warn!("normalizing DB version");
+        tracing::warn!("normalizing DB version for core");
+        provider.set_version(self.raw(), [0, 0, 1])?;
+        Ok(())
+    }
+}
+
+impl CoreDbExt for CellsDb {
+    fn normalize_version(&self) -> anyhow::Result<()> {
+        let provider = CellsTables::new_version_provider();
+
+        // Check if there is NO VERSION
+        if provider.get_version(self.raw())?.is_some() {
+            return Ok(());
+        }
+
+        // Check if the DB is NOT EMPTY
+        {
+            let mut cells_iter = self.cells.raw_iterator();
+            cells_iter.seek_to_first();
+            cells_iter.status()?;
+            if cells_iter.item().is_none() {
+                return Ok(());
+            }
+        }
+
+        // Set the initial version
+        tracing::warn!("normalizing DB version for cells");
         provider.set_version(self.raw(), [0, 0, 1])?;
         Ok(())
     }
 }
 
 impl NamedTables for CoreTables {
-    const NAME: &'static str = "base";
+    const NAME: &'static str = "core";
 }
 
 impl WithMigrations for CoreTables {
@@ -68,9 +95,37 @@ weedb::tables! {
         pub block_handles: tables::BlockHandles,
         pub key_blocks: tables::KeyBlocks,
         pub full_block_ids: tables::FullBlockIds,
+        pub block_connections: tables::BlockConnections,
+    }
+}
+
+weedb::tables! {
+    pub struct CellsTables<TableContext> {
+        pub state: tables::State,
+
         pub shard_states: tables::ShardStates,
         pub cells: tables::Cells,
         pub temp_cells: tables::TempCells,
-        pub block_connections: tables::BlockConnections,
+    }
+}
+
+impl NamedTables for CellsTables {
+    const NAME: &'static str = "cells";
+}
+
+impl WithMigrations for CellsTables {
+    const VERSION: Semver = [0, 0, 1];
+
+    type VersionProvider = StateVersionProvider<tables::State>;
+
+    fn new_version_provider() -> Self::VersionProvider {
+        StateVersionProvider::new::<Self>()
+    }
+
+    fn register_migrations(
+        _migrations: &mut Migrations<Self::VersionProvider, Self>,
+        _cancelled: CancellationFlag,
+    ) -> Result<(), MigrationError> {
+        Ok(())
     }
 }

--- a/core/src/storage/persistent_state/shard_state/writer.rs
+++ b/core/src/storage/persistent_state/shard_state/writer.rs
@@ -13,10 +13,10 @@ use tycho_util::FastHashMap;
 use tycho_util::compression::ZstdCompressedFile;
 use tycho_util::sync::CancellationFlag;
 
-use crate::storage::CoreDb;
+use crate::storage::CellsDb;
 
 pub struct ShardStateWriter<'a> {
-    db: &'a CoreDb,
+    db: &'a CellsDb,
     states_dir: &'a Dir,
     block_id: &'a BlockId,
 }
@@ -37,7 +37,7 @@ impl<'a> ShardStateWriter<'a> {
         PathBuf::from(block_id.to_string()).with_extension(Self::FILE_EXTENSION_TEMP)
     }
 
-    pub fn new(db: &'a CoreDb, states_dir: &'a Dir, block_id: &'a BlockId) -> Self {
+    pub fn new(db: &'a CellsDb, states_dir: &'a Dir, block_id: &'a BlockId) -> Self {
         Self {
             db,
             states_dir,


### PR DESCRIPTION
Using a separate db for cells reduces locking on the write path and eliminates most cases of tokio blocking.


Data obtained from running transfers 20k for 1h.

| name | tokio total block before | tokio total block after | diff_human |
|:-|:-|:-|:-|
| tycho_core::storage::block::store_block_data | 2 hours and 39 minutes | 58 seconds | 2 hours, 38 minutes and 2 seconds |
| tycho_collator::state_node::store_state_root | 2 hours, 1 minute and 20 seconds | 25 seconds | 2 hours and 55 seconds |
| tycho_core::block_strider::process_shard_blocks | 1 hour, 48 minutes and 43 seconds | 44 seconds | 1 hour, 47 minutes and 59 seconds |
| tycho_core::storage::block::store_block_proof | 40 minutes and 30 seconds | 27 seconds | 40 minutes and 3 seconds |
| tycho_collator::manager::notify_top_processed_to_anchor_to_mempool | 4 minutes and 56 seconds | 1 second | 4 minutes and 55 seconds |
| tycho_core::storage::block::store_queue_diff | 3 minutes and 58 seconds | 2 seconds | 3 minutes and 56 seconds |
| tycho_core::storage::block::blobs::move_into_archive | 1 minute and 55 seconds | 0 seconds | 1 minute and 54 seconds |
| tycho_collator::manager::restore_queue | 1 minute and 42 seconds | 0 seconds | 1 minute and 42 seconds |
| tycho_collator::mempool::impls::std_impl::anchor_handler::handle_mempool_output | 55 seconds | 0 seconds | 55 seconds |
| tycho_core::block_strider::block_saver::save_block | 44 seconds | 0 seconds | 44 seconds |
| tycho_collator::manager::commit_valid_master_block | 37 seconds | 0 seconds | 37 seconds |
| tycho_collator::collator::do_collate::finalize_collation | 38 seconds | 1 second | 37 seconds |
| tycho_core::storage::block::remove_outdated_blocks | 34 seconds | 0 seconds | 33 seconds |
| tycho_core::block_strider::process_mc_block | 26 seconds | 0 seconds | 26 seconds |
| tycho_collator::manager::handle_block_from_bc | 18 seconds | 0 seconds | 18 seconds |