### PR TITLE
fix: handle zerostate/hardfork on max messages per range reader limit check

### DIFF
--- a/collator/src/collator/messages_buffer.rs
+++ b/collator/src/collator/messages_buffer.rs
@@ -19,7 +19,7 @@ type SlotId = u16;
 type FastIndexMap<K, V> = indexmap::IndexMap<K, V, ahash::RandomState>;
 pub type FastIndexSet<K> = indexmap::IndexSet<K, ahash::RandomState>;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct MessagesBufferLimits {
     pub max_count: usize,
     pub slots_count: usize,

--- a/collator/src/collator/messages_reader/externals_reader.rs
+++ b/collator/src/collator/messages_reader/externals_reader.rs
@@ -399,7 +399,7 @@ impl<'a, 'b> ExternalsReader<'a, 'b> {
             seqno = self.block_seqno,
             fully_read = reader_state.fully_read,
             reader_state = ?DebugExternalsRangeReaderState(&reader_state),
-            "externals reader: created next range state",
+            "externals reader: created next range reader state",
         );
 
         reader_state

--- a/collator/src/collator/messages_reader/internals_reader.rs
+++ b/collator/src/collator/messages_reader/internals_reader.rs
@@ -375,7 +375,7 @@ impl<'a, V: InternalMessageValue> InternalsPartitionReader<'a, V> {
             self.msgs_exec_params.current().range_messages_limit
         };
 
-        let (reader, state) = self.create_next_range(Some(range_max_messages))?;
+        let (reader, state) = self.create_next_range_reader(Some(range_max_messages))?;
         let seqno = reader.seqno;
         // we should add created range reader using calculated reader seqno instead of current block seqno
         // otherwise the next range will exeed the max blocks limit
@@ -398,7 +398,7 @@ impl<'a, V: InternalMessageValue> InternalsPartitionReader<'a, V> {
     }
 
     #[tracing::instrument(skip_all)]
-    fn create_next_range(
+    fn create_next_range_reader(
         &self,
         range_max_messages: Option<u32>,
     ) -> Result<(InternalsRangeReader<V>, InternalsRangeReaderState), CollatorError> {
@@ -411,6 +411,7 @@ impl<'a, V: InternalMessageValue> InternalsPartitionReader<'a, V> {
                 })
             })
             .unwrap_or_default();
+        let last_range_reader_exists = last_range_reader_info_opt.is_some();
 
         let mut shard_reader_states = BTreeMap::new();
 
@@ -425,12 +426,29 @@ impl<'a, V: InternalMessageValue> InternalsPartitionReader<'a, V> {
             last_range_block_seqno,
         } = last_range_reader_info_opt.unwrap_or_default();
 
-        let (range_seqno, current_shard_range_to) = match range_max_messages {
-            None => (
+        tracing::debug!(target: tracing_targets::COLLATOR,
+            partition_id = %self.partition_id,
+            last_range_reader_exists,
+            ?last_to_lts,
+            last_range_block_seqno,
+            all_end_lts = ?DebugIter(all_end_lts.clone().collect::<Vec<_>>().iter()),
+            ?range_max_messages,
+            "internals reader: creating next range reader",
+        );
+
+        let (range_seqno, current_shard_range_to) = match (
+            range_max_messages,
+            last_range_reader_exists,
+        ) {
+            // NOTE: when there is no existing range readers in state,
+            //      it means that we starting from zerostate or hardfork,
+            //      then we unable to get previous diffs info,
+            //      so we should omit max range reader messages check
+            (None, _) | (_, false) => (
                 self.block_seqno,
                 QueueKey::max_for_lt(self.prev_state_gen_lt),
             ),
-            Some(max_messages) => {
+            (Some(max_messages), _) => {
                 let mut next_seqno = last_range_block_seqno + 1;
                 let mut range_to = QueueKey::max_for_lt(self.prev_state_gen_lt);
 
@@ -865,7 +883,7 @@ impl<'a, V: InternalMessageValue> InternalsPartitionReader<'a, V> {
         if last_seqno < self.block_seqno {
             // we should look thru the whole range to check for pending messages
             // so we do not pass `range_max_messages` to force use the prev block end lt
-            let (mut range_reader, mut state) = self.create_next_range(None)?;
+            let (mut range_reader, mut state) = self.create_next_range_reader(None)?;
 
             if !state.is_fully_read() {
                 range_reader.init(&mut state, &self.mq_adapter)?;

--- a/collator/src/collator/messages_reader/mod.rs
+++ b/collator/src/collator/messages_reader/mod.rs
@@ -22,7 +22,10 @@ use crate::collator::messages_buffer::DebugMessageGroup;
 use crate::collator::messages_reader::internals_range_reader::{
     InternalsRangeReader, InternalsRangeReaderKind,
 };
-use crate::collator::messages_reader::state::int::reader::InternalsReaderState;
+use crate::collator::messages_reader::state::ext::reader::DebugExternalsReaderState;
+use crate::collator::messages_reader::state::int::reader::{
+    DebugInternalsReaderState, InternalsReaderState,
+};
 use crate::collator::statistics::cumulative::CumulativeStatistics;
 use crate::collator::statistics::queue::TrackedQueueStatistics;
 use crate::internal_queue::types::diff::QueueDiffWithMessages;
@@ -111,8 +114,8 @@ impl<'a, 'b, V: InternalMessageValue> MessagesReader<'a, 'b, V> {
     ) -> Result<Self> {
         let current_msgs_exec_params = cx.msgs_exec_params.current();
         let CurrentMessagesBufferLimits {
-            externals,
-            internals,
+            externals: externals_buffer_limits,
+            internals: internals_buffer_limits,
         } = Self::get_buffer_limits(&current_msgs_exec_params)?;
 
         Self::msgs_exec_params_metrics(&current_msgs_exec_params)?;
@@ -127,6 +130,14 @@ impl<'a, 'b, V: InternalMessageValue> MessagesReader<'a, 'b, V> {
             externals: externals_reader_state,
             internals: internals_reader_state,
         } = cx.reader_state;
+
+        tracing::trace!(target: tracing_targets::COLLATOR,
+            externals_reader_state = ?DebugExternalsReaderState(externals_reader_state),
+            ?externals_buffer_limits,
+            internals_reader_state = ?DebugInternalsReaderState(internals_reader_state),
+            ?internals_buffer_limits,
+            "creating messages reader",
+        );
 
         if let Some(params) = cx.cumulative_stats_calc_params {
             // if cumulative statistics are already present, then we should
@@ -197,7 +208,7 @@ impl<'a, 'b, V: InternalMessageValue> MessagesReader<'a, 'b, V> {
             cx.block_seqno,
             cx.next_chain_time,
             msgs_exec_params.clone(),
-            externals,
+            externals_buffer_limits,
             cx.anchors_cache,
             externals_reader_state,
         );
@@ -245,7 +256,7 @@ impl<'a, 'b, V: InternalMessageValue> MessagesReader<'a, 'b, V> {
             unreachable!("partition must exist after ensure_partition()");
         };
 
-        let BufferLimits { target, max } = internals.get(&MAIN_PARTITION_ID).unwrap();
+        let BufferLimits { target, max } = internals_buffer_limits.get(&MAIN_PARTITION_ID).unwrap();
 
         let main_par_reader = InternalsPartitionReader::new(
             InternalsPartitionReaderContext {
@@ -264,7 +275,7 @@ impl<'a, 'b, V: InternalMessageValue> MessagesReader<'a, 'b, V> {
             mq_adapter.clone(),
         )?;
 
-        let BufferLimits { target, max } = internals.get(&LP_PARTITION_ID).unwrap();
+        let BufferLimits { target, max } = internals_buffer_limits.get(&LP_PARTITION_ID).unwrap();
 
         let lp_par_reader = InternalsPartitionReader::new(
             InternalsPartitionReaderContext {
@@ -1606,6 +1617,7 @@ struct CurrentMessagesBufferLimits {
     pub internals: BTreeMap<QueuePartitionIdx, BufferLimits>,
 }
 
+#[derive(Debug)]
 struct BufferLimits {
     pub target: MessagesBufferLimits,
     pub max: MessagesBufferLimits,

--- a/collator/src/collator/messages_reader/state/ext/reader.rs
+++ b/collator/src/collator/messages_reader/state/ext/reader.rs
@@ -7,7 +7,10 @@ use tycho_util::transactional::value::TransactionalValue;
 use tycho_util_proc::Transactional;
 
 use crate::collator::messages_reader::state::ext::partition_reader::ExternalsPartitionReaderState;
-use crate::collator::messages_reader::state::ext::range_reader::ExternalsRangeReaderState;
+use crate::collator::messages_reader::state::ext::range_reader::{
+    DebugExternalsRangeReaderState, ExternalsRangeReaderState,
+};
+use crate::types::DebugIter;
 use crate::types::processed_upto::BlockSeqno;
 
 #[derive(Transactional, Default)]
@@ -39,5 +42,28 @@ impl ExternalsReaderState {
         self.by_partitions
             .get(&par_id)
             .with_context(|| format!("externals reader state not exists for partition {par_id}"))
+    }
+}
+
+pub struct DebugExternalsReaderState<'a>(pub &'a ExternalsReaderState);
+
+impl std::fmt::Debug for DebugExternalsReaderState<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("")
+            .field(
+                "ranges",
+                &DebugIter(
+                    self.0
+                        .ranges
+                        .iter()
+                        .map(|(seqno, state)| (seqno, DebugExternalsRangeReaderState(state))),
+                ),
+            )
+            .field("by_partitions", &DebugIter(self.0.by_partitions.iter()))
+            .field(
+                "last_read_to_anchor_chain_time",
+                &*self.0.last_read_to_anchor_chain_time,
+            )
+            .finish()
     }
 }

--- a/collator/src/collator/messages_reader/state/int/partition_reader.rs
+++ b/collator/src/collator/messages_reader/state/int/partition_reader.rs
@@ -5,9 +5,10 @@ use tycho_util::transactional::value::TransactionalValue;
 use tycho_util_proc::Transactional;
 
 use crate::collator::messages_reader::state;
+use crate::collator::messages_reader::state::int::DebugInternalsRangeReaderState;
 use crate::collator::messages_reader::state::int::range_reader::InternalsRangeReaderState;
-use crate::types::ProcessedTo;
 use crate::types::processed_upto::{BlockSeqno, InternalsProcessedUptoStuff};
+use crate::types::{DebugIter, ProcessedTo};
 
 #[derive(Transactional, Default)]
 pub struct InternalsPartitionReaderState {
@@ -58,5 +59,25 @@ impl From<&InternalsProcessedUptoStuff> for InternalsPartitionReaderState {
             processed_to: value.processed_to.clone().into(),
             ranges: ranges.into(),
         }
+    }
+}
+
+pub struct DebugInternalsPartitionReaderState<'a>(pub &'a InternalsPartitionReaderState);
+
+impl std::fmt::Debug for DebugInternalsPartitionReaderState<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("")
+            .field(
+                "ranges",
+                &DebugIter(
+                    self.0
+                        .ranges
+                        .iter()
+                        .map(|(seqno, state)| (seqno, DebugInternalsRangeReaderState(state))),
+                ),
+            )
+            .field("processed_to", &*self.0.processed_to)
+            .field("curr_processed_offset", &*self.0.curr_processed_offset)
+            .finish()
     }
 }

--- a/collator/src/collator/messages_reader/state/int/reader.rs
+++ b/collator/src/collator/messages_reader/state/int/reader.rs
@@ -4,9 +4,11 @@ use tycho_util::transactional::hashmap::TransactionalHashMap;
 use tycho_util::transactional::option::TransactionalOption;
 use tycho_util_proc::Transactional;
 
-use crate::collator::messages_reader::state::int::partition_reader::InternalsPartitionReaderState;
+use crate::collator::messages_reader::state::int::partition_reader::{
+    DebugInternalsPartitionReaderState, InternalsPartitionReaderState,
+};
 use crate::collator::statistics::cumulative::CumulativeStatistics;
-use crate::types::ProcessedTo;
+use crate::types::{DebugIter, ProcessedTo};
 
 #[derive(Transactional, Default)]
 pub struct InternalsReaderState {
@@ -42,5 +44,23 @@ impl InternalsReaderState {
         if !self.partitions.contains_key(&par_id) {
             self.partitions.insert(par_id, Default::default());
         }
+    }
+}
+
+pub struct DebugInternalsReaderState<'a>(pub &'a InternalsReaderState);
+
+impl std::fmt::Debug for DebugInternalsReaderState<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("")
+            .field(
+                "partitions",
+                &DebugIter(
+                    self.0
+                        .partitions
+                        .iter()
+                        .map(|(par_id, state)| (par_id, DebugInternalsPartitionReaderState(state))),
+                ),
+            )
+            .finish()
     }
 }

--- a/collator/src/manager/blocks_cache.rs
+++ b/collator/src/manager/blocks_cache.rs
@@ -243,6 +243,8 @@ impl BlocksCache {
     /// ```
     /// and MB2 is first applied
     /// then will return `[MB1, SB2]`
+    ///
+    /// Returns empty on zerostate or hard fork.
     pub fn read_before_tail_ids_of_mc_block(
         &self,
         mc_block_key: &BlockCacheKey,

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -2449,6 +2449,13 @@ where
                     tracing::debug!(
                         target: tracing_targets::COLLATION_MANAGER,
                         public_key = %self.keypair.public_key,
+                        current_session_seqno,
+                        hash_short,
+                        "Current node was not authorized to collate shard {}. Use TRACE to see subset",
+                        shard_id,
+                    );
+                    tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
+                        subset = ?DebugIter(subset.values()),
                         "Current node was not authorized to collate shard {}",
                         shard_id,
                     );

--- a/util/src/transactional/hashmap.rs
+++ b/util/src/transactional/hashmap.rs
@@ -82,7 +82,7 @@ impl<K: Hash + Eq + Clone, V: Transactional> TransactionalHashMap<K, V> {
         self.inner.is_empty()
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> + Clone {
         self.inner.iter()
     }
 


### PR DESCRIPTION
When hardfork was made on very high block seqno, e.g. 57971914, collator stuck on trying to check the max messages limit per an internals range reader. It tried to read diffs 0..57971914 to perform check but they are not exists.

Added fallback. The check is omitted when there is not previous range reader state in processed_upto, that means that is a start from zerostate/hardfork.

## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

[None]

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

[None]

---

### COMPATIBILITY

Fully compatible

### SPECIAL DEPLOYMENT ACTIONS

[Not Required]

---

### PERFORMANCE IMPACT

[No impact expected]

---

### TESTS

#### Unit Tests

[No coverage]

#### Network Tests

[No coverage]

#### Manual Tests

Manual tests used:
- run network
- stop some node X
- drop database
- restart node X

---

**Notes/Additional Comments:**  