### PR TITLE
chore: fix clippy errors for 1.90

### DIFF
--- a/cli/src/util/mod.rs
+++ b/cli/src/util/mod.rs
@@ -163,7 +163,7 @@ impl std::fmt::Display for FpTokens {
         int.fmt(f)?;
         if frac > 0 {
             let mut len = 9usize;
-            while frac % 10 == 0 && frac > 0 {
+            while frac.is_multiple_of(10) && frac > 0 {
                 len -= 1;
                 frac /= 10;
             }

--- a/collator/src/collator/do_collate/finalize.rs
+++ b/collator/src/collator/do_collate/finalize.rs
@@ -451,13 +451,19 @@ impl Phase<FinalizeState> {
 
         // HACK: make every 3-d block incorrect on debug if env variable defined
         //      use command `RUSTFLAGS="--cfg tycho_unstable" cargo ...` to activate it
-        let version =
-            if cfg!(tycho_unstable) && self.state.collation_data.block_id_short.seqno % 3 == 0 {
-                let val = std::env::var("HACK_MISMATCH_BLOCK_VER").unwrap_or_default();
-                val.parse::<u32>().unwrap_or(0)
-            } else {
-                0
-            };
+        let version = if cfg!(tycho_unstable)
+            && self
+                .state
+                .collation_data
+                .block_id_short
+                .seqno
+                .is_multiple_of(3)
+        {
+            let val = std::env::var("HACK_MISMATCH_BLOCK_VER").unwrap_or_default();
+            val.parse::<u32>().unwrap_or(0)
+        } else {
+            0
+        };
 
         // build block info
         let mut new_block_info = BlockInfo {

--- a/collator/src/collator/tests/messages_reader_tests.rs
+++ b/collator/src/collator/tests/messages_reader_tests.rs
@@ -661,7 +661,11 @@ where
         )?;
 
         // collate master every 3 shard blocks
-        if self.sc_collator.block_seqno % collate_master_every == 0 {
+        if self
+            .sc_collator
+            .block_seqno
+            .is_multiple_of(collate_master_every)
+        {
             let all_shards_processed_to = self.get_all_shards_processed_to_by_partitions();
 
             let TestCollateResult {

--- a/core/src/storage/block/blobs/mod.rs
+++ b/core/src/storage/block/blobs/mod.rs
@@ -629,7 +629,7 @@ impl BlobStorage {
     /// Get a chunk of the archive at the specified offset.
     pub async fn get_archive_chunk(&self, id: u32, offset: u64) -> Result<Bytes> {
         anyhow::ensure!(
-            offset % DEFAULT_CHUNK_SIZE == 0,
+            offset.is_multiple_of(DEFAULT_CHUNK_SIZE),
             BlockStorageError::InvalidOffset {
                 offset,
                 chunk_size: DEFAULT_CHUNK_SIZE,

--- a/core/src/storage/persistent_state/queue_state/writer.rs
+++ b/core/src/storage/persistent_state/queue_state/writer.rs
@@ -147,7 +147,7 @@ impl<'a> QueueStateWriter<'a> {
 
             // Write padding
             const PADDING: [u8; 3] = [0; 3];
-            if total_size % 4 != 0 {
+            if !total_size.is_multiple_of(4) {
                 buffer.write_all(&PADDING[0..4 - (total_size as usize) % 4])?;
             }
         }

--- a/core/src/storage/persistent_state/shard_state/writer.rs
+++ b/core/src/storage/persistent_state/shard_state/writer.rs
@@ -340,7 +340,7 @@ impl<'a> ShardStateWriter<'a> {
                     }
 
                     iteration += 1;
-                    if iteration % 100000 == 0 {
+                    if iteration.is_multiple_of(100000) {
                         tracing::info!(iteration);
                     }
 

--- a/util/src/sync/task.rs
+++ b/util/src/sync/task.rs
@@ -52,7 +52,7 @@ impl DebounceCancellationFlag {
     pub fn check(&mut self) -> bool {
         let mut cancelled = false;
 
-        if self.counter % self.debounce.get() == 0 {
+        if self.counter.is_multiple_of(self.debounce.get()) {
             self.counter = 0;
             cancelled |= self.inner.check();
         }

--- a/util/src/tl.rs
+++ b/util/src/tl.rs
@@ -136,7 +136,7 @@ impl<const MAX_SIZE: usize> BigBytesRef<MAX_SIZE> {
         let len = bytes.len();
         packet.write_u32(len as u32);
         packet.write_raw_slice(bytes);
-        if len % 4 != 0 {
+        if !len.is_multiple_of(4) {
             packet.write_raw_slice(&PADDING[0..4 - len % 4]);
         }
     }


### PR DESCRIPTION
`cargo clippy --all --all-targets --fix`