### PR TITLE
Feature/slasher remap by peerid

### DIFF
--- a/collator/src/validator/impls/std_impl/session.rs
+++ b/collator/src/validator/impls/std_impl/session.rs
@@ -255,7 +255,7 @@ impl ValidatorSession {
         );
 
         // Notify listeners about the own signature
-        events_scope.receive_signature(self.inner.own_validator_idx, true);
+        events_scope.receive_signature(self.inner.peer_id.as_bytes(), true);
 
         let mut total_weight = self.inner.own_weight;
 
@@ -421,7 +421,6 @@ impl ValidatorSession {
                     };
 
                     let validator_info = validators.get(peer_id).expect("peer info out of sync");
-                    let validator_idx = validator_info.validator_idx;
 
                     if !validator_info.public_key.verify_raw(&data, &signature) {
                         tracing::warn!(
@@ -439,14 +438,14 @@ impl ValidatorSession {
                         metrics::counter!(METRIC_INVALID_SIGNATURES_CACHED_TOTAL).increment(1);
 
                         if let Some(scope) = events_scope.upgrade() {
-                            scope.receive_signature(validator_idx, false);
+                            scope.receive_signature(peer_id.as_bytes(), false);
                         }
 
                         break 'stored Default::default();
                     }
 
                     if let Some(scope) = events_scope.upgrade() {
-                        scope.receive_signature(validator_idx, true);
+                        scope.receive_signature(peer_id.as_bytes(), true);
                     }
 
                     total_weight += validator_info.weight;
@@ -699,7 +698,7 @@ impl SessionState {
             metrics::counter!(METRIC_INVALID_SIGNATURES_IN_TOTAL).increment(1);
 
             if let Some(scope) = block.events_scope.upgrade() {
-                scope.receive_signature(validator_info.validator_idx, false);
+                scope.receive_signature(peer_id.as_bytes(), false);
             }
 
             return Err(ValidationError::InvalidSignature);
@@ -740,7 +739,7 @@ impl SessionState {
             && !was_sealed
             && let Some(scope) = block.events_scope.upgrade()
         {
-            scope.receive_signature(validator_info.validator_idx, true);
+            scope.receive_signature(peer_id.as_bytes(), true);
         }
 
         Ok(())

--- a/slasher-traits/src/lib.rs
+++ b/slasher-traits/src/lib.rs
@@ -4,3 +4,5 @@ pub use self::validator::{
 };
 
 mod validator;
+
+pub type PeerIdInner = [u8; 32];

--- a/slasher-traits/src/validator.rs
+++ b/slasher-traits/src/validator.rs
@@ -6,6 +6,8 @@ use indexmap::IndexMap;
 use tycho_types::models::{BlockId, IndexedValidatorDescription};
 use tycho_util::FastHasherState;
 
+use crate::PeerIdInner;
+
 // TODO: Decide how to be with this collator-defined type
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ValidationSessionId {
@@ -61,12 +63,9 @@ impl ValidatorEvents {
         self.listener
             .on_session_started(session_id, first_mc_seqno, own_validator_idx, validators);
 
-        let mut remap = IndexMap::<u16, u16, FastHasherState>::with_capacity_and_hasher(
-            validators.len(),
-            Default::default(),
-        );
+        let mut remap = IndexMap::with_capacity_and_hasher(validators.len(), Default::default());
         for (i, validator) in validators.iter().enumerate() {
-            remap.insert(validator.validator_idx, i as u16);
+            remap.insert(validator.desc.public_key.0, i as u16);
         }
 
         ValidatorSessionScope {
@@ -81,7 +80,7 @@ impl ValidatorEvents {
 pub struct ValidatorSessionScope {
     recorder: Arc<dyn ValidatorEventsListener>,
     session_id: ValidationSessionId,
-    remap_ids: Arc<IndexMap<u16, u16, FastHasherState>>,
+    remap_ids: Arc<IndexMap<PeerIdInner, u16, FastHasherState>>,
     is_sealed: AtomicBool,
 }
 
@@ -120,7 +119,7 @@ impl Drop for ValidatorSessionScope {
 pub struct BlockValidationScope {
     recorder: Arc<dyn ValidatorEventsListener>,
     session_id: ValidationSessionId,
-    remap_ids: Arc<IndexMap<u16, u16, FastHasherState>>,
+    remap_ids: Arc<IndexMap<PeerIdInner, u16, FastHasherState>>,
     block_id: BlockId,
     signature_slots: Box<[AtomicU8]>,
     is_sealed: AtomicBool,
@@ -135,14 +134,14 @@ impl BlockValidationScope {
         &self.block_id
     }
 
-    pub fn receive_signature(&self, validator_idx: u16, is_valid: bool) -> bool {
+    pub fn receive_signature(&self, peer_id: &PeerIdInner, is_valid: bool) -> bool {
         let mask = if is_valid {
             ReceivedSignature::VALID_SIGNATURE_BIT
         } else {
             ReceivedSignature::INVALID_SIGNATURE_BIT
         };
 
-        let Some(slot_id) = self.remap_ids.get(&validator_idx) else {
+        let Some(slot_id) = self.remap_ids.get(peer_id) else {
             return false;
         };
 


### PR DESCRIPTION
is there any need to use `validator_idx` to slot map?
(assume a prerequisite to https://github.com/broxus/tycho/pull/1067)