### PR TITLE
feat(core): add ability to sync node using only zerostate proof

### DIFF
--- a/block-util/src/state/state_proof.rs
+++ b/block-util/src/state/state_proof.rs
@@ -54,7 +54,7 @@ pub fn check_zerostate_proof(
     };
 
     anyhow::ensure!(
-        !config_cell.descriptor().level_mask().is_empty(),
+        config_cell.descriptor().level_mask().is_empty(),
         "zerostate proof has pruned branches"
     );
 
@@ -63,9 +63,143 @@ pub fn check_zerostate_proof(
     };
 
     anyhow::ensure!(
-        !shard_hashes.descriptor().level_mask().is_empty(),
+        shard_hashes.descriptor().level_mask().is_empty(),
         "zerostate shard_hashes has pruned branches"
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Context;
+    use tycho_types::cell::{Cell, CellBuilder, CellFamily, UsageTree, UsageTreeMode};
+    use tycho_types::dict::{AugDict, Dict};
+    use tycho_types::merkle::MerkleProof;
+    use tycho_types::models::{
+        BlockchainConfig, ConsensusInfo, CurrencyCollection, McStateExtra, ShardHashes,
+        ShardStateUnsplit, ValidatorInfo,
+    };
+    use tycho_types::prelude::HashBytes;
+
+    use super::*;
+
+    fn make_config() -> anyhow::Result<BlockchainConfig> {
+        let mut config = BlockchainConfig::new_empty(HashBytes::ZERO);
+        config.set_raw(1, Cell::empty_cell())?;
+        config.set_raw(2, Cell::empty_cell())?;
+        Ok(config)
+    }
+
+    fn make_shards() -> anyhow::Result<ShardHashes> {
+        let mut shards_dict = Dict::<i32, Cell>::new();
+        shards_dict.set(0, Cell::empty_cell())?;
+        shards_dict.set(1, Cell::empty_cell())?;
+        Ok(ShardHashes::from_dict(shards_dict))
+    }
+
+    fn make_extra(shards: ShardHashes, config: BlockchainConfig) -> McStateExtra {
+        McStateExtra {
+            shards,
+            config,
+            validator_info: ValidatorInfo {
+                validator_list_hash_short: 0,
+                catchain_seqno: 0,
+                nx_cc_updated: false,
+            },
+            consensus_info: ConsensusInfo::ZEROSTATE,
+            prev_blocks: AugDict::new(),
+            after_key_block: false,
+            last_key_block: None,
+            block_create_stats: None,
+            global_balance: CurrencyCollection::ZERO,
+        }
+    }
+
+    fn make_state_cell_with(extra: Option<&McStateExtra>) -> anyhow::Result<Cell> {
+        let mut state = ShardStateUnsplit::default();
+        state.set_custom(extra)?;
+        Ok(CellBuilder::build_from(&state)?)
+    }
+
+    fn make_state_cell() -> anyhow::Result<Cell> {
+        let shards = make_shards()?;
+        let config = make_config()?;
+        let extra = make_extra(shards, config);
+
+        make_state_cell_with(Some(&extra))
+    }
+
+    fn make_pruned_state_proof(root: &Cell) -> anyhow::Result<Cell> {
+        let usage_tree = UsageTree::new(UsageTreeMode::OnLoad);
+        let tracked_cell = usage_tree.track(root);
+
+        let state = tracked_cell.parse::<ShardStateUnsplit>()?;
+        let extra = state.custom.context("McStateExtra not found in state")?;
+        let _ = extra.load()?;
+
+        let merkle_proof = MerkleProof::create(root.as_ref(), usage_tree).build()?;
+        Ok(merkle_proof.cell)
+    }
+
+    #[test]
+    fn check_zerostate_proof_test() -> anyhow::Result<()> {
+        let state_root = make_state_cell()?;
+        let expected_root_hash = *state_root.repr_hash();
+
+        let full_proof = prepare_master_state_proof(&state_root)?;
+        check_zerostate_proof(expected_root_hash, &full_proof)?;
+
+        let pruned_proof = make_pruned_state_proof(&state_root)?;
+        let err = check_zerostate_proof(expected_root_hash, &pruned_proof).unwrap_err();
+        assert!(
+            err.to_string().contains("pruned branches"),
+            "unexpected error: {err:#}",
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn check_invalid_zerostate_proof_test() -> anyhow::Result<()> {
+        let state_root = make_state_cell()?;
+        let full_proof = prepare_master_state_proof(&state_root)?;
+
+        let expected_hash = *state_root.repr_hash();
+        let wrong_hash = if expected_hash == HashBytes::ZERO {
+            HashBytes([1; 32])
+        } else {
+            HashBytes::ZERO
+        };
+
+        let err = check_zerostate_proof(wrong_hash, &full_proof).unwrap_err();
+        assert!(
+            err.to_string().contains("incorrect root hash"),
+            "unexpected error: {err:#}",
+        );
+
+        let state_root = make_state_cell_with(None)?;
+        let expected_root_hash = *state_root.repr_hash();
+
+        let err = check_zerostate_proof(expected_root_hash, &state_root).unwrap_err();
+        assert!(
+            err.to_string().contains("mc state extra"),
+            "unexpected error: {err:#}",
+        );
+
+        let shards = ShardHashes::default();
+        let config = make_config()?;
+        let extra = make_extra(shards, config);
+        let state_root = make_state_cell_with(Some(&extra))?;
+        let expected_root_hash = *state_root.repr_hash();
+        let full_proof = prepare_master_state_proof(&state_root)?;
+
+        let err = check_zerostate_proof(expected_root_hash, &full_proof).unwrap_err();
+        assert!(
+            err.to_string().contains("shard_hashes are empty"),
+            "unexpected error: {err:#}",
+        );
+
+        Ok(())
+    }
 }

--- a/core/src/block_strider/state_applier.rs
+++ b/core/src/block_strider/state_applier.rs
@@ -354,6 +354,7 @@ impl<S> Inner<S> {
             .await?;
 
         metrics::counter!("tycho_core_ps_subscriber_saved_persistent_states_count").increment(1);
+        tracing::debug!("saved persistent state for {}", mc_block_handle.id());
 
         Ok(())
     }


### PR DESCRIPTION
## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

None

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

[None]

---

### COMPATIBILITY

<!--Is the new version compatible with the previous state of the node and blockchain? Specify which compatibility-sensitive features were modified. Possible list below. If a feature is not affected, do not list it.-->

Affected features:
None

### SPECIAL DEPLOYMENT ACTIONS

Not Required

---

### PERFORMANCE IMPACT

Expected impact:

There is no need anymore to download heavy zerostate after hardfork to run and sync node.

---

### TESTS

#### Unit Tests

New `check_zerostate_proof_test` and `check_invalid_zerostate_proof_test` were added

#### Network Tests

No coverage

#### Manual Tests

#### Test 1: No persistent key blocks available

**Description:**  
A fourth node joins the network from scratch when no persistent key blocks exist beyond the zerostate.

**Steps:**

1. Node downloads the **zerostate proof**.  
2. Node downloads **key blocks** from the network.  
3. Node detects by selected zerostate keyblock that **no persistent state exists**.  
4. Node downloads the **zerostate** (since its the only persistent state) and initializes blockchain state from it.  
5. Node continues synchronization by downloading remaining blocks from the regular blockchain provider.

**Expected Result:**

- Node initializes correctly from zerostate.  
- Node synchronizes to the current chain tip.  
- All nodes reach the same blockchain state.

---

#### Test 2: Persistent key block with persistent state available

**Description:**  
A fourth node joins the network where a key block with persistent state already exists.

**Steps:**

1. Node downloads the **zerostate proof**.  
2. Node downloads **key blocks** from the network.  
3. Node detects a **key block with available persistent state**.  
4. Node downloads the **persistent state** and initializes blockchain state from it.  
5. Node continues synchronization by downloading subsequent blocks.

**Expected Result:**

- Node initializes from persistent state (skipping zerostate).  
- Node synchronizes to the current chain tip.  
- All nodes reach the same blockchain state.

---

#### Test 3: Key block exists but persistent state is missing

**Description:**  
A fourth node joins the network where a key block exists but its persistent state is missing.

**Steps:**

1. Node downloads the **zerostate proof**.  
2. Node downloads **key blocks** from the network.  
3. Node detects that the any **persistent state is missing** but zerostate.  
4. Node downloads zerostate and **archives** starting from zerostate key block and reconstructs blockchain state from it.  
5. Node switches to the regular blockchain provider to download remaining blocks.

**Expected Result:**

- Node reconstructs state using archive correctly.  
- Node continues synchronization normally.  
- All nodes reach the same blockchain state.

---

**Notes/Additional Comments:**  
<!-- Add any additional information or context for reviewers here. -->
