### PR TITLE
set HAS_STATE flag when persistent state downloaded and stored

### DIFF
--- a/core/src/block_strider/starter/cold_boot.rs
+++ b/core/src/block_strider/starter/cold_boot.rs
@@ -752,6 +752,9 @@ impl StarterInner {
                 }
             };
 
+            // set flag that state stored
+            block_handles.set_has_shard_state(&block_handle);
+
             let from = StoreZeroStateFrom::File(state_file);
             try_save_persistent(&block_handle, from)
                 .await

--- a/core/src/storage/block_handle/mod.rs
+++ b/core/src/storage/block_handle/mod.rs
@@ -36,6 +36,14 @@ impl BlockHandleStorage {
         updated
     }
 
+    pub fn set_has_shard_state(&self, handle: &BlockHandle) -> bool {
+        let updated = handle.meta().add_flags(BlockFlags::HAS_STATE);
+        if updated {
+            self.store_handle(handle, false);
+        }
+        updated
+    }
+
     pub fn set_block_persistent(&self, handle: &BlockHandle) -> bool {
         let updated = handle.meta().add_flags(BlockFlags::IS_PERSISTENT);
         if updated {


### PR DESCRIPTION
Previously, when loading the persistent state, the HAS_STATE flag was not set in BlockHandle, which could lead to the state being loaded again after an unsuccessful node restart.

This flag is now correctly added.