### PR TITLE
fix mempool alt resolved metrics: fork vs late

### DIFF
--- a/consensus/src/dag/dag_location.rs
+++ b/consensus/src/dag/dag_location.rs
@@ -260,7 +260,17 @@ impl InclusionState {
                 resolved.alt(),
             )
         }
-        ValidateCtx::resolved(dag_point); // meter after checks
+        let alt_valid_case =
+            if matches!(dag_point, DagPoint::Valid(_)) && !dag_point.is_first_resolved() {
+                Some(match self.0.resolved.get() {
+                    Some(FirstResolved::Closed) => "late",
+                    Some(FirstResolved::Valid(_, _)) | Some(FirstResolved::NotValid(_)) => "fork",
+                    None => "fork",
+                })
+            } else {
+                None
+            };
+        ValidateCtx::resolved(dag_point, alt_valid_case); // meter after checks
 
         // first valid
 

--- a/consensus/src/dag/verifier.rs
+++ b/consensus/src/dag/verifier.rs
@@ -940,8 +940,11 @@ impl ValidateCtx {
         metrics::counter!("tycho_mempool_points_verify_err", Self::KIND => label).increment(1);
     }
 
-    pub fn resolved(dag_point: &DagPoint) {
+    /// For `ord=alt` valid points, pass `fork` (equivocation vs first resolved) or `late` (location
+    /// was already closed for signing when this point resolved). First resolutions omit this.
+    pub fn resolved(dag_point: &DagPoint, alt_valid_case: Option<&'static str>) {
         const ORD: &str = "ord";
+        const CASE: &str = "case";
         let ord = if dag_point.is_first_resolved() {
             "first"
         } else {
@@ -953,7 +956,12 @@ impl ValidateCtx {
             DagPoint::Invalid(_) => "invalid",
             DagPoint::TransInvalid(_) => "trans_invalid",
             DagPoint::Valid(_) => {
-                metrics::counter!("tycho_mempool_points_resolved_ok", ORD => ord).increment(1);
+                if let Some(case) = alt_valid_case {
+                    metrics::counter!("tycho_mempool_points_resolved_ok", ORD => ord, CASE => case)
+                        .increment(1);
+                } else {
+                    metrics::counter!("tycho_mempool_points_resolved_ok", ORD => ord).increment(1);
+                }
                 return;
             }
         };


### PR DESCRIPTION
## what this does

`tycho_mempool_points_resolved_ok` with `ord=alt` mixed together two different situations: equivocation (another digest already first resolved) and points that resolve after the inclusion location was already **closed** for signing. Issue #876.

This adds a `case` label only for **alt + valid** resolutions:

- `case=fork` — first resolved state is still `Valid` / `NotValid` for another digest (normal equivocation path).
- `case=late` — first resolved state is `Closed` (engine moved on / signing closed), so the valid point is not the same kind of fork signal.

First resolutions and error paths are unchanged (same labels as before).

## testing

Not run here (windows checkout of this repo fails on `test/data` paths with colons). CI should cover `consensus`.

built by mooncitydev

Fixes #876