### PR TITLE
fix(ci): check built metrics chart

### DIFF
--- a/.github/scripts/post_network_test_instructions.py
+++ b/.github/scripts/post_network_test_instructions.py
@@ -13,29 +13,25 @@ from typing import Optional, Dict, Any, List
 
 def get_github_context() -> Dict[str, Any]:
     """Get GitHub context from environment variables."""
-    github_token = os.getenv('GITHUB_TOKEN')
-    github_repository = os.getenv('GITHUB_REPOSITORY')
-    github_event_path = os.getenv('GITHUB_EVENT_PATH')
-    
+    github_token = os.getenv("GITHUB_TOKEN")
+    github_repository = os.getenv("GITHUB_REPOSITORY")
+    github_event_path = os.getenv("GITHUB_EVENT_PATH")
+
     if not all([github_token, github_repository, github_event_path]):
         raise ValueError("Missing required GitHub environment variables")
-    
-    with open(github_event_path, 'r') as f:
+
+    with open(github_event_path, "r") as f:
         event_data = json.load(f)
-    
-    return {
-        'token': github_token,
-        'repository': github_repository,
-        'event': event_data
-    }
+
+    return {"token": github_token, "repository": github_repository, "event": event_data}
 
 
 def get_pr_number(event_data: Dict[str, Any]) -> int:
     """Extract PR number from GitHub event data."""
-    if 'pull_request' in event_data:
-        return event_data['pull_request']['number']
-    elif 'number' in event_data:
-        return event_data['number']
+    if "pull_request" in event_data:
+        return event_data["pull_request"]["number"]
+    elif "number" in event_data:
+        return event_data["number"]
     else:
         raise ValueError("Unable to determine PR number from event data")
 
@@ -43,29 +39,54 @@ def get_pr_number(event_data: Dict[str, Any]) -> int:
 def get_test_names_from_yaml() -> List[str]:
     """Extract test names from network-tests.yml workflow file."""
     try:
-        workflow_path = os.path.join(os.path.dirname(__file__), '..', 'workflows', 'network-tests.yml')
-        with open(workflow_path, 'r') as f:
+        workflow_path = os.path.join(
+            os.path.dirname(__file__), "..", "workflows", "network-tests.yml"
+        )
+        with open(workflow_path, "r") as f:
             workflow_data = yaml.safe_load(f)
-        
-        matrix_include = workflow_data.get('jobs', {}).get('network-tests', {}).get('strategy', {}).get('matrix', {}).get('include', [])
-        test_names = [item.get('test_name') for item in matrix_include if item.get('test_name')]
-        
+
+        matrix_include = (
+            workflow_data.get("jobs", {})
+            .get("network-tests", {})
+            .get("strategy", {})
+            .get("matrix", {})
+            .get("include", [])
+        )
+        test_names = [
+            item.get("test_name") for item in matrix_include if item.get("test_name")
+        ]
+
         if not test_names:
             # Fallback to hardcoded list if parsing fails
-            return ['destroyable', 'ping-pong', 'one-to-many-internal-messages', 'fq-deploy', 'nft-index']
-        
+            return [
+                "destroyable",
+                "ping-pong",
+                "one-to-many-internal-messages",
+                "fq-deploy",
+                "nft-index",
+            ]
+
         return test_names
     except Exception as e:
-        print(f"Warning: Could not parse test names from YAML, using fallback: {e}", file=sys.stderr)
+        print(
+            f"Warning: Could not parse test names from YAML, using fallback: {e}",
+            file=sys.stderr,
+        )
         # Fallback to hardcoded list if parsing fails
-        return ['destroyable', 'ping-pong', 'one-to-many-internal-messages', 'fq-deploy', 'nft-index']
+        return [
+            "destroyable",
+            "ping-pong",
+            "one-to-many-internal-messages",
+            "fq-deploy",
+            "nft-index",
+        ]
 
 
 def create_comment_body(pr_number: int) -> str:
     """Create the comment body with network test instructions."""
     test_names = get_test_names_from_yaml()
-    test_types_str = ', '.join(f'`{name}`' for name in test_names)
-    
+    test_types_str = ", ".join(f"`{name}`" for name in test_names)
+
     return f"""## 🧪 Network Tests
 
 To run network tests for this PR, use:
@@ -82,49 +103,56 @@ gh workflow run network-tests.yml -f pr_number={pr_number}
 Results will be posted as workflow runs in the Actions tab."""
 
 
-def find_existing_comment(github_token: str, repo: str, pr_number: int) -> Optional[int]:
+def find_existing_comment(
+    github_token: str, repo: str, pr_number: int
+) -> Optional[int]:
     """Find existing network test instructions comment."""
     url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
     headers = {
-        'Authorization': f'token {github_token}',
-        'Accept': 'application/vnd.github.v3+json'
+        "Authorization": f"token {github_token}",
+        "Accept": "application/vnd.github.v3+json",
     }
-    
+
     response = requests.get(url, headers=headers)
     response.raise_for_status()
-    
+
     comments = response.json()
-    
+
     for comment in comments:
-        if (comment.get('user', {}).get('type') == 'Bot' and 
-            '🧪 Network Tests' in comment.get('body', '')):
-            return comment['id']
-    
+        if comment.get("user", {}).get(
+            "type"
+        ) == "Bot" and "🧪 Network Tests" in comment.get("body", ""):
+            return comment["id"]
+
     return None
 
 
-def post_or_update_comment(github_token: str, repo: str, pr_number: int, body: str) -> None:
+def post_or_update_comment(
+    github_token: str, repo: str, pr_number: int, body: str
+) -> None:
     """Post new comment or update existing one."""
     headers = {
-        'Authorization': f'token {github_token}',
-        'Accept': 'application/vnd.github.v3+json'
+        "Authorization": f"token {github_token}",
+        "Accept": "application/vnd.github.v3+json",
     }
-    
+
     existing_comment_id = find_existing_comment(github_token, repo, pr_number)
-    
+
     if existing_comment_id:
         # Update existing comment
-        url = f"https://api.github.com/repos/{repo}/issues/comments/{existing_comment_id}"
-        data = {'body': body}
+        url = (
+            f"https://api.github.com/repos/{repo}/issues/comments/{existing_comment_id}"
+        )
+        data = {"body": body}
         response = requests.patch(url, headers=headers, json=data)
         print(f"Updated existing comment {existing_comment_id}")
     else:
         # Create new comment
         url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
-        data = {'body': body}
+        data = {"body": body}
         response = requests.post(url, headers=headers, json=data)
         print(f"Created new comment on PR {pr_number}")
-    
+
     response.raise_for_status()
 
 
@@ -132,24 +160,21 @@ def main():
     """Main function."""
     try:
         context = get_github_context()
-        pr_number = get_pr_number(context['event'])
-        
+        pr_number = get_pr_number(context["event"])
+
         print(f"Processing PR #{pr_number}")
-        
+
         comment_body = create_comment_body(pr_number)
         post_or_update_comment(
-            context['token'],
-            context['repository'],
-            pr_number,
-            comment_body
+            context["token"], context["repository"], pr_number, comment_body
         )
-        
+
         print("Successfully posted network test instructions")
-        
+
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       shell: ${{ steps.filter.outputs.shell }}
       proto: ${{ steps.filter.outputs.proto }}
       contracts: ${{ steps.filter.outputs.contracts }}
+      python: ${{ steps.filter.outputs.python }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -49,6 +50,24 @@ jobs:
               - '**.proto'
             contracts:
               - 'contracts/**'
+            python:
+              - '**.py'
+
+  python-format:
+    name: Python Format
+    needs: changes
+    if: ${{ needs.changes.outputs.python == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2
+      - name: Check Python formatting
+        run: just check_format_py
   rustfmt:
     name: Rustfmt
     needs: changes
@@ -212,9 +231,9 @@ jobs:
       - name: Install protobuf
         run: sudo apt update && sudo apt-get -y install protobuf-compiler
       - name: Update RPC proto
-        run: just update_rpc_proto
-      - name: Check for uncommitted changes
-        run: git diff --exit-code
+        run: |
+          just update_rpc_proto
+          git diff --exit-code
 
   check-cli-reference:
     name: Check CLI Reference
@@ -227,6 +246,45 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/init
       - name: Update CLI reference
-        run: just update_cli_reference
-      - name: Check for uncommitted changes
-        run: git diff --exit-code
+        run: |
+          just update_cli_reference
+          git diff --exit-code
+
+  ci-failure-comment:
+    name: CI Failure Comment
+    needs:
+      - python-format
+      - check-protos
+      - check-cli-reference
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Post combined failure comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          messages=()
+          if [ "${{ needs.python-format.result }}" = "failure" ]; then
+            messages+=($'❌ Python formatting check failed in CI.\n\nPlease run `just fmt_py` locally and push the updated files.')
+          fi
+          if [ "${{ needs.check-protos.result }}" = "failure" ]; then
+            messages+=($'❌ RPC proto check failed in CI.\n\nPlease run `just update_rpc_proto`, ensure `protoc` is installed, then commit the generated changes.')
+          fi
+          if [ "${{ needs.check-cli-reference.result }}" = "failure" ]; then
+            messages+=($'❌ CLI reference check failed in CI.\n\nPlease run `just update_cli_reference`, add the updated docs/cli-reference.md, and push the changes.')
+          fi
+
+          if [ ${#messages[@]} -eq 0 ]; then
+            echo "No tracked failures; skipping comment."
+            exit 0
+          fi
+
+          body=$(printf '%s\n\n' "${messages[@]}")
+          gh pr comment "$PR_NUMBER" --body "$body"

--- a/justfile
+++ b/justfile
@@ -72,7 +72,7 @@ test_cov:
     fi
 
 check_dashboard:
-    /usr/bin/env python ./scripts/check-metrics.py
+    ./scripts/run-py.sh ./scripts/check-metrics.py
 
 # Generates a Grafana panel JSON.
 gen_dashboard:
@@ -81,6 +81,12 @@ gen_dashboard:
         ./scripts/install-python-deps.sh
     fi
     /usr/bin/env python ./scripts/gen-dashboard.py
+
+fmt_py:
+    ./scripts/run-py.sh -m ruff format .
+
+check_format_py:
+    ./scripts/run-py.sh -m ruff format --check .
 
 update_rpc_proto:
     cargo run -p tycho-gen-protos

--- a/scripts/gen-dashboard.py
+++ b/scripts/gen-dashboard.py
@@ -35,10 +35,6 @@ from grafanalib.core import (
 )
 
 
-# todo: do something with this metrics
-# tycho_core_last_mc_block_applied
-
-
 def heatmap_color_warm() -> HeatmapColor:
     return HeatmapColor()
 
@@ -598,10 +594,12 @@ def core_blockchain_rpc_general() -> RowPanel:
             "Current score per peer",
         ),
         create_counter_panel(
-            "tycho_core_overlay_client_neighbour_total_requests", "Number of total requests per peer"
+            "tycho_core_overlay_client_neighbour_total_requests",
+            "Number of total requests per peer",
         ),
         create_counter_panel(
-            "tycho_core_overlay_client_neighbour_failed_requests", "Number of failed requests per peer"
+            "tycho_core_overlay_client_neighbour_failed_requests",
+            "Number of failed requests per peer",
         ),
     ]
     return create_row("blockchain: RPC - General Stats", metrics)
@@ -651,8 +649,8 @@ def util_reclaimer() -> RowPanel:
         title="Reclaimer queue length",
         targets=[
             target(
-                "sum by (instance) (tycho_delayed_drop_enqueued{instance=~\"$instance\"}) - sum by (instance) (tycho_delayed_drop_dropped{instance=~\"$instance\"})",
-                legend_format="{{instance}}"
+                'sum by (instance) (tycho_delayed_drop_enqueued{instance=~"$instance"}) - sum by (instance) (tycho_delayed_drop_dropped{instance=~"$instance"})',
+                legend_format="{{instance}}",
             )
         ],
         unit=UNITS.NUMBER_FORMAT,
@@ -924,7 +922,7 @@ def storage() -> RowPanel:
         create_gauge_panel(
             "tycho_storage_state_max_epoch",
             "Max known state root cell epoch",
-            unit_format="Seqno"
+            unit_format="Seqno",
         ),
         create_gauge_panel(
             "tycho_storage_raw_cells_cache_size",
@@ -995,8 +993,8 @@ def storage() -> RowPanel:
             title="States GC seqno guard",
             targets=[
                 target(
-                    "tycho_min_ref_mc_seqno{instance=~\"$instance\"} > 0",
-                    legend_format="{{instance}}"
+                    'tycho_min_ref_mc_seqno{instance=~"$instance"} > 0',
+                    legend_format="{{instance}}",
                 )
             ],
             unit="States",
@@ -1005,8 +1003,8 @@ def storage() -> RowPanel:
             title="States GC safe range",
             targets=[
                 target(
-                    "tycho_min_ref_mc_seqno{instance=~\"$instance\"} - tycho_gc_states_seqno{instance=~\"$instance\"}",
-                    legend_format="{{instance}}"
+                    'tycho_min_ref_mc_seqno{instance=~"$instance"} - tycho_gc_states_seqno{instance=~"$instance"}',
+                    legend_format="{{instance}}",
                 )
             ],
             unit="States",
@@ -2093,7 +2091,6 @@ def collator_wu_params() -> RowPanel:
             "tycho_do_collate_wu_param_prepare_add_to_msg_groups_target",
             "prepare.add_to_msg_groups (target)",
         ),
-
         create_gauge_panel(
             "tycho_do_collate_wu_param_execute_prepare_curr",
             "execute.prepare (current)",
@@ -2150,7 +2147,6 @@ def collator_wu_params() -> RowPanel:
             "tycho_do_collate_wu_param_execute_max_threads_target",
             "execute.max_threads (target)",
         ),
-
         create_gauge_panel(
             "tycho_do_collate_wu_param_finalize_build_transactions_curr",
             "finalize.build_transactions (current)",
@@ -2440,7 +2436,8 @@ def collator_state_adapter_metrics() -> RowPanel:
             "Prepare block proof",
         ),
         create_heatmap_panel(
-            "tycho_collator_state_adapter_save_block_proof_time_high", "Save block proof"
+            "tycho_collator_state_adapter_save_block_proof_time_high",
+            "Save block proof",
         ),
         create_heatmap_panel(
             "tycho_collator_state_store_state_root_time_high",
@@ -2449,7 +2446,9 @@ def collator_state_adapter_metrics() -> RowPanel:
         ),
         create_heatmap_panel("tycho_collator_state_load_block_time", "Load block"),
         create_heatmap_panel("tycho_collator_state_load_state_time", "Load state"),
-        create_heatmap_panel("tycho_collator_state_load_state_root_time", "Load state root"),
+        create_heatmap_panel(
+            "tycho_collator_state_load_state_root_time", "Load state root"
+        ),
         create_heatmap_panel(
             "tycho_collator_state_load_queue_diff_time", "Load queue diff"
         ),

--- a/scripts/install-python-deps.sh
+++ b/scripts/install-python-deps.sh
@@ -5,8 +5,40 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
 root_dir=$(cd "${script_dir}/../" && pwd -P)
 
 venv_dir="${root_dir}/.venv"
+requirements_file="${script_dir}/requirements.txt"
 
-python -m venv "${venv_dir}"
-source "${venv_dir}/bin/activate"
+# Skip reinstall if deps already match
+if [ -x "${venv_dir}/bin/python" ] && [ -f "${venv_dir}/.deps-hash" ]; then
+    current_hash=$(REQUIREMENTS_FILE="${requirements_file}" python - <<'PY'
+import hashlib, os
+from pathlib import Path
 
-pip install -r "${script_dir}/requirements.txt" --ignore-installed
+req = Path(os.environ["REQUIREMENTS_FILE"])
+print(hashlib.sha256(req.read_bytes()).hexdigest())
+PY
+)
+    stored_hash=$(cat "${venv_dir}/.deps-hash")
+    if [ "${current_hash}" = "${stored_hash}" ]; then
+        echo "Python dependencies up to date; skipping install."
+        exit 0
+    fi
+fi
+
+if command -v uv >/dev/null 2>&1; then
+    uv venv "${venv_dir}"
+    uv pip install --python "${venv_dir}/bin/python" -r "${requirements_file}"
+else
+    python3 -m venv "${venv_dir}"
+    source "${venv_dir}/bin/activate"
+    python3 -m pip install -r "${requirements_file}" --ignore-installed
+fi
+
+REQUIREMENTS_FILE="${requirements_file}" DEPS_HASH_FILE="${venv_dir}/.deps-hash" "${venv_dir}/bin/python" - <<'PY'
+import hashlib
+import os
+from pathlib import Path
+
+req = Path(os.environ["REQUIREMENTS_FILE"])
+digest = hashlib.sha256(req.read_bytes()).hexdigest()
+Path(os.environ["DEPS_HASH_FILE"]).write_text(digest)
+PY

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/broxus/grafana-builder.git@376e405ac6620a76598dcdf81e7b6ff10aa702eb#egg=dashboard-builder
 grafanalib==0.7.1
 nekoton==0.1.23
+ruff==0.7.3

--- a/scripts/run-py.sh
+++ b/scripts/run-py.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+root_dir=$(cd "${script_dir}/../" && pwd -P)
+venv_dir="${root_dir}/.venv"
+python_bin="${venv_dir}/bin/python"
+
+if [ ! -x "${python_bin}" ]; then
+    "${script_dir}/install-python-deps.sh"
+fi
+
+if [ -x "${python_bin}" ]; then
+    exec "${python_bin}" "$@"
+fi
+
+exec python "$@"


### PR DESCRIPTION
Build dashboard to find metrics which names in dashboard are defined as concatenation.

Previously `check-metrics.py` was able to generate false positives in case the name is defined as concatenation in dashboard thus not found during check.

This removes the ability to name metric somewhere in dashboard comments to suppress warning.

## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

None

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

None

---

### COMPATIBILITY

Full

### SPECIAL DEPLOYMENT ACTIONS

Not Required

### PERFORMANCE IMPACT

No impact expected

---

### TESTS

#### Unit Tests

No coverage

#### Network Tests

No coverage

#### Manual Tests

run script