### PR TITLE
fix(block-util): revert workchain range check for `ExtMsgRepr`

### DIFF
--- a/core/src/block_strider/starter/cold_boot.rs
+++ b/core/src/block_strider/starter/cold_boot.rs
@@ -8,7 +8,6 @@ use futures_util::StreamExt;
 use tokio::sync::mpsc;
 use tycho_block_util::archive::{ArchiveData, WithArchiveData};
 use tycho_block_util::block::{BlockProofStuff, BlockProofStuffAug, BlockStuff};
-use tycho_block_util::message::ExtMsgRepr;
 use tycho_block_util::queue::QueueDiffStuff;
 use tycho_block_util::state::{MinRefMcStateTracker, ShardStateStuff};
 use tycho_storage::fs::FileBuilder;
@@ -26,7 +25,7 @@ use crate::overlay_client::PunishReason;
 use crate::proto::blockchain::KeyBlockProof;
 use crate::storage::{
     BlockHandle, CoreStorage, KeyBlocksDirection, MaybeExistingHandle, NewBlockMeta,
-    PersistentStateKind, ShardStateStorage,
+    PersistentStateKind,
 };
 
 impl StarterInner {
@@ -91,34 +90,6 @@ impl StarterInner {
         );
 
         Ok(last_mc_block_id)
-    }
-
-    #[tracing::instrument(skip_all)]
-    pub async fn init_allowed_workchains(
-        shard_state_storage: &ShardStateStorage,
-        last_mc_block_id: &BlockId,
-    ) -> Result<()> {
-        let mc_state = shard_state_storage
-            .load_state(last_mc_block_id.seqno, last_mc_block_id)
-            .await?;
-
-        let config = mc_state.config_params()?;
-
-        let mut allowed_workchains = vec![-1];
-        for item in config.get_workchains()?.iter() {
-            let (w_id, _) = item?;
-            allowed_workchains.push(w_id.try_into().expect("workchain id cannot be out of i8"));
-        }
-
-        tracing::info!(
-            last_mc_block_id = %last_mc_block_id,
-            ?allowed_workchains,
-            "init",
-        );
-
-        ExtMsgRepr::set_allowed_workchains(allowed_workchains)?;
-
-        Ok(())
     }
 
     // === Sync steps ===

--- a/core/src/block_strider/starter/mod.rs
+++ b/core/src/block_strider/starter/mod.rs
@@ -15,7 +15,7 @@ use tycho_util::serde_helpers;
 
 use crate::blockchain_rpc::BlockchainRpcClient;
 use crate::global_config::ZerostateId;
-use crate::storage::{CoreStorage, QueueStateReader, ShardStateStorage};
+use crate::storage::{CoreStorage, QueueStateReader};
 
 mod cold_boot;
 
@@ -161,13 +161,6 @@ impl Starter {
         P: ZerostateProvider,
     {
         self.inner.cold_boot(boot_type, zerostate_provider).await
-    }
-
-    pub async fn init_allowed_workchains(
-        shard_state_storage: &ShardStateStorage,
-        last_mc_block_id: &BlockId,
-    ) -> Result<()> {
-        StarterInner::init_allowed_workchains(shard_state_storage, last_mc_block_id).await
     }
 }
 

--- a/core/src/node/mod.rs
+++ b/core/src/node/mod.rs
@@ -111,9 +111,6 @@ impl NodeBase {
             }
         };
 
-        let shard_state = self.core_storage.shard_state_storage();
-        Starter::init_allowed_workchains(shard_state, &last_mc_block_id).await?;
-
         tracing::info!(
             %last_mc_block_id,
             "boot finished"

--- a/core/tests/overlay_server.rs
+++ b/core/tests/overlay_server.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use anyhow::Result;
 use tycho_block_util::block::{BlockProofStuff, BlockStuff};
-use tycho_block_util::message::ExtMsgRepr;
 use tycho_block_util::queue::QueueDiffStuff;
 use tycho_block_util::state::ShardStateStuff;
 use tycho_core::blockchain_rpc::{
@@ -28,8 +27,6 @@ mod utils;
 #[tokio::test]
 async fn overlay_server_msg_broadcast() -> Result<()> {
     tycho_util::test::init_logger("overlay_server_msg_broadcast", "info");
-
-    let _ = ExtMsgRepr::set_allowed_workchains(vec![-1, 0]);
 
     #[derive(Default, Clone)]
     struct BroadcastCounter {

--- a/light-node/src/cli.rs
+++ b/light-node/src/cli.rs
@@ -275,9 +275,6 @@ impl<C> Node<C> {
             }
         };
 
-        let shard_state = self.storage.shard_state_storage();
-        Starter::init_allowed_workchains(shard_state, &last_mc_block_id).await?;
-
         tracing::info!(
             %last_mc_block_id,
             "boot finished"


### PR DESCRIPTION
It adds useless complexity and is still insufficient this way.