### PR TITLE
fix(consensus): hang at config change

### DIFF
--- a/consensus/src/engine/impl_.rs
+++ b/consensus/src/engine/impl_.rs
@@ -355,6 +355,10 @@ impl Engine {
             start_span.in_scope(|| tracing::warn!("mempool engine run stopped"));
         });
         let mut round_ctx = RoundCtx::new(&self.ctx, self.dag.top().round());
+        self.round_task.state.init_responder(
+            &self.dag.head(&self.round_task.state.peer_schedule), // reproducible first loop
+            &round_ctx,
+        );
         let db_clean_task: Task<Never> = self.db_cleaner.new_task(
             self.round_task.state.consensus_round.receiver(),
             self.round_task.state.top_known_anchor.receiver(),

--- a/consensus/src/engine/round_task.rs
+++ b/consensus/src/engine/round_task.rs
@@ -30,6 +30,20 @@ pub struct RoundTaskState {
     pub responder: Responder,
     pub downloader: Downloader,
 }
+impl RoundTaskState {
+    pub fn init_responder(&self, head: &DagHead, round_ctx: &RoundCtx) {
+        self.responder.init(
+            &self.store,
+            &self.consensus_round,
+            &self.peer_schedule,
+            &self.downloader,
+            head,
+            round_ctx,
+            #[cfg(feature = "mock-feedback")]
+            &self.top_known_anchor,
+        );
+    }
+}
 
 pub struct RoundTaskReady {
     pub state: RoundTaskState,
@@ -53,14 +67,6 @@ impl RoundTaskReady {
             &net.peer_schedule,
             consensus_round.receiver(),
             conf,
-        );
-        net.responder.init(
-            store,
-            consensus_round,
-            &net.peer_schedule,
-            &downloader,
-            #[cfg(feature = "mock-feedback")]
-            &bind.top_known_anchor,
         );
         Self {
             state: RoundTaskState {

--- a/consensus/src/intercom/core/responder.rs
+++ b/consensus/src/intercom/core/responder.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 use std::time::Instant;
 
 use arc_swap::ArcSwapOption;
@@ -7,32 +7,24 @@ use futures_util::{FutureExt, future};
 use tycho_network::{Response, Service, ServiceRequest};
 
 use crate::dag::DagHead;
-use crate::effects::{AltFormat, RoundCtx};
+use crate::effects::{AltFormat, Ctx, RoundCtx};
 use crate::engine::round_watch::{Consensus, RoundWatch};
 use crate::intercom::broadcast::Signer;
-use crate::intercom::core::{
-    PointByIdResponse, QueryRequest, QueryRequestRaw, QueryRequestTag, QueryResponse,
-    SignatureResponse,
-};
+use crate::intercom::core::{QueryRequest, QueryRequestRaw, QueryResponse};
 use crate::intercom::{BroadcastFilter, Downloader, PeerSchedule, Uploader};
 use crate::storage::MempoolStore;
 
 #[derive(Clone, Default)]
-pub struct Responder(Arc<ResponderInner>);
+pub struct Responder(Arc<ArcSwapOption<ResponderInner>>);
 
-#[derive(Default)]
 struct ResponderInner {
-    state: OnceLock<ResponderState>,
-    broadcast_filter: BroadcastFilter,
-    current: ArcSwapOption<ResponderCurrent>,
-}
-
-struct ResponderCurrent {
+    state: Arc<ResponderState>,
     head: DagHead,
     round_ctx: RoundCtx,
 }
 
 struct ResponderState {
+    broadcast_filter: BroadcastFilter,
     // state and storage components go here
     store: MempoolStore,
     consensus_round: RoundWatch<Consensus>,
@@ -43,39 +35,56 @@ struct ResponderState {
 }
 
 impl Responder {
+    #[allow(clippy::too_many_arguments)]
     pub fn init(
         &self,
         store: &MempoolStore,
         consensus_round: &RoundWatch<Consensus>,
         peer_schedule: &PeerSchedule,
         downloader: &Downloader,
+        head: &DagHead,
+        round_ctx: &RoundCtx,
         #[cfg(feature = "mock-feedback")] top_known_anchor: &RoundWatch<
             crate::engine::round_watch::TopKnownAnchor,
         >,
     ) {
-        let result = self.0.state.set(ResponderState {
+        let state = ResponderState {
+            broadcast_filter: BroadcastFilter::default(),
             store: store.clone(),
             consensus_round: consensus_round.clone(),
             peer_schedule: peer_schedule.clone(),
             downloader: downloader.clone(),
             #[cfg(feature = "mock-feedback")]
             top_known_anchor: top_known_anchor.clone(),
-        });
-        result.ok().expect("cannot init responder twice");
+        };
+        let old = self.0.swap(Some(Arc::new(ResponderInner {
+            state: Arc::new(state),
+            head: head.clone(),
+            round_ctx: round_ctx.clone(),
+        })));
+        assert!(old.is_none(), "cannot init responder twice");
     }
 
     /// as `Self` is passed to Overlay as a `Service` and may be cloned there,
     /// free `DagHead` and other resources upon `Engine` termination
     pub fn dispose(&self) {
-        self.0.current.store(None);
+        self.0.store(None);
     }
 
     pub fn update(&self, head: &DagHead, round_ctx: &RoundCtx) {
-        let state = self.0.state.get().expect("responder must be init");
+        let Some(inner) = self.0.load_full() else {
+            tracing::warn!(
+                parent: round_ctx.span(),
+                "cannot update Responder: not init or already disposed"
+            );
+            return;
+        };
+        let state = &inner.state;
         // Note: Signer must see DAG rounds completely flushed from BroadcastFilter,
         //  its OK if Signer uses outdated DagHead and doesn't see the DAG up to the latest top
-        (self.0.broadcast_filter).flush_to_dag(head, &state.downloader, &state.store, round_ctx);
-        self.0.current.store(Some(Arc::new(ResponderCurrent {
+        (state.broadcast_filter).flush_to_dag(head, &state.downloader, &state.store, round_ctx);
+        self.0.store(Some(Arc::new(ResponderInner {
+            state: state.clone(),
             head: head.clone(),
             round_ctx: round_ctx.clone(),
         })));
@@ -89,7 +98,10 @@ impl Service<ServiceRequest> for Responder {
 
     #[inline]
     fn on_query(&self, req: ServiceRequest) -> Self::OnQueryFuture {
-        self.clone().handle_query(req).boxed()
+        match self.0.load_full() {
+            Some(inner) => inner.handle_query(req).boxed(),
+            None => futures_util::future::ready(None).boxed(),
+        }
     }
 
     #[inline]
@@ -98,24 +110,30 @@ impl Service<ServiceRequest> for Responder {
         {
             use crate::mock_feedback::RoundBoxed;
             if let Ok(data) = _req.parse_tl::<RoundBoxed>()
-                && let Some(state) = self.0.state.get()
+                && let Some(inner) = self.0.load_full()
             {
-                state.top_known_anchor.set_max(data.round);
+                inner.state.top_known_anchor.set_max(data.round);
             }
         }
         future::ready(())
     }
 }
 
-impl Responder {
-    async fn handle_query(self, req: ServiceRequest) -> Option<Response> {
+impl ResponderInner {
+    async fn handle_query(self: Arc<Self>, req: ServiceRequest) -> Option<Response> {
         let task_start = Instant::now();
+        let ResponderInner {
+            state,
+            head,
+            round_ctx,
+        } = self.as_ref();
+        let peer_id = &req.metadata.peer_id;
 
         let raw_query = match QueryRequestRaw::new(req.body) {
             Ok(wrapper) => wrapper,
             Err(error) => {
                 tracing::error!(
-                    peer_id = display(req.metadata.peer_id.alt()),
+                    peer_id = display(peer_id.alt()),
                     %error,
                     "unexpected query",
                 );
@@ -129,7 +147,7 @@ impl Responder {
             Err(error) => {
                 tracing::error!(
                     tag = ?raw_query_tag,
-                    peer_id = display(req.metadata.peer_id.alt()),
+                    peer_id = display(peer_id.alt()),
                     %error,
                     "bad query",
                 );
@@ -137,33 +155,16 @@ impl Responder {
             }
         };
 
-        let Some(current) = self.0.current.load_full() else {
-            return Some(match raw_query_tag {
-                QueryRequestTag::Broadcast => {
-                    // do nothing: sender has retry loop via signature request
-                    QueryResponse::broadcast(task_start)
-                }
-                QueryRequestTag::PointById => {
-                    QueryResponse::point_by_id::<&[u8]>(task_start, PointByIdResponse::TryLater)
-                }
-                QueryRequestTag::Signature => {
-                    QueryResponse::signature(task_start, SignatureResponse::TryLater)
-                }
-            });
-        };
-
-        let state = self.0.state.get().expect("responder must be init");
-
         Some(match query {
             QueryRequest::Broadcast(point) => {
-                let reached_threshold = self.0.broadcast_filter.add_check_threshold(
-                    &req.metadata.peer_id,
+                let reached_threshold = state.broadcast_filter.add_check_threshold(
+                    peer_id,
                     &point,
                     &state.store,
                     &state.peer_schedule,
                     &state.downloader,
-                    &current.head,
-                    &current.round_ctx,
+                    head,
+                    round_ctx,
                 );
                 if reached_threshold {
                     // notify Collector after max consensus round is updated
@@ -171,34 +172,23 @@ impl Responder {
                     // round is determined, so clean history;
                     // do not flush to DAG as it may have no needed rounds yet
                     if state.consensus_round.get() == point.info().round() {
-                        self.0.broadcast_filter.clean(
-                            point.info().round(),
-                            &current.head,
-                            &current.round_ctx,
-                        );
+                        (state.broadcast_filter).clean(point.info().round(), head, round_ctx);
                     } // else: engine is not paused, let it do its work
                 }
                 QueryResponse::broadcast(task_start)
             }
             QueryRequest::PointById(point_id) => QueryResponse::point_by_id(
                 task_start,
-                Uploader::find(
-                    &req.metadata.peer_id,
-                    point_id,
-                    &state.store,
-                    &current.head,
-                    &current.round_ctx,
-                )
-                .await,
+                Uploader::find(peer_id, point_id, &state.store, head, round_ctx).await,
             ),
             QueryRequest::Signature(round) => QueryResponse::signature(
                 task_start,
                 Signer::signature_response(
-                    &req.metadata.peer_id,
+                    peer_id,
                     round,
-                    &self.0.broadcast_filter,
-                    &current.head,
-                    &current.round_ctx,
+                    &state.broadcast_filter,
+                    head,
+                    round_ctx,
                 ),
             ),
         })


### PR DESCRIPTION
Also `just mempool ..` hanged at Ctrl+C so it had to be killed with -9.

## Pull Request Checklist

None

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

None

### COMPATIBILITY

Full

### SPECIAL DEPLOYMENT ACTIONS

Not Required

---

### PERFORMANCE IMPACT

No impact expected

---

### TESTS

#### Unit Tests

No coverage

#### Network Tests

No coverage

#### Manual Tests

`just mempool 1 --restarts 3`

**Notes/Additional Comments:**  

Bug was introduced in https://github.com/broxus/tycho/pull/919 so released versions are not affected.