### PR TITLE
fix(contracts): properly reset election flags on each new stake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
       shell: ${{ steps.filter.outputs.shell }}
       proto: ${{ steps.filter.outputs.proto }}
+      contracts: ${{ steps.filter.outputs.contracts }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -46,6 +47,8 @@ jobs:
               - '**.sh'
             proto:
               - '**.proto'
+            contracts:
+              - 'contracts/**'
   rustfmt:
     name: Rustfmt
     needs: changes
@@ -139,6 +142,27 @@ jobs:
         env:
           RUST_LOG: warn
         run: just run_integration_tests
+
+  contracts-tests:
+    name: Contracts Tests
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.contracts == 'true' }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: '22'
+          cache: 'yarn'
+          cache-dependency-path: contracts/yarn.lock
+      - name: Install contracts dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: contracts
+      - name: Run contracts tests
+        run: yarn test
+        working-directory: contracts
 
   metrics:
     name: Metrics

--- a/contracts/src/elector-base.tolk
+++ b/contracts/src/elector-base.tolk
@@ -48,6 +48,12 @@ struct Storage<T> {
     customData: T
 }
 
+/// Loads C4 and returns `true` if current election is set.
+fun Storage<T>.hasCurrentElection(): bool {
+    val data = lazy Storage<T>.load();
+    return data.currentElection != null;
+}
+
 /// Loads C4 and parses it into a typed struct.
 fun Storage<T>.load(): Storage<T> {
     return Storage<T>.fromCell(contract.getData());
@@ -259,7 +265,10 @@ get fun past_election_ids(): tuple {
 /// - currentElection
 /// - pastElections
 /// - credits
-fun conductElection<T>(data: Storage<T>, election: Election): bool {
+fun conductElection<T>(): bool {
+    var data = lazy Storage<T>.load();
+    var election = lazy data.currentElection!.load();
+
     if (blockchain.now() < election.electClose) {
         // Election not finished yet.
         return false;
@@ -567,7 +576,10 @@ fun computeTotalStake(allStakes: tuple, n: int, lowestStake: coins): coins {
 /// - grams
 /// - activeId
 /// - activeHash
-fun syncElectionWithVset<T>(data: Storage<T>, election: Election): bool {
+fun syncElectionWithVset<T>(): bool {
+    var data = lazy Storage<T>.load();
+    var election = lazy data.currentElection!.load();
+
     if (!election.finished) {
         // Election not finished yet.
         return false;
@@ -591,7 +603,7 @@ fun syncElectionWithVset<T>(data: Storage<T>, election: Election): bool {
         data.currentElection = null;
         data.save();
 
-        updateActiveVsetId(data);
+        updateActiveVsetId<T>();
         return true;
     }
 
@@ -608,7 +620,7 @@ fun syncElectionWithVset<T>(data: Storage<T>, election: Election): bool {
 ///
 /// Mutates persistent storage fields:
 /// - currentElection
-fun announceNewElection<T>(data: Storage<T>): bool {
+fun announceNewElection<T>(): bool {
     if (blockchain.configParam(PARAM_IDX_NEXT_VSET) != null) {
         // Next validator set exists, no election needed.
         return false;
@@ -649,6 +661,7 @@ fun announceNewElection<T>(data: Storage<T>): bool {
     val electAt = t + timingsConfig.electionsBeginBefore;
     val electClose = electAt - timingsConfig.electionsEndBefore;
 
+    var data = lazy Storage<T>.load();
     data.currentElection = Election {
         electAt,
         electClose,
@@ -678,7 +691,9 @@ fun announceNewElection<T>(data: Storage<T>): bool {
 /// - grams
 /// - activeId
 /// - activeHash
-fun updateActiveVsetId<T>(data: Storage<T>): bool {
+fun updateActiveVsetId<T>(): bool {
+    var data = lazy Storage<T>.load();
+
     val currentVsetHash = blockchain.configParam(PARAM_IDX_CURRENT_VSET)!.hash();
     if (currentVsetHash == data.activeHash) {
         // Validator set unchanged.
@@ -746,7 +761,9 @@ fun updateActiveVsetId<T>(data: Storage<T>): bool {
 /// - credits
 /// - pastElections
 /// - grams
-fun checkUnfreeze<T>(data: Storage<T>): bool {
+fun checkUnfreeze<T>(): bool {
+    var data = lazy Storage<T>.load();
+
     var iterNext = -1;
     do {
         var (id, cs, found) = data.pastElections.uDictGetNext(32, iterNext);
@@ -913,6 +930,10 @@ fun processNewStakeImpl<T>(source: address, value: coins, body: slice): int {
         adnlAddr,
     };
     election.participants.uDictSetBuilder(256, pubkey, beginCell().storeAny(participant));
+
+    // NOTE: Always reset `failed` flag on each new stake so that the elector
+    // can try to conduct election again in the next tick-tock transaction.
+    election.failed = false;
 
     // Update storage.
     data.currentElection = election.toCell();

--- a/contracts/src/elector-poa.tolk
+++ b/contracts/src/elector-poa.tolk
@@ -27,37 +27,33 @@ struct PoAData {
 //
 /// Sync state at the beginning and end of the masterchain block.
 fun onRunTickTock(_isTock: bool) {
-    var data = lazy Storage<PoAData>.load();
-    if (data.currentElection != null) {
-        // Sync current election state if there is any.
-        var election: Election = data.currentElection!.load();
-
+    if (Storage<PoAData>.hasCurrentElection()) {
         // Try to form a new vset.
-        if (conductElection(data, election)) {
+        if (conductElection<PoAData>()) {
             // New vset formed. Wait for a new transaction.
             return;
         }
 
         // Check that `currentElection` vset was installed.
-        if (syncElectionWithVset(data, election)) {
+        if (syncElectionWithVset<PoAData>()) {
             // Validator set installed. Wait for a new transaction.
             return;
         }
     } else {
         // Otherwise try to start a new election.
-        if (announceNewElection(data)) {
+        if (announceNewElection<PoAData>()) {
             // New election started. Wait for a new transaction.
             return;
         }
     }
 
     // Sync current validator set info.
-    if (updateActiveVsetId(data)) {
+    if (updateActiveVsetId<PoAData>()) {
         return; // active validator set id updated, exit
     }
 
     // Unfreeze stakes if any.
-    checkUnfreeze(data);
+    checkUnfreeze<PoAData>();
 }
 
 //

--- a/contracts/src/elector.tolk
+++ b/contracts/src/elector.tolk
@@ -10,37 +10,33 @@ struct NoData {}
 //
 /// Sync state at the beginning and end of the masterchain block.
 fun onRunTickTock(_isTock: bool) {
-    var data = lazy Storage<NoData>.load();
-    if (data.currentElection != null) {
-        // Sync current election state if there is any.
-        var election: Election = data.currentElection!.load();
-
+    if (Storage<NoData>.hasCurrentElection()) {
         // Try to form a new vset.
-        if (conductElection(data, election)) {
+        if (conductElection<NoData>()) {
             // New vset formed. Wait for a new transaction.
             return;
         }
 
         // Check that `currentElection` vset was installed.
-        if (syncElectionWithVset(data, election)) {
+        if (syncElectionWithVset<NoData>()) {
             // Validator set installed. Wait for a new transaction.
             return;
         }
     } else {
         // Otherwise try to start a new election.
-        if (announceNewElection(data)) {
+        if (announceNewElection<NoData>()) {
             // New election started. Wait for a new transaction.
             return;
         }
     }
 
     // Sync current validator set info.
-    if (updateActiveVsetId(data)) {
+    if (updateActiveVsetId<NoData>()) {
         return; // active validator set id updated, exit
     }
 
     // Unfreeze stakes if any.
-    checkUnfreeze(data);
+    checkUnfreeze<NoData>();
 }
 
 //


### PR DESCRIPTION
- Previously, when election failed, it was impossible to change anything after that because there was no flag reset in the stake handler.
- There were some unneeded `data` overwrites in the tick-tock handler. Without them contract behavior is closer to the original one, and the resulting code is smaller.