### PR TITLE
fix(consensus): bump types to default serde for unused config field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4217,7 +4217,7 @@ dependencies = [
 [[package]]
 name = "tycho-types"
 version = "0.3.1"
-source = "git+https://github.com/broxus/tycho-types.git?rev=9ab6af16b7e3597fa111a96a3c107018eab6856c#9ab6af16b7e3597fa111a96a3c107018eab6856c"
+source = "git+https://github.com/broxus/tycho-types.git?rev=863f612fc7f0ccd1fb2c2cd0a13747f92b3cadcc#863f612fc7f0ccd1fb2c2cd0a13747f92b3cadcc"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4248,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "tycho-types-abi-proc"
 version = "0.3.0"
-source = "git+https://github.com/broxus/tycho-types.git?rev=9ab6af16b7e3597fa111a96a3c107018eab6856c#9ab6af16b7e3597fa111a96a3c107018eab6856c"
+source = "git+https://github.com/broxus/tycho-types.git?rev=863f612fc7f0ccd1fb2c2cd0a13747f92b3cadcc#863f612fc7f0ccd1fb2c2cd0a13747f92b3cadcc"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "tycho-types-proc"
 version = "0.3.0"
-source = "git+https://github.com/broxus/tycho-types.git?rev=9ab6af16b7e3597fa111a96a3c107018eab6856c#9ab6af16b7e3597fa111a96a3c107018eab6856c"
+source = "git+https://github.com/broxus/tycho-types.git?rev=863f612fc7f0ccd1fb2c2cd0a13747f92b3cadcc#863f612fc7f0ccd1fb2c2cd0a13747f92b3cadcc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ tycho-wu-tuner = { path = "./wu-tuner", version = "0.3.5" }
 
 [patch.crates-io]
 # patches here
-tycho-types = { git = "https://github.com/broxus/tycho-types.git", rev = "9ab6af16b7e3597fa111a96a3c107018eab6856c" }
+tycho-types = { git = "https://github.com/broxus/tycho-types.git", rev = "863f612fc7f0ccd1fb2c2cd0a13747f92b3cadcc" }
 
 [workspace.lints.rust]
 future_incompatible = "warn"


### PR DESCRIPTION
Use `serde(default)`  for unused consensus config field from https://github.com/broxus/tycho-types/pull/59 

## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

None

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

None

---

### COMPATIBILITY

Full

### SPECIAL DEPLOYMENT ACTIONS

Not Required

---

### PERFORMANCE IMPACT

No impact expected

---

### TESTS

#### Unit Tests

No coverage

#### Network Tests

No coverage

#### Manual Tests

None

---

**Notes/Additional Comments:**  