### PR TITLE
feat(core): add cli arg groups for light nodes

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -83,7 +83,7 @@ similar-asserts = { workspace = true }
 [features]
 default = ["cells-metrics"]
 test = []
-cli = ["dep:clap", "clap/derive"]
+cli = ["dep:clap", "clap/derive", "tycho-util/cli"]
 cells-metrics = []
 s3 = ["dep:object_store", "object_store/aws"]
 

--- a/core/src/node/cli.rs
+++ b/core/src/node/cli.rs
@@ -1,0 +1,225 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Args;
+use serde::{Deserialize, Serialize};
+use tycho_util::cli;
+use tycho_util::config::PartialConfig;
+use tycho_util::serde_helpers::{load_json_from_file, save_json_to_file};
+
+use crate::block_strider::ColdBootType;
+use crate::blockchain_rpc::NoopBroadcastListener;
+use crate::global_config::GlobalConfig;
+use crate::node::{NodeBase, NodeBaseConfig, NodeBootArgs, NodeKeys};
+
+/// Run the Tycho node.
+#[derive(Args)]
+pub struct CmdRunArgs {
+    /// dump the node config template
+    #[clap(short, long, conflicts_with = Self::RUN_GROUP)]
+    pub init_config: Option<PathBuf>,
+
+    /// include all fields when dumping a node config template
+    #[clap(long, short, conflicts_with = Self::RUN_GROUP)]
+    pub all: bool,
+
+    /// overwrite the existing config
+    #[clap(short, long, conflicts_with = Self::RUN_GROUP)]
+    pub force: bool,
+
+    /// path to the node config
+    #[clap(short, long, required_unless_present = "init_config", group = Self::RUN_GROUP)]
+    pub config: Option<PathBuf>,
+
+    /// path to the global config
+    #[clap(short, long, required_unless_present = "init_config", group = Self::RUN_GROUP)]
+    pub global_config: Option<PathBuf>,
+
+    /// path to node keys
+    #[clap(short, long, required_unless_present = "init_config", group = Self::RUN_GROUP)]
+    pub keys: Option<PathBuf>,
+
+    /// path to the logger config
+    #[clap(short, long, group = Self::RUN_GROUP)]
+    pub logger_config: Option<PathBuf>,
+
+    /// list of zerostate files to import
+    #[clap(short = 'z', long, group = Self::RUN_GROUP)]
+    pub import_zerostate: Option<Vec<PathBuf>>,
+
+    /// Overwrite cold boot type. Default: `latest-persistent`
+    #[clap(short = 'b', long, group = Self::RUN_GROUP)]
+    pub cold_boot: Option<ColdBootType>,
+}
+
+impl CmdRunArgs {
+    pub const RUN_GROUP: &str = "_run_args";
+
+    /// Either initialized config or prepares the node to run.
+    pub fn init_config_or_run<C>(self) -> Result<CmdRunStatus>
+    where
+        C: Default + PartialConfig + Serialize,
+    {
+        let Some(config_path) = &self.init_config else {
+            return Ok(CmdRunStatus::Run(CmdRunOnlyArgs {
+                config: self.config.context("no config")?,
+                global_config: self.global_config.context("no global config")?,
+                keys: self.keys.context("no keys")?,
+                logger_config: self.logger_config,
+                import_zerostate: self.import_zerostate,
+                cold_boot: self.cold_boot,
+            }));
+        };
+
+        if config_path.exists() && !self.force {
+            anyhow::bail!("config file already exists, use --force to overwrite");
+        }
+
+        let config = C::default();
+        if self.all {
+            save_json_to_file(config, config_path)?;
+        } else {
+            save_json_to_file(config.into_partial(), config_path)?;
+        }
+        Ok(CmdRunStatus::ConfigCreated)
+    }
+
+    /// Either initialized config or prepares an environment for the most generic light node.
+    pub fn init_config_or_run_light_node<F, Fut, C>(self, f: F) -> Result<()>
+    where
+        F: FnOnce(LightNodeContext<C>) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<()>> + Send,
+        C: LightNodeConfig + Send + Sync + 'static,
+    {
+        match self.init_config_or_run::<C>()? {
+            CmdRunStatus::Run(args) => args.run_light_node(f),
+            CmdRunStatus::ConfigCreated => Ok(()),
+        }
+    }
+}
+
+/// The outcome of [`CmdRun::init_config_or_run`].
+pub enum CmdRunStatus {
+    Run(CmdRunOnlyArgs),
+    ConfigCreated,
+}
+
+/// Run the Tycho node.
+#[derive(Args)]
+#[group(id = CmdRunArgs::RUN_GROUP)]
+pub struct CmdRunOnlyArgs {
+    /// path to the node config
+    #[clap(short, long)]
+    pub config: PathBuf,
+
+    /// path to the global config
+    #[clap(short, long)]
+    pub global_config: PathBuf,
+
+    /// path to node keys (the file will be created if missing).
+    #[clap(short, long)]
+    pub keys: PathBuf,
+
+    /// path to the logger config
+    #[clap(short, long)]
+    pub logger_config: Option<PathBuf>,
+
+    /// list of zerostate files to import
+    #[clap(short = 'z', long)]
+    pub import_zerostate: Option<Vec<PathBuf>>,
+
+    /// Overwrite cold boot type. Default: `latest-persistent`
+    #[clap(short = 'b', long)]
+    pub cold_boot: Option<ColdBootType>,
+}
+
+impl CmdRunOnlyArgs {
+    /// Prepares an environment for the most generic light node.
+    pub fn run_light_node<F, Fut, C>(self, f: F) -> Result<()>
+    where
+        F: FnOnce(LightNodeContext<C>) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<()>> + Send,
+        C: LightNodeConfig + Send + Sync + 'static,
+    {
+        let node_config = self.load_config::<C>()?;
+
+        if let Some(logger_config) = node_config.logger() {
+            cli::logger::init_logger(logger_config, self.logger_config.clone())?;
+            cli::logger::set_abort_with_tracing();
+        }
+
+        node_config
+            .threads()
+            .init_all_and_run(cli::signal::run_or_terminate(async move {
+                if let Some(metrics) = node_config.metrics() {
+                    tycho_util::cli::metrics::init_metrics(metrics)?;
+                }
+
+                // Build node.
+                let keys = self.load_keys()?;
+                let global_config = self.load_global_config()?;
+                let public_addr = node_config.base().resolve_public_ip().await?;
+
+                let node = NodeBase::builder(node_config.base(), &global_config)
+                    .init_network(public_addr, &keys.as_secret())?
+                    .init_storage()
+                    .await?
+                    .init_blockchain_rpc(NoopBroadcastListener, NoopBroadcastListener)?
+                    .build()?;
+
+                f(LightNodeContext {
+                    keys,
+                    global_config,
+                    node,
+                    boot_args: self.make_boot_args(),
+                    config: node_config,
+                })
+                .await
+            }))
+    }
+
+    /// Tries to load node config.
+    pub fn load_config<T>(&self) -> Result<T>
+    where
+        for<'de> T: Deserialize<'de>,
+    {
+        load_json_from_file(&self.config).context("failed to load node config")
+    }
+
+    /// Tries to load global config.
+    pub fn load_global_config(&self) -> Result<GlobalConfig> {
+        GlobalConfig::from_file(&self.global_config).context("failed to load global config")
+    }
+
+    /// Tries to load node keys.
+    ///
+    /// Generates and saves new keys if the file doesn't exist.
+    pub fn load_keys(&self) -> Result<NodeKeys> {
+        NodeKeys::load_or_create(&self.keys)
+    }
+
+    /// Creates default [`NodeBootArgs`] using the provided CLI arguments.
+    pub fn make_boot_args(&self) -> NodeBootArgs {
+        NodeBootArgs {
+            boot_type: self.cold_boot.unwrap_or(ColdBootType::LatestPersistent),
+            zerostates: self.import_zerostate.clone(),
+            queue_state_handler: None,
+            ignore_states: false,
+        }
+    }
+}
+
+pub struct LightNodeContext<C> {
+    pub keys: NodeKeys,
+    pub global_config: GlobalConfig,
+    pub node: NodeBase,
+    pub boot_args: NodeBootArgs,
+    pub config: C,
+}
+
+pub trait LightNodeConfig: Default + PartialConfig + Serialize + for<'de> Deserialize<'de> {
+    fn base(&self) -> &NodeBaseConfig;
+    fn threads(&self) -> &cli::config::ThreadPoolConfig;
+    fn metrics(&self) -> Option<&cli::metrics::MetricsConfig>;
+    fn logger(&self) -> Option<&cli::logger::LoggerConfig>;
+}

--- a/core/src/node/config.rs
+++ b/core/src/node/config.rs
@@ -91,6 +91,12 @@ impl Default for NodeBaseConfig {
 }
 
 impl NodeBaseConfig {
+    #[cfg(feature = "cli")]
+    pub async fn resolve_public_ip(&self) -> anyhow::Result<std::net::SocketAddr> {
+        let public_ip = tycho_util::cli::resolve_public_ip(self.public_ip).await?;
+        Ok(std::net::SocketAddr::new(public_ip, self.port))
+    }
+
     pub fn with_relative_paths<P: AsRef<Path>>(mut self, base_dir: P) -> Self {
         let base_dir = base_dir.as_ref();
         self.storage.root_dir = base_dir.join(self.storage.root_dir);

--- a/core/src/node/mod.rs
+++ b/core/src/node/mod.rs
@@ -10,6 +10,8 @@ use tycho_network::{
 use tycho_storage::{StorageConfig, StorageContext};
 use tycho_types::models::{BlockId, ValidatorSet};
 
+#[cfg(feature = "cli")]
+pub use self::cli::{CmdRunArgs, CmdRunOnlyArgs, CmdRunStatus, LightNodeConfig, LightNodeContext};
 pub use self::config::NodeBaseConfig;
 pub use self::keys::NodeKeys;
 use crate::block_strider::{
@@ -26,6 +28,8 @@ use crate::overlay_client::{PublicOverlayClient, ValidatorsResolver};
 use crate::s3::S3Client;
 use crate::storage::{CoreStorage, CoreStorageConfig};
 
+#[cfg(feature = "cli")]
+mod cli;
 mod config;
 mod keys;
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -197,18 +197,18 @@ Run a Tycho node
 
 ###### **Options:**
 
-* `--config <CONFIG>` — Path to the node config. Default: `$TYCHO_HOME/config.json`
-* `--global-config <GLOBAL_CONFIG>` — Path to the global config. Default: `$TYCHO_HOME/global-config.json`
-* `--keys <KEYS>` — Path to the node keys. Default: `$TYCHO_HOME/node_keys.json`
-* `--control-socket <CONTROL_SOCKET>` — Path to the control socket. Default: `$TYCHO_HOME/control.sock`
-* `--logger-config <LOGGER_CONFIG>` — Path to the logger config
-* `--import-zerostate <IMPORT_ZEROSTATE>` — List of zerostate files to import
+* `-c`, `--config <CONFIG>` — Path to the node config. Default: `$TYCHO_HOME/config.json`
+* `-g`, `--global-config <GLOBAL_CONFIG>` — Path to the global config. Default: `$TYCHO_HOME/global-config.json`
+* `-k`, `--keys <KEYS>` — Path to the node keys. Default: `$TYCHO_HOME/node_keys.json`
+* `-t`, `--control-socket <CONTROL_SOCKET>` — Path to the control socket. Default: `$TYCHO_HOME/control.sock`
+* `-l`, `--logger-config <LOGGER_CONFIG>` — Path to the logger config
+* `-z`, `--import-zerostate <IMPORT_ZEROSTATE>` — List of zerostate files to import
 * `--wu-tuner-config <WU_TUNER_CONFIG>` — Path to the work units tuner config
-* `--cold-boot <COLD_BOOT>` — Overwrite cold boot type. Default: `latest-persistent`
+* `-b`, `--cold-boot <COLD_BOOT>` — Overwrite cold boot type. Default: `latest-persistent`
 
   Possible values: `genesis`, `latest-persistent`
 
-* `--single-node` — Pass this flag if you used `just gen_network 1` for manual tests
+* `-s`, `--single-node` — Pass this flag if you used `just gen_network 1` for manual tests
 
 
 


### PR DESCRIPTION
The first step towards "light-node-in-core" way of writing indexers.

This PR helps to reduce the most common boilerplate of creating indexers (config + env + node base creation). 

Example: https://github.com/broxus/tycho-l2/compare/master...0ff1e94bfa05f4b5906df4aa70d06109f70419cb