### PR TITLE
fix(collator): don't apply outdated genesis to restart mempool session

### DIFF
--- a/collator/src/mempool/impls/std_impl.rs
+++ b/collator/src/mempool/impls/std_impl.rs
@@ -83,8 +83,19 @@ impl MempoolAdapterStdImpl {
             );
 
             // when genesis doesn't change - just (re-)schedule v_set change as defined by collator
-            if session.genesis_info() == new_cx.consensus_info.genesis_info {
+            if new_cx.consensus_info.genesis_info == session.genesis_info() {
                 session.set_peers(ConfigAdapter::init_peers(new_cx)?);
+                return Ok(());
+            }
+
+            if !(new_cx.consensus_info.genesis_info).overrides(&session.genesis_info()) {
+                tracing::warn!(
+                    target: tracing_targets::MEMPOOL_ADAPTER,
+                    id = %new_cx.mc_block_id.as_short_id(),
+                    new_cx = ?DebugStateUpdateContext(new_cx),
+                    current = ?session.genesis_info(),
+                    "Ignoring new genesis: it does not override current, node state was deleted?",
+                );
                 return Ok(());
             }
 


### PR DESCRIPTION
After node state was deleted, node should not apply latest key block on top of newer genesis from global config

## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

None

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

None

---

### COMPATIBILITY

Full

### SPECIAL DEPLOYMENT ACTIONS

Not Required

---

### PERFORMANCE IMPACT

No impact expected

---

### TESTS

#### Unit Tests

No coverage

#### Network Tests

No coverage

#### Manual Tests

Stop the node, delete block state, apply new genesis, start the node