### PR TITLE
feat(network): add optional bootstrap peers refill task

### DIFF
--- a/consensus/src/test_utils/bootstrap.rs
+++ b/consensus/src/test_utils/bootstrap.rs
@@ -98,7 +98,7 @@ pub fn from_validator<T: ToSocket, A: Into<Address>>(
     }
     let peer_resolver = peer_resolver_builder.build(&network);
 
-    dht_tasks.spawn(&network);
+    dht_tasks.spawn_without_bootstrap(&network);
     overlay_tasks.spawn(&network);
 
     (

--- a/core/src/node/mod.rs
+++ b/core/src/node/mod.rs
@@ -514,7 +514,7 @@ impl ConfiguredNetwork {
             .build(local_addr, router)
             .context("failed to build node network")?;
 
-        dht_tasks.spawn(&network);
+        let bootstrap_peer_count = dht_tasks.spawn(&network, bootstrap_peers)?;
         overlay_tasks.spawn(&network);
 
         let dht_client = dht_service.make_client(&network);
@@ -522,12 +522,6 @@ impl ConfiguredNetwork {
             .make_peer_resolver()
             .with_config(base_config.peer_resolver.clone())
             .build(&network);
-
-        let mut bootstrap_peer_count = 0usize;
-        for peer in bootstrap_peers {
-            let is_new = dht_client.add_peer(Arc::new(peer.clone()))?;
-            bootstrap_peer_count += is_new as usize;
-        }
 
         tracing::info!(
             %local_id,

--- a/core/tests/network/mod.rs
+++ b/core/tests/network/mod.rs
@@ -44,7 +44,7 @@ impl NodeBase {
             .build((Ipv4Addr::LOCALHOST, 0), router)
             .unwrap();
 
-        dht_tasks.spawn(&network);
+        dht_tasks.spawn_without_bootstrap(&network);
         overlay_tasks.spawn(&network);
 
         let peer_resolver = dht_service.make_peer_resolver().build(&network);

--- a/light-node/src/cli.rs
+++ b/light-node/src/cli.rs
@@ -153,7 +153,7 @@ impl<C> Node<C> {
             .build(local_addr, router)
             .context("failed to build node network")?;
 
-        dht_tasks.spawn(&network);
+        let bootstrap_peer_count = dht_tasks.spawn(&network, &global_config.bootstrap_peers)?;
         overlay_tasks.spawn(&network);
 
         let dht_client = dht_service.make_client(&network);
@@ -162,17 +162,11 @@ impl<C> Node<C> {
             .with_config(node_config.peer_resolver)
             .build(&network);
 
-        let mut bootstrap_peers = 0usize;
-        for peer in global_config.bootstrap_peers {
-            let is_new = dht_client.add_peer(Arc::new(peer))?;
-            bootstrap_peers += is_new as usize;
-        }
-
         tracing::info!(
             %local_id,
             %local_addr,
             %public_addr,
-            bootstrap_peers,
+            bootstrap_peer_count,
             "initialized network"
         );
 

--- a/network/src/dht/config.rs
+++ b/network/src/dht/config.rs
@@ -70,6 +70,12 @@ pub struct DhtConfig {
     ///
     /// Default: 10.
     pub announced_peers_channel_capacity: usize,
+
+    /// A period of refilling bootstrap peers in the routing table.
+    ///
+    /// Default: 1 minutes.
+    #[serde(with = "serde_helpers::humantime")]
+    pub bootstrap_peers_refill_period: Option<Duration>,
 }
 
 impl Default for DhtConfig {
@@ -86,6 +92,7 @@ impl Default for DhtConfig {
             routing_table_refresh_period: Duration::from_secs(600),
             routing_table_refresh_period_max_jitter: Duration::from_secs(60),
             announced_peers_channel_capacity: 10,
+            bootstrap_peers_refill_period: Some(Duration::from_secs(60)),
         }
     }
 }

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -74,7 +74,7 @@ mod tests {
             .build((Ipv4Addr::LOCALHOST, 0), router)
             .unwrap();
 
-        dht_tasks.spawn(&network);
+        dht_tasks.spawn_without_bootstrap(&network);
         overlay_tasks.spawn(&network);
 
         let peer_resolver = dht_service.make_peer_resolver().build(&network);

--- a/network/tests/common/mod.rs
+++ b/network/tests/common/mod.rs
@@ -40,7 +40,7 @@ impl NodeBase {
             .build((Ipv4Addr::LOCALHOST, 0), router)
             .unwrap();
 
-        dht_tasks.spawn(&network);
+        dht_tasks.spawn_without_bootstrap(&network);
         overlay_tasks.spawn(&network);
 
         let peer_resolver = dht_service.make_peer_resolver().build(&network);

--- a/network/tests/dht.rs
+++ b/network/tests/dht.rs
@@ -45,7 +45,7 @@ impl Node {
             .unwrap();
 
         if spawn_dht_tasks {
-            dht_tasks.spawn(&network);
+            dht_tasks.spawn_without_bootstrap(&network);
         }
 
         let dht = dht_service.make_client(&network);


### PR DESCRIPTION
PR resolve the problem of looking for neighbours for nodes not from bootstrap peers when all neighbours were lost (for example: network shutdown more than 1h)

## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

Yes

Added .dht.bootstrap_peers_refill_period: Option with default value None. Enable refilling bootstrap peers in the routing table.

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

None

### COMPATIBILITY

Full compatibility

### SPECIAL DEPLOYMENT ACTIONS

Not Required

### PERFORMANCE IMPACT

No impact expected

### TESTS

No
