### PR TITLE
fix(cli): fix parsing of wins/losses and config params

### DIFF
--- a/cli/src/util/config.rs
+++ b/cli/src/util/config.rs
@@ -146,8 +146,8 @@ pub struct ConfigProposal {
     pub voters: Vec<u16>,
     pub weight_remaining: i64,
     pub rounds_remaining: u8,
-    pub losses: u8,
     pub wins: u8,
+    pub losses: u8,
 }
 
 impl ConfigProposal {
@@ -204,8 +204,8 @@ impl FromStackValue for ConfigProposal {
             voters: tuple.read_next().map(LispList::into_inner)?,
             weight_remaining: tuple.read_next()?,
             rounds_remaining: tuple.read_next()?,
-            losses: tuple.read_next()?,
             wins: tuple.read_next()?,
+            losses: tuple.read_next()?,
         })
     }
 }


### PR DESCRIPTION
- Config proposal fields `wins` and `losses` were mixed up;
- `parsed` field in proposals list was always set even when the parameter is actually unknown;
- We now parse only the required parameter in `get-param` to allow partial updates for some models without breaking the whole tool.