### PR TITLE
explicit cancel collation flow

### DIFF
--- a/collator/src/collator/do_collate/execute.rs
+++ b/collator/src/collator/do_collate/execute.rs
@@ -9,7 +9,7 @@ use super::finalize::FinalizeState;
 use super::phase::{Phase, PhaseState};
 use super::work_units::PrepareMsgGroupsWu;
 use crate::collator::do_collate::work_units::ExecuteWu;
-use crate::collator::error::{CollationCancelReason, CollatorError};
+use crate::collator::error::CollatorError;
 use crate::collator::messages_reader::{
     GetNextMessageGroupMode, MessagesReader, MessagesReaderMetrics,
 };
@@ -119,9 +119,7 @@ impl<'a, 'b> Phase<ExecuteState<'a, 'b>> {
 
             // exit collation if cancelled
             if self.state.collation_is_cancelled.check() {
-                return Err(CollatorError::Cancelled(
-                    CollationCancelReason::ExternalCancel,
-                ));
+                return Err(CollatorError::Cancelled);
             }
 
             let timer = std::time::Instant::now();

--- a/collator/src/collator/do_collate/finalize.rs
+++ b/collator/src/collator/do_collate/finalize.rs
@@ -29,7 +29,7 @@ use crate::collator::do_collate::finalize::vset_update_start::{
     KbNextSessionStart, KbNextSessionUpdate,
 };
 use crate::collator::do_collate::work_units::FinalizeWu;
-use crate::collator::error::{CollationCancelReason, CollatorError};
+use crate::collator::error::{CollationAbortReason, CollatorError};
 use crate::collator::execution_manager::MessagesExecutor;
 use crate::collator::max_anchors_processing_lag_rounds;
 use crate::collator::messages_reader::{FinalizedMessagesReader, MessagesReader};
@@ -127,7 +127,7 @@ impl Phase<FinalizeState> {
                         "finalize_messages_reader: cannot get diff with stats from queue for block {}",
                         top_block_id.as_short_id(),
                     );
-                    CollatorError::Cancelled(CollationCancelReason::DiffNotFoundInQueue(
+                    CollatorError::Aborted(CollationAbortReason::DiffNotFoundInQueue(
                         top_block_id.as_short_id(),
                     ))
                 })?;

--- a/collator/src/collator/do_collate/mod.rs
+++ b/collator/src/collator/do_collate/mod.rs
@@ -25,7 +25,7 @@ use self::phase::{ActualState, Phase};
 use self::prepare::PrepareState;
 use self::work_units::{DoCollateWu, WuEvent, WuEventData};
 use crate::collator::anchors_cache::AnchorsCacheTransaction;
-use crate::collator::error::{CollationCancelReason, CollatorError};
+use crate::collator::error::CollatorError;
 use crate::collator::messages_reader::state::ReaderState;
 use crate::collator::types::{
     AnchorsCache, BlockCollationData, BlockCollationDataBuilder, BlockSerializerCache,
@@ -232,9 +232,7 @@ impl CollatorStdImpl {
                     .and_then(|(collation_result, pending_queue_diff_tx)| {
                         // exit collation if cancelled before writing queue diff
                         if collation_is_cancelled.check() {
-                            return Err(CollatorError::Cancelled(
-                                CollationCancelReason::ExternalCancel,
-                            ));
+                            return Err(CollatorError::Cancelled);
                         }
                         Ok((collation_result, pending_queue_diff_tx))
                     });
@@ -333,13 +331,21 @@ impl CollatorStdImpl {
             execute_result,
             final_result,
         } = match do_collate_res {
-            Err(CollatorError::Cancelled(reason)) => {
+            Err(CollatorError::Cancelled) => {
                 tracing::info!(target: tracing_targets::COLLATOR,
-                    "collation was cancelled on do_collate",
+                    "collation was cancelled by manager on do_collate",
                 );
 
                 // cancel collation
-                return Ok(CollatorResult::cancelled(
+                return Ok(CollatorResult::cancelled(mc_block_id, next_block_id_short));
+            }
+            Err(CollatorError::Aborted(reason)) => {
+                tracing::info!(target: tracing_targets::COLLATOR,
+                    "collation was aborted on do_collate",
+                );
+
+                // abort collation
+                return Ok(CollatorResult::aborted(
                     mc_block_id,
                     next_block_id_short,
                     reason,
@@ -644,9 +650,7 @@ impl CollatorStdImpl {
 
         // exit collation if cancelled
         if collation_is_cancelled.check() {
-            return Err(CollatorError::Cancelled(
-                CollationCancelReason::ExternalCancel,
-            ));
+            return Err(CollatorError::Cancelled);
         }
 
         let diff_tail_len =

--- a/collator/src/collator/do_collate/mod.rs
+++ b/collator/src/collator/do_collate/mod.rs
@@ -314,7 +314,7 @@ impl CollatorStdImpl {
             _ = async move {
                 collation_cancelled.await;
                 tracing::info!(target: tracing_targets::COLLATOR,
-                    "collation was cancelled by manager on do_collate",
+                    "collation cancel requested on do_collate",
                 );
                 collation_is_cancelled.cancel();
                 std::future::pending::<()>().await;
@@ -334,6 +334,10 @@ impl CollatorStdImpl {
             final_result,
         } = match do_collate_res {
             Err(CollatorError::Cancelled(reason)) => {
+                tracing::info!(target: tracing_targets::COLLATOR,
+                    "collation was cancelled on do_collate",
+                );
+
                 // cancel collation
                 return Ok(CollatorResult::cancelled(
                     mc_block_id,

--- a/collator/src/collator/do_collate/prepare.rs
+++ b/collator/src/collator/do_collate/prepare.rs
@@ -6,7 +6,6 @@ use tycho_types::models::GlobalCapability;
 use super::execute::ExecuteState;
 use super::execution_wrapper::ExecutorWrapper;
 use super::phase::{Phase, PhaseState};
-use crate::collator::CollationCancelReason;
 use crate::collator::anchors_cache::AnchorsCacheTransaction;
 use crate::collator::do_collate::phase::ActualState;
 use crate::collator::error::CollatorError;
@@ -176,9 +175,7 @@ impl<'a, 'b> Phase<PrepareState<'a, 'b>> {
 
             // exit collation if cancelled
             if collation_is_cancelled_debounce.check() {
-                return Err(CollatorError::Cancelled(
-                    CollationCancelReason::ExternalCancel,
-                ));
+                return Err(CollatorError::Cancelled);
             }
         }
 

--- a/collator/src/collator/error.rs
+++ b/collator/src/collator/error.rs
@@ -3,17 +3,18 @@ use tycho_types::models::BlockIdShort;
 use crate::mempool::MempoolAnchorId;
 
 #[derive(Debug)]
-pub enum CollationCancelReason {
+pub enum CollationAbortReason {
     AnchorNotFound(MempoolAnchorId),
     NextAnchorNotFound(MempoolAnchorId),
-    ExternalCancel,
     DiffNotFoundInQueue(BlockIdShort),
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum CollatorError {
-    #[error("Cancelled(reason: {0:?})")]
-    Cancelled(CollationCancelReason),
+    #[error("Aborted(reason: {0:?})")]
+    Aborted(CollationAbortReason),
+    #[error("Cancelled externally")]
+    Cancelled,
     #[error(transparent)]
     Anyhow(#[from] anyhow::Error),
 }

--- a/collator/src/collator/mod.rs
+++ b/collator/src/collator/mod.rs
@@ -116,7 +116,9 @@ where
 
 #[async_trait]
 pub trait Collator: Send + Sync + 'static {
+    fn next_block_id_short(&self) -> &BlockIdShort;
     fn shard_id(&self) -> &ShardIdent;
+
     /// Init collator and try to collate next block
     async fn init(
         self: Box<Self>,
@@ -194,6 +196,10 @@ pub struct CollatorStdImpl {
 
 #[async_trait]
 impl Collator for CollatorStdImpl {
+    fn next_block_id_short(&self) -> &BlockIdShort {
+        &self.next_block_info
+    }
+
     fn shard_id(&self) -> &ShardIdent {
         &self.shard_id
     }
@@ -344,6 +350,10 @@ impl CollatorStdImpl {
             .try_import_init_anchors(&mut working_state, anchors_proc_info_opt, &genesis_info)
             .await?
         {
+            tracing::info!(target: tracing_targets::COLLATOR,
+                "collation was cancelled by manager on init_collator",
+            );
+
             self.delayed_working_state.delay(working_state);
             return Ok(CollatorResult::Cancelled(cancel_ctx));
         }
@@ -557,7 +567,7 @@ impl CollatorStdImpl {
             res = import_fut => res,
             _ = cancel_collation.notified() => {
                 tracing::info!(target: tracing_targets::COLLATOR,
-                    "collation was cancelled by manager",
+                    "collation was cancelled by manager on try_import_init_anchors",
                 );
                 let labels = [("workchain", self.shard_id.workchain().to_string())];
                 metrics::counter!("tycho_collator_anchor_import_cancelled_count", &labels[..]).increment(1);
@@ -605,7 +615,7 @@ impl CollatorStdImpl {
         Ok(NextCollationFlowStep::Continue)
     }
 
-    #[tracing::instrument("resume_collation", skip_all, fields(next_block_id = %self.next_block_info))]
+    #[tracing::instrument(name = "resume_collation", skip_all, fields(next_block_id = %self.next_block_info))]
     async fn resume_collation_impl(
         &mut self,
         mc_data: Arc<McData>,
@@ -702,6 +712,10 @@ impl CollatorStdImpl {
                 .try_import_init_anchors(&mut working_state, anchors_proc_info_opt, &genesis_info)
                 .await?
             {
+                tracing::info!(target: tracing_targets::COLLATOR,
+                    "collation was cancelled by manager on resume_collation",
+                );
+
                 self.delayed_working_state.delay(working_state);
                 return Ok(CollatorResult::Cancelled(cancel_ctx));
             }

--- a/collator/src/collator/mod.rs
+++ b/collator/src/collator/mod.rs
@@ -24,8 +24,8 @@ use self::error::CollatorError;
 use self::messages_reader::state::ReaderState;
 use self::messages_reader::{MessagesReader, MessagesReaderContext};
 use self::types::{
-    BlockSerializerCache, CollatorStats, MsgsExecutionParamsStuff, NextCollationFlowStep, PrevData,
-    WorkingState,
+    AbortedContext, BlockSerializerCache, CollatorStats, MsgsExecutionParamsStuff,
+    NextCollationFlowStep, PrevData, WorkingState,
 };
 use crate::internal_queue::types::message::EnqueuedMessage;
 use crate::mempool::{GetAnchorResult, MempoolAdapter, MempoolAnchorId};
@@ -50,7 +50,7 @@ mod statistics;
 mod types;
 
 pub use do_collate::{is_first_block_after_prev_master, work_units};
-pub use error::CollationCancelReason;
+pub use error::CollationAbortReason;
 pub use types::{
     CancelledContext, CollatorResult, DebugCollatorResult, ForceMasterCollation,
     ShardDescriptionExt,
@@ -346,16 +346,27 @@ impl CollatorStdImpl {
         } = self.handle_mempool_genesis(&mut working_state).await?;
 
         // try import init anchors
-        if let NextCollationFlowStep::Cancel(cancel_ctx) = self
+        let try_import_res = self
             .try_import_init_anchors(&mut working_state, anchors_proc_info_opt, &genesis_info)
-            .await?
-        {
-            tracing::info!(target: tracing_targets::COLLATOR,
-                "collation was cancelled by manager on init_collator",
-            );
+            .await?;
+        match try_import_res {
+            NextCollationFlowStep::Cancel(cancel_ctx) => {
+                tracing::info!(target: tracing_targets::COLLATOR,
+                    "collation was cancelled by manager on init_collator",
+                );
 
-            self.delayed_working_state.delay(working_state);
-            return Ok(CollatorResult::Cancelled(cancel_ctx));
+                self.delayed_working_state.delay(working_state);
+                return Ok(CollatorResult::Cancelled(cancel_ctx));
+            }
+            NextCollationFlowStep::Abort(abort_ctx) => {
+                tracing::info!(target: tracing_targets::COLLATOR,
+                    "collation was aborted on init_collator",
+                );
+
+                self.delayed_working_state.delay(working_state);
+                return Ok(CollatorResult::Aborted(abort_ctx));
+            }
+            NextCollationFlowStep::Continue => {}
         }
 
         self.timer = std::time::Instant::now();
@@ -493,8 +504,8 @@ impl CollatorStdImpl {
             // if last processed_to anchor is before the start round for master,
             // then cancel collation because we need to receive more blocks from bc
             else if self.shard_id.is_masterchain() {
-                return Err(CollatorError::Cancelled(
-                    CollationCancelReason::AnchorNotFound(anchors_proc_info.processed_to_anchor_id),
+                return Err(CollatorError::Aborted(
+                    CollationAbortReason::AnchorNotFound(anchors_proc_info.processed_to_anchor_id),
                 ));
             }
             // last processed_to anchor in shard can be before last processed in master
@@ -571,7 +582,7 @@ impl CollatorStdImpl {
                 );
                 let labels = [("workchain", self.shard_id.workchain().to_string())];
                 metrics::counter!("tycho_collator_anchor_import_cancelled_count", &labels[..]).increment(1);
-                Err(CollatorError::Cancelled(CollationCancelReason::ExternalCancel))
+                Err(CollatorError::Cancelled)
             }
         };
 
@@ -579,11 +590,17 @@ impl CollatorStdImpl {
             anchors_info,
             mut anchors_count_above_last_imported_in_current_shard,
         } = match import_res {
-            Err(CollatorError::Cancelled(cancel_reason)) => {
+            Err(CollatorError::Cancelled) => {
                 return Ok(NextCollationFlowStep::Cancel(CancelledContext {
                     prev_mc_block_id: working_state.mc_data.block_id,
                     next_block_id_short: working_state.next_block_id_short,
-                    cancel_reason,
+                }));
+            }
+            Err(CollatorError::Aborted(reason)) => {
+                return Ok(NextCollationFlowStep::Abort(AbortedContext {
+                    prev_mc_block_id: working_state.mc_data.block_id,
+                    next_block_id_short: working_state.next_block_id_short,
+                    reason,
                 }));
             }
             res => res?,
@@ -708,16 +725,27 @@ impl CollatorStdImpl {
             genesis_was_updated = genesis_updated;
 
             // try import init anchors
-            if let NextCollationFlowStep::Cancel(cancel_ctx) = self
+            let try_import_res = self
                 .try_import_init_anchors(&mut working_state, anchors_proc_info_opt, &genesis_info)
-                .await?
-            {
-                tracing::info!(target: tracing_targets::COLLATOR,
-                    "collation was cancelled by manager on resume_collation",
-                );
+                .await?;
+            match try_import_res {
+                NextCollationFlowStep::Cancel(cancel_ctx) => {
+                    tracing::info!(target: tracing_targets::COLLATOR,
+                        "collation was cancelled by manager on resume_collation",
+                    );
 
-                self.delayed_working_state.delay(working_state);
-                return Ok(CollatorResult::Cancelled(cancel_ctx));
+                    self.delayed_working_state.delay(working_state);
+                    return Ok(CollatorResult::Cancelled(cancel_ctx));
+                }
+                NextCollationFlowStep::Abort(abort_ctx) => {
+                    tracing::info!(target: tracing_targets::COLLATOR,
+                        "collation was aborted on resume_collation",
+                    );
+
+                    self.delayed_working_state.delay(working_state);
+                    return Ok(CollatorResult::Aborted(abort_ctx));
+                }
+                NextCollationFlowStep::Continue => {}
             }
 
             working_state
@@ -1251,8 +1279,8 @@ impl CollatorStdImpl {
                     .get_anchor_by_id(processed_to_anchor_id)
                     .await?
                 else {
-                    return Err(CollatorError::Cancelled(
-                        CollationCancelReason::AnchorNotFound(processed_to_anchor_id),
+                    return Err(CollatorError::Aborted(
+                        CollationAbortReason::AnchorNotFound(processed_to_anchor_id),
                     ));
                 };
                 prev_anchor_id = anchor.id;
@@ -1304,8 +1332,8 @@ impl CollatorStdImpl {
             let GetAnchorResult::Exist(anchor) =
                 mpool_adapter.get_next_anchor(prev_anchor_id).await?
             else {
-                return Err(CollatorError::Cancelled(
-                    CollationCancelReason::NextAnchorNotFound(prev_anchor_id),
+                return Err(CollatorError::Aborted(
+                    CollationAbortReason::NextAnchorNotFound(prev_anchor_id),
                 ));
             };
             prev_anchor_id = anchor.id;
@@ -1491,7 +1519,6 @@ impl CollatorStdImpl {
                         let res = CollatorResult::cancelled(
                             working_state.mc_data.block_id,
                             working_state.next_block_id_short,
-                            CollationCancelReason::ExternalCancel,
                         );
                         self.delayed_working_state.delay(working_state);
 
@@ -1677,7 +1704,6 @@ impl CollatorStdImpl {
                 let res = CollatorResult::cancelled(
                     working_state.mc_data.block_id,
                     working_state.next_block_id_short,
-                    CollationCancelReason::ExternalCancel,
                 );
                 self.delayed_working_state.delay(working_state);
 
@@ -1700,10 +1726,10 @@ impl CollatorStdImpl {
                         "next anchor not exist, cancel collation attempts",
                     );
 
-                    let res = CollatorResult::cancelled(
+                    let res = CollatorResult::aborted(
                         working_state.mc_data.block_id,
                         working_state.next_block_id_short,
-                        CollationCancelReason::NextAnchorNotFound(prev_anchor_id),
+                        CollationAbortReason::NextAnchorNotFound(prev_anchor_id),
                     );
                     self.delayed_working_state.delay(working_state);
 
@@ -1958,7 +1984,6 @@ impl CollatorStdImpl {
                             let res = CollatorResult::cancelled(
                                     working_state.mc_data.block_id,
                                     working_state.next_block_id_short,
-                                    CollationCancelReason::ExternalCancel,
                                 );
                             self.delayed_working_state.delay(working_state);
 
@@ -1982,10 +2007,10 @@ impl CollatorStdImpl {
                                     "next anchor not exist, cancel collation attempts",
                                 );
 
-                                let res = CollatorResult::cancelled(
+                                let res = CollatorResult::aborted(
                                     working_state.mc_data.block_id,
                                     working_state.next_block_id_short,
-                                    CollationCancelReason::NextAnchorNotFound(prev_anchor_id),
+                                    CollationAbortReason::NextAnchorNotFound(prev_anchor_id),
                                 );
                                 self.delayed_working_state.delay(working_state);
 

--- a/collator/src/collator/tests/messages_reader_tests.rs
+++ b/collator/src/collator/tests/messages_reader_tests.rs
@@ -826,7 +826,7 @@ impl<V: InternalMessageValue> TestCollator<V> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument("test_collate", skip_all, fields(block_id = %BlockIdShort { shard: self.shard_id, seqno: self.block_seqno + 1 }))]
+    #[tracing::instrument(name = "test_collate", skip_all, fields(block_id = %BlockIdShort { shard: self.shard_id, seqno: self.block_seqno + 1 }))]
     fn test_collate_block_and_check_refill<F>(
         &mut self,
         block_tx_limit: usize,

--- a/collator/src/collator/types.rs
+++ b/collator/src/collator/types.rs
@@ -28,7 +28,7 @@ use tycho_types::num::Tokens;
 use tycho_util::{FastHashMap, FastHashSet};
 
 use super::do_collate::work_units::PrepareMsgGroupsWu;
-use super::error::CollationCancelReason;
+use super::error::CollationAbortReason;
 use super::messages_reader::MessagesReaderMetrics;
 use crate::collator::do_collate::work_units::{DoCollateWu, ExecuteWu, FinalizeWu};
 use crate::collator::messages_reader::MetricsTimer;
@@ -204,13 +204,20 @@ impl PrevData {
 pub(super) enum NextCollationFlowStep {
     Continue,
     Cancel(CancelledContext),
+    Abort(AbortedContext),
 }
 
 #[derive(Debug)]
 pub struct CancelledContext {
     pub prev_mc_block_id: BlockId,
     pub next_block_id_short: BlockIdShort,
-    pub cancel_reason: CollationCancelReason,
+}
+
+#[derive(Debug)]
+pub struct AbortedContext {
+    pub prev_mc_block_id: BlockId,
+    pub next_block_id_short: BlockIdShort,
+    pub reason: CollationAbortReason,
 }
 
 pub enum CollatorResult {
@@ -222,6 +229,7 @@ pub enum CollatorResult {
         collation_config: Arc<CollationConfig>,
     },
     Cancelled(CancelledContext),
+    Aborted(AbortedContext),
     BlockCandidate {
         collation_result: BlockCollationResult,
     },
@@ -248,6 +256,9 @@ impl std::fmt::Debug for DebugCollatorResult<'_> {
                 .finish(),
             CollatorResult::Cancelled(cancel_ctx) => {
                 f.debug_tuple("Cancelled").field(cancel_ctx).finish()
+            }
+            CollatorResult::Aborted(abort_ctx) => {
+                f.debug_tuple("Aborted").field(abort_ctx).finish()
             }
             CollatorResult::BlockCandidate { .. } => {
                 f.debug_struct("BlockCandidate").finish_non_exhaustive()
@@ -279,15 +290,22 @@ impl CollatorResult {
         }
     }
 
-    pub fn cancelled(
-        prev_mc_block_id: BlockId,
-        next_block_id_short: BlockIdShort,
-        cancel_reason: CollationCancelReason,
-    ) -> Self {
+    pub fn cancelled(prev_mc_block_id: BlockId, next_block_id_short: BlockIdShort) -> Self {
         Self::Cancelled(CancelledContext {
             prev_mc_block_id,
             next_block_id_short,
-            cancel_reason,
+        })
+    }
+
+    pub fn aborted(
+        prev_mc_block_id: BlockId,
+        next_block_id_short: BlockIdShort,
+        reason: CollationAbortReason,
+    ) -> Self {
+        Self::Aborted(AbortedContext {
+            prev_mc_block_id,
+            next_block_id_short,
+            reason,
         })
     }
 }

--- a/collator/src/manager/active_collators.rs
+++ b/collator/src/manager/active_collators.rs
@@ -23,6 +23,27 @@ where
         }
     }
 
+    pub(super) fn set_collator_and_state<SetState>(
+        &self,
+        collator: Box<CF::Collator>,
+        set_state: SetState,
+    ) -> Result<CollatorState>
+    where
+        SetState: FnOnce(&mut ActiveCollator<Box<CF::Collator>>),
+    {
+        match self.active_collators.get_mut(collator.shard_id()) {
+            Some(mut active_collator) => {
+                active_collator.collator = Some(collator);
+                set_state(&mut active_collator);
+                Ok(active_collator.state)
+            }
+            None => bail!(
+                "active_collators does not contain collator state for {}",
+                collator.shard_id(),
+            ),
+        }
+    }
+
     pub(super) fn take_collator_and_set_state_if<Check, SetState>(
         &self,
         shard_id: &ShardIdent,
@@ -51,29 +72,25 @@ where
         }
     }
 
-    pub(super) fn set_collator_state<F>(&self, shard_id: &ShardIdent, f: F) -> Option<CollatorState>
+    pub(super) fn set_collator_state<SetState>(
+        &self,
+        shard_id: &ShardIdent,
+        set_state: SetState,
+    ) -> Option<CollatorState>
     where
-        F: Fn(&mut ActiveCollator<Box<CF::Collator>>),
+        SetState: FnOnce(&mut ActiveCollator<Box<CF::Collator>>),
     {
         match self.active_collators.get_mut(shard_id) {
             Some(mut active_collator) => {
-                f(&mut active_collator);
+                set_state(&mut active_collator);
                 Some(active_collator.state)
             }
             None => None,
         }
     }
 
-    pub(super) fn set_collators_state<Filter, F>(&self, mut filter: Filter, f: F)
-    where
-        Filter: FnMut(&ShardIdent, &ActiveCollator<Box<CF::Collator>>) -> bool,
-        F: Fn(&mut ActiveCollator<Box<CF::Collator>>),
-    {
-        for mut active_collator in self.active_collators.iter_mut() {
-            if filter(active_collator.key(), active_collator.value()) {
-                f(&mut active_collator);
-            }
-        }
+    pub(super) fn get_collator_state(&self, shard_id: &ShardIdent) -> Option<CollatorState> {
+        self.active_collators.get(shard_id).map(|ac| ac.state)
     }
 
     pub(super) fn request_cancel_collations(&self) -> bool {
@@ -88,7 +105,7 @@ where
         has_active
     }
 
-    pub(super) fn has_active_collator(&self) -> bool {
+    pub(super) fn has_active_collations(&self) -> bool {
         self.active_collators
             .iter()
             .any(|ac| ac.state == CollatorState::Active || ac.state == CollatorState::CancelPending)

--- a/collator/src/manager/active_collators.rs
+++ b/collator/src/manager/active_collators.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, bail};
+use futures_util::FutureExt;
 use tycho_types::models::ShardIdent;
 
 use crate::collator::{Collator, CollatorFactory};
@@ -66,6 +67,10 @@ where
                 };
 
                 set_state(&mut active_collator);
+
+                // drain a stale cancel permit before starting another collation attempt
+                let _ = active_collator.cancel_collation.notified().now_or_never();
+
                 Some(collator).transpose()
             }
             None => bail!("collator for {} not started", shard_id),

--- a/collator/src/manager/active_collators.rs
+++ b/collator/src/manager/active_collators.rs
@@ -89,6 +89,18 @@ where
         }
     }
 
+    pub(super) fn set_collators_state<Filter, F>(&self, mut filter: Filter, f: F)
+    where
+        Filter: FnMut(&ShardIdent, &ActiveCollator<Box<CF::Collator>>) -> bool,
+        F: Fn(&mut ActiveCollator<Box<CF::Collator>>),
+    {
+        for mut active_collator in self.active_collators.iter_mut() {
+            if filter(active_collator.key(), active_collator.value()) {
+                f(&mut active_collator);
+            }
+        }
+    }
+
     pub(super) fn get_collator_state(&self, shard_id: &ShardIdent) -> Option<CollatorState> {
         self.active_collators.get(shard_id).map(|ac| ac.state)
     }

--- a/collator/src/manager/blocks_cache.rs
+++ b/collator/src/manager/blocks_cache.rs
@@ -379,6 +379,8 @@ impl BlocksCache {
     }
 
     /// Store received from bc block in a cache
+    ///
+    /// Returns `None` when received block is not newer then existed
     #[tracing::instrument(skip_all)]
     pub async fn store_received(
         &self,
@@ -405,6 +407,8 @@ impl BlocksCache {
         let last_known_synced = 'sync: {
             if block_id.is_masterchain() {
                 let mut masters_guard = self.inner.masters.lock();
+
+                // do not store if received block is not newer than existed
                 if let Some(last_known_synced) =
                     masters_guard.check_refresh_last_known_synced(block_id.seqno)
                 {
@@ -430,6 +434,7 @@ impl BlocksCache {
 
                 let res = {
                     let mut g = self.inner.shards.entry(block_id.shard).or_default();
+                    // do not store if received block is not newer than existed
                     if let Some(last_known_synced) =
                         g.check_refresh_last_known_synced(block_id.seqno)
                     {

--- a/collator/src/manager/cancel_validation_runner.rs
+++ b/collator/src/manager/cancel_validation_runner.rs
@@ -7,12 +7,17 @@ use tycho_block_util::state::ShardStateStuff;
 use super::CollationManager;
 use crate::collator::CollatorFactory;
 use crate::tracing_targets;
-use crate::validator::Validator;
+use crate::validator::{ValidationSessionId, Validator};
+
+struct CancelValidationTask {
+    state: ShardStateStuff,
+    session_id: Option<ValidationSessionId>,
+}
 
 #[derive(Default)]
 pub(super) struct CancelValidationRunnerState {
     running: bool,
-    pending: Option<ShardStateStuff>,
+    pending: Option<CancelValidationTask>,
 }
 
 impl<CF, V> CollationManager<CF, V>
@@ -29,11 +34,19 @@ where
             return;
         }
 
+        // capture session id and create cancellation task
+        let session_id = self
+            .active_collation_sessions
+            .read()
+            .get(&state.block_id().shard)
+            .map(|session_info| session_info.get_validation_session_id());
+        let task = CancelValidationTask { state, session_id };
+
         let mut guard = self.cancel_validation_runner.lock();
 
         // schedule next task if cancellation is already running
         if guard.running {
-            guard.pending = Some(state);
+            guard.pending = Some(task);
             return;
         }
 
@@ -44,7 +57,7 @@ where
         let mgr = self.clone();
         tokio::spawn(
             async move {
-                mgr.run_cancel_validation_sessions_until_block(state).await;
+                mgr.run_cancel_validation_sessions_until_block(task).await;
             }
             .instrument(tracing::Span::current()),
         );
@@ -52,11 +65,11 @@ where
 
     async fn run_cancel_validation_sessions_until_block(
         self: Arc<Self>,
-        mut state: ShardStateStuff,
+        mut task: CancelValidationTask,
     ) {
         loop {
             // execute validation cancellation
-            if let Err(e) = self.cancel_validation_sessions_until_block(state) {
+            if let Err(e) = self.cancel_validation_sessions_until_block(task) {
                 tracing::error!(
                     target: tracing_targets::COLLATION_MANAGER,
                     "failed to cancel validation sessions: {e:?}",
@@ -78,23 +91,17 @@ where
 
             // run next cancellation task or exit
             match next {
-                Some(next) => state = next,
+                Some(next) => task = next,
                 None => break,
             }
         }
     }
 
-    #[tracing::instrument(skip_all, fields(block_id = %state.block_id().as_short_id()))]
-    fn cancel_validation_sessions_until_block(&self, state: ShardStateStuff) -> Result<()> {
-        let block_id = state.block_id().as_short_id();
-
-        let session_id = self
-            .active_collation_sessions
-            .read()
-            .get(&block_id.shard)
-            .map(|session_info| session_info.get_validation_session_id());
-
-        self.validator.cancel_validation(&block_id, session_id)?;
+    #[tracing::instrument(skip_all, fields(block_id = %task.state.block_id().as_short_id()))]
+    fn cancel_validation_sessions_until_block(&self, task: CancelValidationTask) -> Result<()> {
+        let block_id = task.state.block_id().as_short_id();
+        self.validator
+            .cancel_validation(&block_id, task.session_id)?;
         Ok(())
     }
 }

--- a/collator/src/manager/cancel_validation_runner.rs
+++ b/collator/src/manager/cancel_validation_runner.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use anyhow::Result;
+use tracing::Instrument;
 use tycho_block_util::state::ShardStateStuff;
 
 use super::CollationManager;
@@ -40,9 +42,12 @@ where
         drop(guard);
 
         let mgr = self.clone();
-        tokio::spawn(async move {
-            mgr.run_cancel_validation_sessions_until_block(state).await;
-        });
+        tokio::spawn(
+            async move {
+                mgr.run_cancel_validation_sessions_until_block(state).await;
+            }
+            .instrument(tracing::Span::current()),
+        );
     }
 
     async fn run_cancel_validation_sessions_until_block(
@@ -77,5 +82,19 @@ where
                 None => break,
             }
         }
+    }
+
+    #[tracing::instrument(skip_all, fields(block_id = %state.block_id().as_short_id()))]
+    fn cancel_validation_sessions_until_block(&self, state: ShardStateStuff) -> Result<()> {
+        let block_id = state.block_id().as_short_id();
+
+        let session_id = self
+            .active_collation_sessions
+            .read()
+            .get(&block_id.shard)
+            .map(|session_info| session_info.get_validation_session_id());
+
+        self.validator.cancel_validation(&block_id, session_id)?;
+        Ok(())
     }
 }

--- a/collator/src/manager/collation_cancel.rs
+++ b/collator/src/manager/collation_cancel.rs
@@ -67,23 +67,26 @@ impl CollationCancelHandle {
 }
 
 impl CollationCancelHandle {
-    #[tracing::instrument(name = "collation_cancel", skip_all, fields(action_after = %DisplayActionAfterCancel(&action), collator_tasks_count = collator_tasks.len()))]
+    #[tracing::instrument(name = "collation_cancel", skip_all, fields(collator_tasks_count = collator_tasks.len()))]
     pub(super) async fn start_or_update<CF: CollatorFactory, V: Validator>(
         &mut self,
         collation_manager: &Arc<CollationManager<CF, V>>,
-        action: ActionAfterCancel,
+        action: Option<ActionAfterCancel>,
         collator_tasks: &mut FuturesUnordered<CollatorJoinTask<CF::Collator>>,
     ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
         // if current action exists,
         // previous cancel task is not finished or cancel result is not handled,
         // so we can update action
         if self.action_after.is_some() {
-            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                old_action_after = ?self.action_after.as_ref().map(DisplayActionAfterCancel),
-                "collation cancel task already exists, action updated",
-            );
+            if let Some(action) = action {
+                tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                    old_action_after = ?self.action_after.as_ref().map(DisplayActionAfterCancel),
+                    new_action_after = %DisplayActionAfterCancel(&action),
+                    "collation cancel task already exists, action updated",
+                );
 
-            self.action_after = Some(action);
+                self.action_after = Some(action);
+            }
 
             // if no new running collation tasks,
             // we can exit and let to handle previous cancel task result with updated action
@@ -91,16 +94,22 @@ impl CollationCancelHandle {
                 return Ok(vec![]);
             }
         } else {
-            // no current action
+            // no current action, no running cancel task
             assert!(
                 self.task_wrapper.is_empty(),
                 "cancel task should be already drained here"
             );
 
+            let Some(action) = action else {
+                // will not cancel if action after sync was not provided
+                return Ok(vec![]);
+            };
+
             // if no new running collation tasks,
             // then just handle action after cancel
             if collator_tasks.is_empty() {
                 tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                    action_after = %DisplayActionAfterCancel(&action),
                     "no collator tasks, will handle action right now",
                 );
 
@@ -174,6 +183,17 @@ impl CollationCancelHandle {
         self.task_wrapper.is_empty()
     }
 
+    pub(super) fn running_and_will_sync_after(&self) -> bool {
+        !self.is_empty()
+            && matches!(
+                self.action_after,
+                Some(ActionAfterCancel::SyncToAppliedMcBlock {
+                    applied_range: Some(_),
+                    ..
+                })
+            )
+    }
+
     pub(super) async fn wait(&mut self) -> Option<Result<ActionAfterCancel>> {
         let res = self.task_wrapper.next().await;
         res.map(|cancel_res| {
@@ -191,6 +211,29 @@ where
     CF: CollatorFactory,
     V: Validator,
 {
+    pub(super) async fn handle_new_collator_tasks_and_cancel_request(
+        self: &Arc<Self>,
+        collation_cancel_task: &mut CollationCancelHandle,
+        collator_tasks_handle: &mut FuturesUnordered<CollatorJoinTask<CF::Collator>>,
+        new_collator_tasks: Vec<CollatorJoinTask<CF::Collator>>,
+        cancel_action: Option<ActionAfterCancel>,
+    ) -> Result<()> {
+        // collect new collator tasks
+        for task in new_collator_tasks {
+            collator_tasks_handle.push(task);
+        }
+
+        // run collation cancel task if requested
+        for task in collation_cancel_task
+            .start_or_update(self, cancel_action, collator_tasks_handle)
+            .await?
+        {
+            collator_tasks_handle.push(task);
+        }
+
+        Ok(())
+    }
+
     pub(super) async fn handle_collation_cancel_action(
         self: &Arc<Self>,
         action: ActionAfterCancel,

--- a/collator/src/manager/collation_cancel.rs
+++ b/collator/src/manager/collation_cancel.rs
@@ -7,7 +7,7 @@ use tracing::Instrument;
 use tycho_types::models::{BlockId, BlockIdShort};
 use tycho_util::futures::JoinTask;
 
-use crate::collator::{Collator, CollatorFactory, DebugCollatorResult};
+use crate::collator::{Collator, CollatorFactory, CollatorResult, DebugCollatorResult};
 use crate::manager::types::CollatorJoinTask;
 use crate::manager::{CollationManager, CollatorState, ProcessMcStateUpdateMode};
 use crate::tracing_targets;
@@ -148,6 +148,11 @@ impl CollationCancelHandle {
                         "cancelled collator task result for {}",
                         collator.shard_id(),
                     );
+
+                    // clear uncomitted queue state on block candidate
+                    if matches!(res, CollatorResult::BlockCandidate { .. }) {
+                        collation_manager.clear_uncommitted_queue_state()?;
+                    }
 
                     // store collator with `Cancelled` state
                     collation_manager.set_collator_and_state(collator, |ac| {

--- a/collator/src/manager/collation_cancel.rs
+++ b/collator/src/manager/collation_cancel.rs
@@ -137,6 +137,8 @@ impl CollationCancelHandle {
             "collation cancel task spawned",
         );
 
+        collation_manager.request_cancel_collations();
+
         // new collation tasks exist
         // we should cancel new collation tasks
         // awaiting previous cancel task before if exists
@@ -150,8 +152,6 @@ impl CollationCancelHandle {
                 while let Some(prev_task_res) = previous_task_wrapper.next().await {
                     prev_task_res?;
                 }
-
-                collation_manager.request_cancel_collations();
 
                 // await collation tasks
                 while let Some(collator_res) = collator_tasks.next().await {

--- a/collator/src/manager/collation_cancel.rs
+++ b/collator/src/manager/collation_cancel.rs
@@ -19,6 +19,7 @@ type CollationCancelResult = Result<()>;
 
 #[derive(Debug)]
 pub(super) enum ActionAfterCancel {
+    Noop,
     SyncToAppliedMcBlock {
         trigger_block_id_short: BlockIdShort,
         last_collated_mc_block_id: Option<BlockId>,
@@ -43,6 +44,7 @@ impl std::fmt::Display for DisplayActionAfterCancel<'_> {
                 .field("applied_range", &applied_range)
                 .field("process_state_update_mode", &process_state_update_mode)
                 .finish(),
+            ActionAfterCancel::Noop => "Noop".fmt(f),
         }
     }
 }
@@ -78,7 +80,9 @@ impl CollationCancelHandle {
         // previous cancel task is not finished or cancel result is not handled,
         // so we can update action
         if self.action_after.is_some() {
-            if let Some(action) = action {
+            if let Some(action) = action
+                && matches!(action, ActionAfterCancel::SyncToAppliedMcBlock { .. })
+            {
                 tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
                     old_action_after = ?self.action_after.as_ref().map(DisplayActionAfterCancel),
                     new_action_after = %DisplayActionAfterCancel(&action),
@@ -111,6 +115,13 @@ impl CollationCancelHandle {
                 tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
                     action_after = %DisplayActionAfterCancel(&action),
                     "no collator tasks, will handle action right now",
+                );
+
+                // mark every collator `Cancelled`
+                // next sync will resume collation
+                collation_manager.set_collators_state(
+                    |_, ac| ac.state != CollatorState::Cancelled,
+                    |ac| ac.state = CollatorState::Cancelled,
                 );
 
                 return collation_manager
@@ -168,6 +179,13 @@ impl CollationCancelHandle {
                         ac.state = CollatorState::Cancelled;
                     })?;
                 }
+
+                // mark every collator `Cancelled`
+                // next sync will resume collation
+                collation_manager.set_collators_state(
+                    |_, ac| ac.state != CollatorState::Cancelled,
+                    |ac| ac.state = CollatorState::Cancelled,
+                );
 
                 Ok::<_, anyhow::Error>(())
             }
@@ -252,6 +270,10 @@ where
                     process_state_update_mode,
                 )
                 .await
+            }
+            ActionAfterCancel::Noop => {
+                // do nothing
+                Ok(vec![])
             }
         }
     }

--- a/collator/src/manager/collation_cancel.rs
+++ b/collator/src/manager/collation_cancel.rs
@@ -1,0 +1,210 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures_util::StreamExt;
+use futures_util::stream::FuturesUnordered;
+use tracing::Instrument;
+use tycho_types::models::{BlockId, BlockIdShort};
+use tycho_util::futures::JoinTask;
+
+use crate::collator::{Collator, CollatorFactory, DebugCollatorResult};
+use crate::manager::types::CollatorJoinTask;
+use crate::manager::{CollationManager, CollatorState, ProcessMcStateUpdateMode};
+use crate::tracing_targets;
+use crate::types::DebugDisplay;
+use crate::types::processed_upto::BlockSeqno;
+use crate::validator::Validator;
+
+type CollationCancelResult = Result<()>;
+
+#[derive(Debug)]
+pub(super) enum ActionAfterCancel {
+    SyncToAppliedMcBlock {
+        trigger_block_id_short: BlockIdShort,
+        last_collated_mc_block_id: Option<BlockId>,
+        applied_range: Option<(BlockSeqno, BlockSeqno)>,
+        process_state_update_mode: ProcessMcStateUpdateMode,
+    },
+}
+
+pub(super) struct DisplayActionAfterCancel<'a>(pub &'a ActionAfterCancel);
+impl std::fmt::Display for DisplayActionAfterCancel<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            ActionAfterCancel::SyncToAppliedMcBlock {
+                trigger_block_id_short,
+                last_collated_mc_block_id,
+                applied_range,
+                process_state_update_mode,
+            } => f
+                .debug_struct("SyncToAppliedMcBlock")
+                .field("trigger_block_id", &DebugDisplay(trigger_block_id_short))
+                .field("last_collated_mc_block_id", last_collated_mc_block_id)
+                .field("applied_range", &applied_range)
+                .field("process_state_update_mode", &process_state_update_mode)
+                .finish(),
+        }
+    }
+}
+impl std::fmt::Debug for DisplayActionAfterCancel<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+
+pub(super) struct CollationCancelHandle {
+    action_after: Option<ActionAfterCancel>,
+    task_wrapper: FuturesUnordered<JoinTask<CollationCancelResult>>,
+}
+
+impl CollationCancelHandle {
+    pub fn new() -> Self {
+        Self {
+            action_after: Default::default(),
+            task_wrapper: Default::default(),
+        }
+    }
+}
+
+impl CollationCancelHandle {
+    #[tracing::instrument(name = "collation_cancel", skip_all, fields(action_after = %DisplayActionAfterCancel(&action), collator_tasks_count = collator_tasks.len()))]
+    pub(super) async fn start_or_update<CF: CollatorFactory, V: Validator>(
+        &mut self,
+        collation_manager: &Arc<CollationManager<CF, V>>,
+        action: ActionAfterCancel,
+        collator_tasks: &mut FuturesUnordered<CollatorJoinTask<CF::Collator>>,
+    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
+        // if current action exists,
+        // previous cancel task is not finished or cancel result is not handled,
+        // so we can update action
+        if self.action_after.is_some() {
+            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                old_action_after = ?self.action_after.as_ref().map(DisplayActionAfterCancel),
+                "collation cancel task already exists, action updated",
+            );
+
+            self.action_after = Some(action);
+
+            // if no new running collation tasks,
+            // we can exit and let to handle previous cancel task result with updated action
+            if collator_tasks.is_empty() {
+                return Ok(vec![]);
+            }
+        } else {
+            // no current action
+            assert!(
+                self.task_wrapper.is_empty(),
+                "cancel task should be already drained here"
+            );
+
+            // if no new running collation tasks,
+            // then just handle action after cancel
+            if collator_tasks.is_empty() {
+                tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                    "no collator tasks, will handle action right now",
+                );
+
+                return collation_manager
+                    .handle_collation_cancel_action(action)
+                    .await;
+            } else {
+                // otherwise store action because we will run cancel task
+                self.action_after = Some(action);
+            }
+        }
+
+        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+            "collation cancel task spawned",
+        );
+
+        // new collation tasks exist
+        // we should cancel new collation tasks
+        // awaiting previous cancel task before if exists
+        let mut previous_task_wrapper = std::mem::take(&mut self.task_wrapper);
+        let mut collator_tasks = std::mem::take(collator_tasks);
+        let collation_manager = collation_manager.clone();
+
+        let task = JoinTask::new(
+            async move {
+                // await prev cancel task
+                while let Some(prev_task_res) = previous_task_wrapper.next().await {
+                    prev_task_res?;
+                }
+
+                collation_manager.request_cancel_collations();
+
+                // await collation tasks
+                while let Some(collator_res) = collator_tasks.next().await {
+                    let (collator, res) = collator_res?;
+
+                    tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                        next_block_id = %collator.next_block_id_short(),
+                        "collator task cancelled for {}",
+                        collator.shard_id(),
+                    );
+                    tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
+                        next_block_id = %collator.next_block_id_short(),
+                        result = ?DebugCollatorResult(&res),
+                        "cancelled collator task result for {}",
+                        collator.shard_id(),
+                    );
+
+                    // store collator with `Cancelled` state
+                    collation_manager.set_collator_and_state(collator, |ac| {
+                        ac.state = CollatorState::Cancelled;
+                    })?;
+                }
+
+                Ok::<_, anyhow::Error>(())
+            }
+            .instrument(tracing::Span::current()),
+        );
+
+        self.task_wrapper.push(task);
+
+        Ok(vec![])
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.task_wrapper.is_empty()
+    }
+
+    pub(super) async fn wait(&mut self) -> Option<Result<ActionAfterCancel>> {
+        let res = self.task_wrapper.next().await;
+        res.map(|cancel_res| {
+            cancel_res.map(|_| {
+                self.action_after
+                    .take()
+                    .expect("action after cancel should exist here")
+            })
+        })
+    }
+}
+
+impl<CF, V> CollationManager<CF, V>
+where
+    CF: CollatorFactory,
+    V: Validator,
+{
+    pub(super) async fn handle_collation_cancel_action(
+        self: &Arc<Self>,
+        action: ActionAfterCancel,
+    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
+        match action {
+            ActionAfterCancel::SyncToAppliedMcBlock {
+                trigger_block_id_short,
+                last_collated_mc_block_id,
+                applied_range,
+                process_state_update_mode,
+            } => {
+                self.sync_to_applied_mc_block_if_exist(
+                    trigger_block_id_short,
+                    last_collated_mc_block_id,
+                    applied_range,
+                    process_state_update_mode,
+                )
+                .await
+            }
+        }
+    }
+}

--- a/collator/src/manager/collation_cancel.rs
+++ b/collator/src/manager/collation_cancel.rs
@@ -54,6 +54,29 @@ impl std::fmt::Debug for DisplayActionAfterCancel<'_> {
     }
 }
 
+pub(super) fn update_action_after(
+    curr_action: &mut Option<ActionAfterCancel>,
+    new_action: Option<ActionAfterCancel>,
+) -> bool {
+    let Some(new_action) = new_action else {
+        return false;
+    };
+
+    // sync must not be downgraded to a drain-only cancel
+    if matches!(
+        (curr_action.as_ref(), &new_action),
+        (
+            Some(ActionAfterCancel::SyncToAppliedMcBlock { .. }),
+            ActionAfterCancel::Noop,
+        )
+    ) {
+        return false;
+    }
+
+    *curr_action = Some(new_action);
+    true
+}
+
 pub(super) struct CollationCancelHandle {
     action_after: Option<ActionAfterCancel>,
     task_wrapper: FuturesUnordered<JoinTask<CollationCancelResult>>,
@@ -80,16 +103,12 @@ impl CollationCancelHandle {
         // previous cancel task is not finished or cancel result is not handled,
         // so we can update action
         if self.action_after.is_some() {
-            if let Some(action) = action
-                && matches!(action, ActionAfterCancel::SyncToAppliedMcBlock { .. })
-            {
+            let action_updated = update_action_after(&mut self.action_after, action);
+            if action_updated {
                 tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                    old_action_after = ?self.action_after.as_ref().map(DisplayActionAfterCancel),
-                    new_action_after = %DisplayActionAfterCancel(&action),
+                    action_after = ?self.action_after.as_ref().map(DisplayActionAfterCancel),
                     "collation cancel task already exists, action updated",
                 );
-
-                self.action_after = Some(action);
             }
 
             // if no new running collation tasks,
@@ -104,7 +123,7 @@ impl CollationCancelHandle {
                 "cancel task should be already drained here"
             );
 
-            let Some(action) = action else {
+            if !update_action_after(&mut self.action_after, action) {
                 // will not cancel if action after sync was not provided
                 return Ok(vec![]);
             };
@@ -112,6 +131,10 @@ impl CollationCancelHandle {
             // if no new running collation tasks,
             // then just handle action after cancel
             if collator_tasks.is_empty() {
+                let action = self
+                    .action_after
+                    .take()
+                    .expect("action after cancel should exist here");
                 tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
                     action_after = %DisplayActionAfterCancel(&action),
                     "no collator tasks, will handle action right now",
@@ -129,7 +152,6 @@ impl CollationCancelHandle {
                     .await;
             } else {
                 // otherwise store action because we will run cancel task
-                self.action_after = Some(action);
             }
         }
 

--- a/collator/src/manager/commit.rs
+++ b/collator/src/manager/commit.rs
@@ -1,0 +1,169 @@
+use anyhow::Result;
+use tycho_types::models::BlockId;
+use tycho_util::metrics::HistogramGuard;
+
+use super::CollationManager;
+use super::types::{
+    BlockCacheEntryData, CandidateStatus, CollatorJoinTask, McBlockSubgraph, McBlockSubgraphExtract,
+};
+use crate::collator::CollatorFactory;
+use crate::tracing_targets;
+use crate::validator::Validator;
+
+impl<CF, V> CollationManager<CF, V>
+where
+    CF: CollatorFactory,
+    V: Validator,
+{
+    /// Try to commit validated and valid master block
+    /// if it was not already committed before
+    /// 1. Check if master block is valid
+    /// 2. Extract master block subgraph with shard blocks
+    /// 3. Send to sync
+    /// 4. Commit queue diff
+    /// 5. Clean up from cache
+    /// 6. Process delayed master state update if exists
+    /// 7. Notify top processed anchor to mempool if block commited by received from bc
+    pub(super) async fn commit_valid_master_block(
+        &self,
+        mc_block_id: &BlockId,
+        skip_process_delayed_mc_state_update: bool,
+    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
+        tracing::debug!(
+            target: tracing_targets::COLLATION_MANAGER,
+            "Start to commit validated and valid master block ({})...",
+            mc_block_id.as_short_id(),
+        );
+
+        // gc blocks from cache when commit finished
+        scopeguard::defer!(self.blocks_cache.gc_prev_blocks());
+
+        // we can process delayed master state update now
+        let (mut top_processed_to_anchor_to_notify, collator_tasks) = self
+            .notify_to_mempool_and_process_delayed_mc_state_update(
+                mc_block_id,
+                skip_process_delayed_mc_state_update,
+            )
+            .await?
+            .unzip();
+
+        let histogram = HistogramGuard::begin("tycho_collator_commit_valid_master_block_time");
+        let histogram_extract =
+            HistogramGuard::begin("tycho_collator_extract_master_block_subgraph_time");
+        let mut extract_elapsed = Default::default();
+        let mut sync_elapsed = Default::default();
+
+        // extract master block with all shard blocks if valid, and process them
+        match self
+            .blocks_cache
+            .extract_mc_block_subgraph_for_sync(mc_block_id)
+        {
+            McBlockSubgraphExtract::Extracted(subgraph) => {
+                extract_elapsed = histogram_extract.finish();
+
+                let partitions = subgraph.get_partitions();
+
+                let McBlockSubgraph {
+                    master_block,
+                    shard_blocks,
+                } = subgraph;
+
+                // we can gc upto to current master block after commit
+                // because we do not need to commit all previous blocks
+                // because all previous blocks are already in bc state
+                // and all previous diffs already committed by current one
+                let to_blocks_keys = master_block.get_top_blocks_keys()?;
+                self.blocks_cache.set_gc_to_boundary(&to_blocks_keys);
+
+                // send to sync only if was not received from bc
+                if matches!(&master_block.data, BlockCacheEntryData::Collated {
+                    received_after_collation: false,
+                    ..
+                }) {
+                    let histogram =
+                        HistogramGuard::begin("tycho_collator_send_blocks_to_sync_time");
+
+                    self.send_block_to_sync(master_block.data)?;
+
+                    for shard_block in shard_blocks {
+                        self.send_block_to_sync(shard_block.data)?;
+                    }
+
+                    sync_elapsed = histogram.finish();
+                    tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                        total = sync_elapsed.as_millis(),
+                        "send_blocks_to_sync timings",
+                    );
+
+                    // if current master block was not applied to bc state yet
+                    // then we should not notify top processed to anchor to mempool now
+                    // because we are not sure that block will be applied
+                    // and should wait until block_accepted event is received
+                    top_processed_to_anchor_to_notify = None;
+                } else {
+                    // if current block was committed by received one
+                    // then `on_block_accepted` will not be called further
+                    // so we need to notify `top_processed_to_anchor` to mempool here
+                    top_processed_to_anchor_to_notify = master_block.top_processed_to_anchor;
+                }
+
+                let _histogram =
+                    HistogramGuard::begin("tycho_collator_send_blocks_to_sync_commit_diffs_time");
+
+                Self::commit_block_queue_diff(
+                    self.mq_adapter.clone(),
+                    &master_block.block_id,
+                    &master_block.top_shard_blocks_info,
+                    &partitions,
+                )?;
+            }
+            McBlockSubgraphExtract::AlreadyExtracted => {
+                tracing::debug!(
+                    target: tracing_targets::COLLATION_MANAGER,
+                    "Master block subgraph is already extracted and cleaned up from cache ({}). Do nothing",
+                    mc_block_id.as_short_id(),
+                );
+            }
+        }
+
+        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+            total = histogram.finish().as_millis(),
+            extract_subgraph = extract_elapsed.as_millis(),
+            sync = sync_elapsed.as_millis(),
+            "commit_valid_master_block timings",
+        );
+
+        // report last processed anchor to mempool
+        if let Some(top_processed_to_anchor) = top_processed_to_anchor_to_notify {
+            self.notify_top_processed_to_anchor_to_mempool(
+                mc_block_id.seqno,
+                top_processed_to_anchor,
+            )
+            .await?;
+        }
+
+        Ok(collator_tasks.unwrap_or_default())
+    }
+
+    fn send_block_to_sync(&self, data: BlockCacheEntryData) -> Result<()> {
+        let candidate_stuff = match data {
+            BlockCacheEntryData::Collated {
+                candidate_stuff,
+                status,
+                received_after_collation: false,
+                ..
+            } if status != CandidateStatus::Synced => candidate_stuff,
+            _ => return Ok(()),
+        };
+
+        let block_id = *candidate_stuff.candidate.block.id();
+        self.state_node_adapter
+            .accept_block(candidate_stuff.into_block_for_sync())?;
+        tracing::debug!(
+            target: tracing_targets::COLLATION_MANAGER,
+            "Block was successfully sent to sync ({})",
+            block_id,
+        );
+        Ok(())
+    }
+}

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -425,21 +425,6 @@ where
         Ok(())
     }
 
-    // TODO: move to cancel_validation_runner.rs
-    #[tracing::instrument(skip_all, fields(block_id = %state.block_id().as_short_id()))]
-    fn cancel_validation_sessions_until_block(&self, state: ShardStateStuff) -> Result<()> {
-        let block_id = state.block_id().as_short_id();
-
-        let session_id = self
-            .active_collation_sessions
-            .read()
-            .get(&block_id.shard)
-            .map(|session_info| session_info.get_validation_session_id());
-
-        self.validator.cancel_validation(&block_id, session_id)?;
-        Ok(())
-    }
-
     #[tracing::instrument(skip_all, fields(block_id = %block_id))]
     fn commit_block_queue_diff(
         mq_adapter: Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
@@ -1197,15 +1182,7 @@ where
         let is_key_block = ctx.state.state_extra()?.after_key_block;
 
         // stop any running validations up to this block
-        // try to get the validation session ID from active collation sessions
-        let session_id = self
-            .active_collation_sessions
-            .read()
-            .get(&block_id.shard)
-            .map(|session_info| session_info.get_validation_session_id());
-
-        self.validator
-            .cancel_validation(&block_id.as_short_id(), session_id)?;
+        self.schedule_cancel_validation_sessions_until_block(ctx.state.clone());
 
         // check if should sync to last applied mc block right now
         let should_sync_to_last_applied_mc_block = 'check_should_sync: {

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -28,9 +28,10 @@ use self::collation_cancel::{ActionAfterCancel, CollationCancelHandle};
 use self::state_event_listener::{ChannelStateEventListener, StateEvent};
 use self::types::{
     ActiveCollator, ActiveSync, BlockCacheEntry, BlockCacheEntryData, BlockCacheKey,
-    CandidateStatus, CollatedBlockInfo, CollationState, CollationStatus, CollationSyncState,
-    CollatorJoinTask, CollatorState, HandledBlockFromBcCtx, ImportedAnchorEvent, McBlockSubgraph,
-    McBlockSubgraphExtract, NextCollationStep, ValidatorJoinTask,
+    BlockCacheStoreResult, CandidateStatus, CollatedBlockInfo, CollationState, CollationStatus,
+    CollationSyncState, CollatorJoinTask, CollatorState, HandledBlockFromBcCtx,
+    ImportedAnchorEvent, McBlockSubgraph, McBlockSubgraphExtract, NextCollationStep,
+    ValidatorJoinTask,
 };
 use self::utils::find_us_in_collators_set;
 use crate::collator::{
@@ -927,62 +928,17 @@ where
         };
 
         // check if should sync to last applied mc block
-        let should_sync_to_last_applied_mc_block = 'check_should_sync: {
-            // do not sync to last applied mc block if newer already received
-            if self.has_newer_received_mc_block(store_res.applied_mc_queue_range) {
-                break 'check_should_sync false;
-            }
-
-            // should sync if collated block mismatched
-            if store_res.block_mismatch {
-                break 'check_should_sync true;
-            }
-
-            // check if should sync when we have applied blocks
-            if let Some((_, applied_range_end)) = store_res.applied_mc_queue_range {
-                // we can sync only when we have any applied block ahead
-                if let Some(last_collated_mc_block_id) = store_res.last_collated_mc_block_id {
-                    let applied_range_end_delta =
-                        applied_range_end.saturating_sub(last_collated_mc_block_id.seqno);
-                    if applied_range_end_delta < self.config.min_mc_block_delta_from_bc_to_sync {
-                        // should collate next own mc block because last applied is not far ahead
-                        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                            "check_should_sync: should collate next own mc block: \
-                            last applied ({}) ahead last collated ({}) on {} < {}",
-                            applied_range_end, last_collated_mc_block_id.seqno,
-                            applied_range_end_delta, self.config.min_mc_block_delta_from_bc_to_sync,
-                        );
-                        false
-                    } else {
-                        // should sync to last applied mc block from bc because it is far ahead
-                        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                            "check_should_sync: should sync to last applied mc block from bc: \
-                            last applied ({}) ahead last collated ({}) on {} >= {}",
-                            applied_range_end, last_collated_mc_block_id.seqno,
-                            applied_range_end_delta, self.config.min_mc_block_delta_from_bc_to_sync,
-                        );
-                        true
-                    }
-                } else {
-                    // should sync to last applied mc block from bc when last collated not exist
-                    tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                        "check_should_sync: should sync to last applied mc block from bc: \
-                        last applied ({}) and last collated not exist",
-                        applied_range_end,
-                    );
-                    true
-                }
-            } else {
-                // should collate next own mc block because no applied ahead
-                tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                    "check_should_sync: should collate next own mc block after because nothing applied ahead",
-                );
-                false
-            }
-        };
+        let should_sync_to_last_applied_mc_block = self.check_should_sync_to_last_applied_mc_block(
+            &store_res,
+            store_res.last_collated_mc_block_id,
+            self.config.min_mc_block_delta_from_bc_to_sync,
+            collation_result
+                .mc_data
+                .as_ref()
+                .map(|mc_data| mc_data.prev_key_block_seqno == mc_data.block_id.seqno),
+        );
 
         // run sync or process just collated block
-        let mut collator_tasks = vec![];
         if should_sync_to_last_applied_mc_block {
             // before sync will cancel any active collations
             Ok(HandleTaskResult::with_cancel(
@@ -1015,6 +971,7 @@ where
 
             // process validation
             let mut validator_task = None;
+            let mut collator_tasks = vec![];
             if store_res.received_and_collated {
                 // NOTE: here commit will not cause on_block_accepted event
                 //      because block already exist in bc state
@@ -1058,7 +1015,7 @@ where
                 "will run next collation step",
             );
 
-            collator_tasks = self
+            let collator_tasks = self
                 .run_next_collation_step(
                     &collation_result.prev_mc_block_id,
                     block_id.shard,
@@ -1249,99 +1206,22 @@ where
         self.schedule_cancel_validation_sessions_until_block(ctx.state.clone());
 
         // check if should sync to last applied mc block right now
-        let should_sync_to_last_applied_mc_block = 'check_should_sync: {
-            // sync only to the last master block from batch or to a key block
-            if !is_last_mc_block_in_batch && !is_key_block {
-                break 'check_should_sync false;
-            }
-
-            // do not sync to last applied mc block if newer already received
-            if self.has_newer_received_mc_block(store_res.applied_mc_queue_range) {
-                break 'check_should_sync false;
-            }
-
-            // should sync if collated block mismatched
-            if store_res.block_mismatch {
-                break 'check_should_sync true;
-            }
-
-            // check if should sync
-            if let Some(top_mc_block_id_for_next_collation) =
-                self.get_top_mc_block_id_for_next_collation(store_res.last_collated_mc_block_id)
-            {
-                // we can sync only when we have any applied block ahead
-                if let Some((_, applied_range_end)) = store_res.applied_mc_queue_range {
-                    // check if should sync according to master block delta
-                    let should_sync = {
-                        let applied_range_end_delta = applied_range_end
-                            .saturating_sub(top_mc_block_id_for_next_collation.seqno);
-
-                        // we should sync to every key block if node is not in current vset
-                        let required_min_mc_block_delta = if is_key_block
-                            && !self.active_collators.contains_key(&ShardIdent::MASTERCHAIN)
-                        {
-                            1
-                        } else {
-                            self.config.min_mc_block_delta_from_bc_to_sync
-                        };
-
-                        if applied_range_end_delta < required_min_mc_block_delta {
-                            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                                last_synced_to_mc_block_id = ?self.get_last_synced_to_mc_block_id().map(|id| id.as_short_id().to_string()),
-                                last_collated_mc_block_id = ?store_res.last_collated_mc_block_id.map(|id| id.as_short_id().to_string()),
-                                last_processed_mc_block_id = ?self.get_last_processed_mc_block_id().map(|id| id.as_short_id().to_string()),
-                                received_is_key_block = is_key_block,
-                                "check_should_sync: should wait for next collated own mc block: \
-                                last applied ({}) ahead of top for collation ({}) on {} < {}",
-                                applied_range_end, top_mc_block_id_for_next_collation.seqno,
-                                applied_range_end_delta, required_min_mc_block_delta,
-                            );
-                            false
-                        } else {
-                            tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                                last_synced_to_mc_block_id = ?self.get_last_synced_to_mc_block_id().map(|id| id.as_short_id().to_string()),
-                                last_collated_mc_block_id = ?store_res.last_collated_mc_block_id.map(|id| id.as_short_id().to_string()),
-                                last_processed_mc_block_id = ?self.get_last_processed_mc_block_id().map(|id| id.as_short_id().to_string()),
-                                received_is_key_block = is_key_block,
-                                "check_should_sync: should sync to last applied mc block from bc: \
-                                last applied ({}) ahead of top for collation ({}) on {} >= {}",
-                                applied_range_end, top_mc_block_id_for_next_collation.seqno,
-                                applied_range_end_delta, required_min_mc_block_delta,
-                            );
-                            true
-                        }
-                    };
-
-                    if should_sync {
-                        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                            last_synced_to_mc_block_id = ?self.get_last_synced_to_mc_block_id().map(|id| id.as_short_id().to_string()),
-                            last_collated_mc_block_id = ?store_res.last_collated_mc_block_id.map(|id| id.as_short_id().to_string()),
-                            last_processed_mc_block_id = ?self.get_last_processed_mc_block_id().map(|id| id.as_short_id().to_string()),
-                            received_is_key_block = is_key_block,
-                            has_active_collations = self.has_active_collations(),
-                            "check_should_sync: will request sync to last applied mc block",
-                        );
-                    }
-
-                    should_sync
-                } else {
-                    // should collate next own mc block because no applied ahead
-                    tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                        last_synced_to_mc_block_id = ?self.get_last_synced_to_mc_block_id().map(|id| id.as_short_id().to_string()),
-                        last_collated_mc_block_id = ?store_res.last_collated_mc_block_id.map(|id| id.as_short_id().to_string()),
-                        last_processed_mc_block_id = ?self.get_last_processed_mc_block_id().map(|id| id.as_short_id().to_string()),
-                        "check_should_sync: should collate next own mc block after because nothing applied ahead",
-                    );
-                    false
-                }
+        let top_mc_block_id_for_next_collation =
+            self.get_top_mc_block_id_for_next_collation(store_res.last_collated_mc_block_id);
+        // we should sync to every key block if node is not in current vset
+        let required_min_mc_block_delta =
+            if is_key_block && !self.active_collators.contains_key(&ShardIdent::MASTERCHAIN) {
+                1
             } else {
-                tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                    received_is_key_block = is_key_block,
-                    "should sync to last applied mc block when no last collated or prev sync to",
-                );
-                true
-            }
-        };
+                self.config.min_mc_block_delta_from_bc_to_sync
+            };
+        let should_sync_to_last_applied_mc_block = (is_last_mc_block_in_batch || is_key_block)
+            && self.check_should_sync_to_last_applied_mc_block(
+                &store_res,
+                top_mc_block_id_for_next_collation,
+                required_min_mc_block_delta,
+                Some(is_key_block),
+            );
 
         // run sync or commit block
         if should_sync_to_last_applied_mc_block {
@@ -1378,6 +1258,93 @@ where
             }
 
             Ok(HandleTaskResult::with_tasks(None, collator_tasks))
+        }
+    }
+
+    fn check_should_sync_to_last_applied_mc_block(
+        &self,
+        store_res: &BlockCacheStoreResult,
+        top_mc_block_id_for_next_collation: Option<BlockId>,
+        required_min_mc_block_delta: BlockSeqno,
+        is_key_block: Option<bool>,
+    ) -> bool {
+        // do not sync to last applied mc block if newer already received
+        if self.has_newer_received_mc_block(store_res.applied_mc_queue_range) {
+            return false;
+        }
+
+        // should sync if collated block mismatched
+        if store_res.block_mismatch {
+            return true;
+        }
+
+        let has_active_collations = self.has_active_collations();
+        let last_synced_to_mc_block_id = self
+            .get_last_synced_to_mc_block_id()
+            .map(|id| id.as_short_id().to_string());
+        let last_collated_mc_block_id = store_res
+            .last_collated_mc_block_id
+            .map(|id| id.as_short_id().to_string());
+        let last_processed_mc_block_id = self
+            .get_last_processed_mc_block_id()
+            .map(|id| id.as_short_id().to_string());
+
+        if let Some(top_mc_block_id_for_next_collation) = top_mc_block_id_for_next_collation {
+            // we can sync only when we have any applied block ahead
+            if let Some((_, applied_range_end)) = store_res.applied_mc_queue_range {
+                // check if should sync according to master block delta
+                let applied_range_end_delta =
+                    applied_range_end.saturating_sub(top_mc_block_id_for_next_collation.seqno);
+
+                if applied_range_end_delta < required_min_mc_block_delta {
+                    tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                        last_synced_to_mc_block_id = ?last_synced_to_mc_block_id,
+                        last_collated_mc_block_id = ?last_collated_mc_block_id,
+                        last_processed_mc_block_id = ?last_processed_mc_block_id,
+                        has_active_collations,
+                        is_key_block = ?is_key_block,
+                        "check_should_sync: should wait for next collated own mc block: \
+                        last applied ({}) ahead of top for collation ({}) on {} < {}",
+                        applied_range_end, top_mc_block_id_for_next_collation.seqno,
+                        applied_range_end_delta, required_min_mc_block_delta,
+                    );
+                    false
+                } else {
+                    tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+                        last_synced_to_mc_block_id = ?last_synced_to_mc_block_id,
+                        last_collated_mc_block_id = ?last_collated_mc_block_id,
+                        last_processed_mc_block_id = ?last_processed_mc_block_id,
+                        has_active_collations,
+                        is_key_block = ?is_key_block,
+                        "check_should_sync: should sync to last applied mc block from bc: \
+                        last applied ({}) ahead of top for collation ({}) on {} >= {}",
+                        applied_range_end, top_mc_block_id_for_next_collation.seqno,
+                        applied_range_end_delta, required_min_mc_block_delta,
+                    );
+                    true
+                }
+            } else {
+                // should collate next own mc block because no applied ahead
+                tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                    last_synced_to_mc_block_id = ?last_synced_to_mc_block_id,
+                    last_collated_mc_block_id = ?last_collated_mc_block_id,
+                    last_processed_mc_block_id = ?last_processed_mc_block_id,
+                    has_active_collations,
+                    is_key_block = ?is_key_block,
+                    "check_should_sync: should collate next own mc block after because nothing applied ahead",
+                );
+                false
+            }
+        } else {
+            tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+                last_synced_to_mc_block_id = ?last_synced_to_mc_block_id,
+                last_collated_mc_block_id = ?last_collated_mc_block_id,
+                last_processed_mc_block_id = ?last_processed_mc_block_id,
+                has_active_collations,
+                is_key_block = ?is_key_block,
+                "check_should_sync: should sync to last applied mc block when no last collated or prev sync to",
+            );
+            true
         }
     }
 

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -24,18 +24,18 @@ use tycho_util::{DashMapEntry, FastDashMap, FastHashMap, FastHashSet};
 
 use self::blocks_cache::BlocksCache;
 use self::cancel_validation_runner::CancelValidationRunnerState;
+use self::collation_cancel::{ActionAfterCancel, CollationCancelHandle};
 use self::state_event_listener::{ChannelStateEventListener, StateEvent};
 use self::types::{
     ActiveCollator, ActiveSync, BlockCacheEntry, BlockCacheEntryData, BlockCacheKey,
-    BlockCacheStoreResult, BlockCacheStoreSource, CandidateStatus, CollatedBlockInfo,
-    CollationState, CollationStatus, CollationSyncState, CollatorJoinTask, CollatorState,
-    HandledBlockFromBcCtx, ImportedAnchorEvent, McBlockSubgraph, McBlockSubgraphExtract,
-    NextCollationStep, ValidatorJoinTask,
+    CandidateStatus, CollatedBlockInfo, CollationState, CollationStatus, CollationSyncState,
+    CollatorJoinTask, CollatorState, HandledBlockFromBcCtx, ImportedAnchorEvent, McBlockSubgraph,
+    McBlockSubgraphExtract, NextCollationStep, ValidatorJoinTask,
 };
 use self::utils::find_us_in_collators_set;
 use crate::collator::{
-    CancelledContext, CollationCancelReason, Collator, CollatorContext, CollatorFactory,
-    CollatorResult, DebugCollatorResult, ForceMasterCollation,
+    Collator, CollatorContext, CollatorFactory, CollatorResult, DebugCollatorResult,
+    ForceMasterCollation,
 };
 use crate::internal_queue::types::diff::{DiffZone, QueueDiffWithMessages};
 use crate::internal_queue::types::message::EnqueuedMessage;
@@ -60,6 +60,7 @@ use crate::validator::{AddSession, ValidationStatus, Validator};
 mod active_collators;
 mod blocks_cache;
 mod cancel_validation_runner;
+mod collation_cancel;
 mod state_event_listener;
 mod types;
 mod utils;
@@ -266,6 +267,7 @@ where
 
         // set of collator tasks
         let mut collator_tasks = FuturesUnordered::new();
+        let mut collation_cancel_task = CollationCancelHandle::new();
 
         // set of validator tasks
         let mut validator_tasks = FuturesUnordered::new();
@@ -295,59 +297,40 @@ where
                         break;
                     }
 
-                    for task in self.handle_blocks_from_bc_batch(blocks_from_bc_batch).await? {
+                    let res = self.handle_blocks_from_bc_batch(blocks_from_bc_batch).await?;
+                    for task in res.collator_tasks {
                         collator_tasks.push(task);
+                    }
+
+                    // run collation cancel task if requested
+                    if let Some(action) = res.cancel_action {
+                        for task in collation_cancel_task.start_or_update(self, action, &mut collator_tasks).await? {
+                            collator_tasks.push(task);
+                        }
                     }
                 },
                 // handle collator tasks
                 Some(collator_res) = collator_tasks.next(), if !collator_tasks.is_empty() => {
-                    let (collator, res) = collator_res?;
+                    let res = self.handle_collator_task(collator_res).await?;
+                    if let Some(task) = res.validator_task {
+                        validator_tasks.push(task);
+                    }
+                    for task in res.collator_tasks {
+                        collator_tasks.push(task);
+                    }
 
-                    tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
-                        result = ?DebugCollatorResult(&res),
-                        "handle collator task result for {}",
-                        collator.shard_id(),
-                    );
-
-                    // store collator
-                    self.set_collator(collator)?;
-
-                    // handle result
-                    match res {
-                        // when collation was skipped
-                        CollatorResult::Skipped {
-                            prev_mc_block_id,
-                            next_block_id_short,
-                            anchor_chain_time,
-                            force_mc_block,
-                            collation_config
-                        } => {
-                            for task in self.handle_collation_skipped(prev_mc_block_id,
-                                next_block_id_short,
-                                anchor_chain_time,
-                                force_mc_block,
-                                collation_config
-                            ).await? {
-                                collator_tasks.push(task);
-                            }
+                    // run collation cancel task if requested
+                    if let Some(action) = res.cancel_action {
+                        for task in collation_cancel_task.start_or_update(self, action, &mut collator_tasks).await? {
+                            collator_tasks.push(task);
                         }
-                        // when collation was cancelled
-                        CollatorResult::Cancelled(cancel_ctx) => {
-                            let CancelledContext { prev_mc_block_id, next_block_id_short, cancel_reason } = cancel_ctx;
-                            for task in self.handle_collation_cancelled(prev_mc_block_id, next_block_id_short, cancel_reason).await? {
-                                collator_tasks.push(task);
-                            }
-                        }
-                        // when block candidate received
-                        CollatorResult::BlockCandidate { collation_result } => {
-                            let res = self.handle_collated_block_candidate(collation_result).await?;
-                            if let Some(task) = res.validator_task {
-                                validator_tasks.push(task);
-                            }
-                            for task in res.collator_tasks {
-                                collator_tasks.push(task);
-                            }
-                        }
+                    }
+                }
+                // handle collation cancel task
+                Some(res) = collation_cancel_task.wait(), if !collation_cancel_task.is_empty() => {
+                    let action_after = res?;
+                    for task in self.handle_collation_cancel_action(action_after).await? {
+                        collator_tasks.push(task);
                     }
                 }
                 // handle validator tasks
@@ -589,56 +572,53 @@ where
         Ok(Some(block_id))
     }
 
-    #[tracing::instrument(skip_all, fields(next_block_id = %next_block_id_short))]
-    async fn handle_collation_cancelled(
+    async fn handle_collator_task(
         self: &Arc<Self>,
-        _prev_mc_block_id: BlockId,
-        next_block_id_short: BlockIdShort,
-        cancel_reason: CollationCancelReason,
-    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
-        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-            ?cancel_reason,
-            "start handle collation cancelled",
+        collator_task_res: Result<(Box<CF::Collator>, CollatorResult)>,
+    ) -> Result<HandleCollatorTaskResult<CF::Collator>> {
+        let (collator, res) = collator_task_res?;
+
+        tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
+            result = ?DebugCollatorResult(&res),
+            "handle collator task result for {}",
+            collator.shard_id(),
         );
 
-        // NOTE: when collation cancelled from collator it guarantees
-        //      that uncommitted queue diff was not saved
-        match cancel_reason {
-            CollationCancelReason::AnchorNotFound(_)
-            | CollationCancelReason::NextAnchorNotFound(_)
-            | CollationCancelReason::ExternalCancel
-            | CollationCancelReason::DiffNotFoundInQueue(_) => {
-                // mark collator as cancelled
-                self.set_collator_state(&next_block_id_short.shard, |ac| {
-                    ac.state = CollatorState::Cancelled;
-                });
+        self.set_collator(collator)?;
 
-                // run sync if all collators cancelled or waiting
-                if !self.has_active_collator() {
-                    tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                        "no active collators in shards and masterchain, \
-                        will run sync to last applied mc block",
-                    );
-
-                    // get info about applied mc blocks in cache
-                    let (last_collated_mc_block_id, applied_range) = self
-                        .blocks_cache
-                        .get_last_collated_block_and_applied_mc_queue_range();
-
-                    // run sync if have applied mc blocks
-                    return self
-                        .sync_to_applied_mc_block_if_exist(
-                            last_collated_mc_block_id,
-                            applied_range,
-                            ProcessMcStateUpdateMode::StartCollation {
-                                reset_collators: true,
-                            },
-                        )
-                        .await;
-                }
+        match res {
+            CollatorResult::Skipped {
+                prev_mc_block_id,
+                next_block_id_short,
+                anchor_chain_time,
+                force_mc_block,
+                collation_config,
+            } => {
+                let collator_tasks = self
+                    .handle_collation_skipped(
+                        prev_mc_block_id,
+                        next_block_id_short,
+                        anchor_chain_time,
+                        force_mc_block,
+                        collation_config,
+                    )
+                    .await?;
+                Ok(HandleCollatorTaskResult {
+                    validator_task: None,
+                    collator_tasks,
+                    cancel_action: None,
+                })
+            }
+            CollatorResult::Cancelled(cancel_ctx) => {
+                bail!(
+                    "should not process `CollatorResult::Cancelled` in the main flow. cancel_ctx={:?}",
+                    cancel_ctx,
+                );
+            }
+            CollatorResult::BlockCandidate { collation_result } => {
+                self.handle_collated_block_candidate(collation_result).await
             }
         }
-        Ok(vec![])
     }
 
     #[tracing::instrument(skip_all, fields(next_block_id = %next_block_id_short, ct = anchor_chain_time, ?force_mc_block))]
@@ -654,18 +634,16 @@ where
             "will run next collation step",
         );
 
-        // cancel collator if cancel was requested during active collation try
-        let updated_collator_state = self.set_collator_state(&next_block_id_short.shard, |ac| {
-            if ac.state == CollatorState::CancelPending {
-                ac.state = CollatorState::Cancelled;
-            }
-        });
-        if updated_collator_state == Some(CollatorState::Cancelled) {
-            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                shard_id = %next_block_id_short.shard,
-                "collator was cancelled before",
+        // check invariant: collator should not be in `CancelPending` or `Cancelled` state
+        // when processing collation skip in the main flow
+        if let Some(collator_state) = self.get_collator_state(&next_block_id_short.shard) {
+            assert!(
+                !matches!(
+                    collator_state,
+                    CollatorState::CancelPending | CollatorState::Cancelled
+                ),
+                "collator should not be in 'cancel' state on collation skip processing",
             );
-            return Ok(vec![]);
         }
 
         self.run_next_collation_step(
@@ -756,47 +734,12 @@ where
         Ok(collator_tasks)
     }
 
-    fn handle_block_mismatch(
-        &self,
-        block_id: &BlockId,
-        store_src: BlockCacheStoreSource,
-    ) -> Result<()> {
+    fn handle_block_mismatch(&self, block_id: &BlockId) -> Result<()> {
         let labels = [("workchain", block_id.shard.workchain().to_string())];
         metrics::counter!("tycho_collator_block_mismatch_count", &labels).increment(1);
 
-        match store_src {
-            BlockCacheStoreSource::Collated => {
-                self.set_collator_state(&block_id.shard, |ac| ac.state = CollatorState::Cancelled);
-            }
-            BlockCacheStoreSource::Received => {
-                // now we cannot cancel active collation directly
-                // so we mark collators to be cancelled when they finish current active collation
-                self.set_collator_state(&block_id.shard, |ac| {
-                    ac.state = match ac.state {
-                        CollatorState::Waiting | CollatorState::Cancelled => {
-                            CollatorState::Cancelled
-                        }
-                        _ => CollatorState::CancelPending,
-                    };
-                });
-            }
-        }
-
-        // when master block mismatched then should cancel shard collators as well
-        if block_id.is_masterchain() {
-            self.set_collators_state(
-                |shard_id, _| shard_id != &block_id.shard,
-                |ac| {
-                    ac.state = match ac.state {
-                        CollatorState::Waiting | CollatorState::Cancelled => {
-                            CollatorState::Cancelled
-                        }
-                        _ => CollatorState::CancelPending,
-                    };
-                },
-            );
-        }
-
+        // should drop uncommitted queue state on block mismatch
+        // because created messages are incorrect
         let top_shards = self.blocks_cache.get_last_top_shards();
         self.mq_adapter.clear_uncommitted_state(&top_shards)?;
 
@@ -818,7 +761,7 @@ where
     async fn handle_collated_block_candidate(
         self: &Arc<Self>,
         collation_result: BlockCollationResult,
-    ) -> Result<HandleBlockCandidateResult<CF::Collator>> {
+    ) -> Result<HandleCollatorTaskResult<CF::Collator>> {
         tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
             ct = collation_result.candidate.chain_time,
             processed_to_anchor_id = collation_result.candidate.processed_to_anchor_id,
@@ -857,51 +800,24 @@ where
 
                 self.set_collator_state(&block_id.shard, |ac| ac.state = CollatorState::Waiting);
 
-                return Ok(HandleBlockCandidateResult::empty());
+                return Ok(HandleCollatorTaskResult::empty());
             }
         };
 
-        // cancel collator now after produced block if cancel was requested during active collation
-        let updated_collator_state = self.set_collator_state(&block_id.shard, |ac| {
-            if ac.state == CollatorState::CancelPending {
-                ac.state = CollatorState::Cancelled;
-            }
-        });
-        let collator_cancelled = updated_collator_state == Some(CollatorState::Cancelled);
-
-        let store_res = if collator_cancelled {
-            tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                shard_id = %block_id.shard,
-                "collator was cancelled before",
+        // check invariant: collator should not be in `CancelPending` or `Cancelled` state
+        // when processing collated block candidate
+        if let Some(collator_state) = self.get_collator_state(&block_id.shard) {
+            assert!(
+                !matches!(
+                    collator_state,
+                    CollatorState::CancelPending | CollatorState::Cancelled
+                ),
+                "collator should not be in 'cancel' state on block candidate processing",
             );
+        }
 
-            // If collator was cancelled then should clear uncommitted queue diffs.
-            // E.g. the queue diff from just collated block is uncommitted at this point,
-            // so it will be deleted because we do not need this just collated block.
-            let top_shards = self.blocks_cache.get_last_top_shards();
-            self.mq_adapter.clear_uncommitted_state(&top_shards)?;
-
-            // we do not save just collated block,
-            // we take last existed info from cache to detect the next step
-            let (last_collated_mc_block_id, applied_mc_queue_range) = self
-                .blocks_cache
-                .get_last_collated_block_and_applied_mc_queue_range();
-
-            let store_res = BlockCacheStoreResult {
-                received_and_collated: false,
-                block_mismatch: false,
-                last_collated_mc_block_id,
-                applied_mc_queue_range,
-            };
-
-            tracing::info!(
-                target: tracing_targets::COLLATION_MANAGER,
-                ?store_res,
-                "block candidate was not saved to cache",
-            );
-
-            store_res
-        } else {
+        // store block to cache
+        let store_res = {
             // if collator ws not cancelled then we consider that just collated block
             // should be correct and try store it to the cache
             let top_shard_blocks_info = collation_result
@@ -932,12 +848,12 @@ where
             )?;
 
             if store_res.block_mismatch {
-                self.handle_block_mismatch(&block_id, BlockCacheStoreSource::Collated)?;
+                self.handle_block_mismatch(&block_id)?;
 
                 tracing::info!(
                     target: tracing_targets::COLLATION_MANAGER,
                     ?store_res,
-                    "saved block candidate to cache",
+                    "saved block candidate to cache: mismatch",
                 );
             } else {
                 tracing::debug!(
@@ -949,8 +865,6 @@ where
 
             store_res
         };
-
-        let collation_cancelled = collator_cancelled || store_res.block_mismatch;
 
         // check if should sync to last applied mc block
         let should_sync_to_last_applied_mc_block = 'check_should_sync: {
@@ -971,9 +885,14 @@ where
                 }
             }
 
-            if collation_cancelled {
-                true
-            } else if let Some((_, applied_range_end)) = store_res.applied_mc_queue_range {
+            // should sync if collated block mismatched
+            if store_res.block_mismatch {
+                break 'check_should_sync true;
+            }
+
+            // check if should sync when we have applied blocks
+            if let Some((_, applied_range_end)) = store_res.applied_mc_queue_range {
+                // we can sync only when we have any applied block ahead
                 if let Some(last_collated_mc_block_id) = store_res.last_collated_mc_block_id {
                     let applied_range_end_delta =
                         applied_range_end.saturating_sub(last_collated_mc_block_id.seqno);
@@ -1017,54 +936,18 @@ where
         // run sync or process just collated block
         let mut collator_tasks = vec![];
         if should_sync_to_last_applied_mc_block {
-            // NOTE: we do not need to commit current master block candidate
-            //      if it is "received and collated" because it is already applied to state
-            //      and we do not need to notify state update and top processed to anchor
-            //      because we will do this for block wich we sync to
-
-            if block_id.is_masterchain() {
-                // run sync if have applied mc blocks
-                collator_tasks = self
-                    .sync_to_applied_mc_block_if_exist(
-                        store_res.last_collated_mc_block_id,
-                        store_res.applied_mc_queue_range,
-                        ProcessMcStateUpdateMode::StartCollation {
-                            reset_collators: true,
-                        },
-                    )
-                    .await?;
-            } else {
-                // cancel further collation of blocks in the current shard because we need to sync
-                tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                    "sync_to_applied_mc_block: mark shard collator Cancelled for shard",
-                );
-
-                self.set_collator_state(&block_id.shard, |ac| ac.state = CollatorState::Cancelled);
-
-                // run sync if all collators cancelled, or waiting, or there are no collators
-                // and we have applied mc blocks
-                if !self.has_active_collator() {
-                    tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                        "sync_to_applied_mc_block: no active collators in shards and master, \
-                        will run sync to last applied mc block",
-                    );
-
-                    // run sync if have applied mc blocks
-                    collator_tasks = self
-                        .sync_to_applied_mc_block_if_exist(
-                            store_res.last_collated_mc_block_id,
-                            store_res.applied_mc_queue_range,
-                            ProcessMcStateUpdateMode::StartCollation {
-                                reset_collators: true,
-                            },
-                        )
-                        .await?;
-                }
-            }
-
-            Ok(HandleBlockCandidateResult {
+            // before sync will cancel any active collations
+            Ok(HandleCollatorTaskResult {
                 validator_task: None,
-                collator_tasks,
+                collator_tasks: vec![],
+                cancel_action: Some(ActionAfterCancel::SyncToAppliedMcBlock {
+                    trigger_block_id_short: block_id.as_short_id(),
+                    last_collated_mc_block_id: store_res.last_collated_mc_block_id,
+                    applied_range: store_res.applied_mc_queue_range,
+                    process_state_update_mode: ProcessMcStateUpdateMode::StartCollation {
+                        reset_collators: true,
+                    },
+                }),
             })
         } else if block_id.is_masterchain() {
             // when candidate is master
@@ -1116,9 +999,10 @@ where
                     .await?;
             }
 
-            Ok(HandleBlockCandidateResult {
+            Ok(HandleCollatorTaskResult {
                 validator_task,
                 collator_tasks,
+                cancel_action: None,
             })
         } else {
             // when candidate is shard
@@ -1146,9 +1030,10 @@ where
                 )
                 .await?;
 
-            Ok(HandleBlockCandidateResult {
+            Ok(HandleCollatorTaskResult {
                 validator_task: None,
                 collator_tasks,
+                cancel_action: None,
             })
         }
     }
@@ -1192,7 +1077,7 @@ where
     async fn handle_blocks_from_bc_batch(
         self: &Arc<Self>,
         batch: Vec<HandledBlockFromBcCtx>,
-    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
+    ) -> Result<HandleBlockFromBcResult<CF::Collator>> {
         // find last master block in buffer
         // will skip sync for all master blocks before it
         let mut last_mc_block_id_opt = None;
@@ -1203,6 +1088,7 @@ where
         }
 
         let mut collator_tasks = vec![];
+        let mut cancel_action = None;
 
         for ctx in batch {
             let is_last_mc_block_in_batch = matches!(
@@ -1212,7 +1098,7 @@ where
             let shard_id = ctx.state.block_id().shard;
 
             // handle block from bc
-            let tasks = self
+            let res = self
                 .handle_block_from_bc(ctx, is_last_mc_block_in_batch)
                 .await
                 .map_err(|err| {
@@ -1226,22 +1112,30 @@ where
             // check invariants
             if !is_last_mc_block_in_batch {
                 assert!(
-                    tasks.is_empty(),
+                    res.collator_tasks.is_empty(),
                     "only last master block should run collator tasks",
                 );
             }
             if !shard_id.is_masterchain() {
                 assert!(
-                    tasks.is_empty(),
+                    res.collator_tasks.is_empty(),
                     "should not run collator tasks on shard block processing",
                 );
             }
-            if !tasks.is_empty() {
-                collator_tasks = tasks;
+            // get collator tasks only from the last master block processing
+            if !res.collator_tasks.is_empty() {
+                collator_tasks = res.collator_tasks;
+            }
+            // get the most actual action after cancel
+            if res.cancel_action.is_some() {
+                cancel_action = res.cancel_action;
             }
         }
 
-        Ok(collator_tasks)
+        Ok(HandleBlockFromBcResult {
+            collator_tasks,
+            cancel_action,
+        })
     }
 
     /// Process new block from blockchain:
@@ -1255,7 +1149,7 @@ where
         self: &Arc<Self>,
         ctx: HandledBlockFromBcCtx,
         is_last_mc_block_in_batch: bool,
-    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
+    ) -> Result<HandleBlockFromBcResult<CF::Collator>> {
         tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
             "start processing block from bc",
         );
@@ -1265,27 +1159,27 @@ where
 
         let _histogram = HistogramGuard::begin("tycho_collator_handle_block_from_bc_time");
 
-        let processed_upto = ProcessedUptoInfoStuff::try_from(ctx.processed_upto)?;
-
         let Some(store_res) = self
             .blocks_cache
             .store_received(
                 self.state_node_adapter.clone(),
                 &ctx.mc_block_id,
                 ctx.state.clone(),
-                processed_upto,
+                ProcessedUptoInfoStuff::try_from(ctx.processed_upto)?,
             )
             .await?
         else {
-            return Ok(vec![]);
+            // received block was not stored
+            // because it is not newer than existed
+            return Ok(HandleBlockFromBcResult::empty());
         };
 
         if store_res.block_mismatch {
-            self.handle_block_mismatch(&block_id, BlockCacheStoreSource::Received)?;
+            self.handle_block_mismatch(&block_id)?;
 
             tracing::info!(target: tracing_targets::COLLATION_MANAGER,
                 ?store_res,
-                "saved block from bc to cache",
+                "saved block from bc to cache: mismatch",
             );
         } else {
             tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
@@ -1294,11 +1188,12 @@ where
             );
         }
 
+        // there is no any possible action with a shard block
         if !block_id.is_masterchain() {
-            return Ok(vec![]);
+            return Ok(HandleBlockFromBcResult::empty());
         }
 
-        // when received block is master
+        // check if received is a key block
         let is_key_block = ctx.state.state_extra()?.after_key_block;
 
         // stop any running validations up to this block
@@ -1314,7 +1209,7 @@ where
 
         // check if should sync to last applied mc block right now
         let should_sync_to_last_applied_mc_block = 'check_should_sync: {
-            // sync only last master block from batch or key block
+            // sync only to the last master block from batch or to a key block
             if !is_last_mc_block_in_batch && !is_key_block {
                 break 'check_should_sync false;
             }
@@ -1336,6 +1231,7 @@ where
                 }
             }
 
+            // check if should sync
             if let Some(top_mc_block_id_for_next_collation) =
                 self.get_top_mc_block_id_for_next_collation(store_res.last_collated_mc_block_id)
             {
@@ -1383,32 +1279,17 @@ where
                     };
 
                     if should_sync {
-                        // we should sync but we can run sync right now only when there are no active collators
-                        let has_active = self.request_cancel_collations();
-                        if has_active {
-                            tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                                last_synced_to_mc_block_id = ?self.get_last_synced_to_mc_block_id().map(|id| id.as_short_id().to_string()),
-                                last_collated_mc_block_id = ?store_res.last_collated_mc_block_id.map(|id| id.as_short_id().to_string()),
-                                last_processed_mc_block_id = ?self.get_last_processed_mc_block_id().map(|id| id.as_short_id().to_string()),
-                                received_is_key_block = is_key_block,
-                                "check_should_sync: cannot sync when there are active collations, \
-                                try to gracefully cancel them",
-                            );
-                            false
-                        } else {
-                            tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                                last_synced_to_mc_block_id = ?self.get_last_synced_to_mc_block_id().map(|id| id.as_short_id().to_string()),
-                                last_collated_mc_block_id = ?store_res.last_collated_mc_block_id.map(|id| id.as_short_id().to_string()),
-                                last_processed_mc_block_id = ?self.get_last_processed_mc_block_id().map(|id| id.as_short_id().to_string()),
-                                received_is_key_block = is_key_block,
-                                "check_should_sync: can sync to last applied mc block \
-                                when all collators were cancelled, or waiting, or there are no collators (node not in set)",
-                            );
-                            true
-                        }
-                    } else {
-                        false
+                        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+                            last_synced_to_mc_block_id = ?self.get_last_synced_to_mc_block_id().map(|id| id.as_short_id().to_string()),
+                            last_collated_mc_block_id = ?store_res.last_collated_mc_block_id.map(|id| id.as_short_id().to_string()),
+                            last_processed_mc_block_id = ?self.get_last_processed_mc_block_id().map(|id| id.as_short_id().to_string()),
+                            received_is_key_block = is_key_block,
+                            has_active_collations = self.has_active_collations(),
+                            "check_should_sync: will request sync to last applied mc block",
+                        );
                     }
+
+                    should_sync
                 } else {
                     // should collate next own mc block because no applied ahead
                     tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
@@ -1428,8 +1309,8 @@ where
             }
         };
 
+        // run sync or commit block
         let mut collator_tasks = vec![];
-
         if should_sync_to_last_applied_mc_block {
             // should only refresh collation sessions when sync on key block
             let process_state_update_mode = if is_last_mc_block_in_batch {
@@ -1439,33 +1320,36 @@ where
             } else {
                 ProcessMcStateUpdateMode::RefreshSessionsOnly
             };
-            // run sync if have applied mc blocks
-            collator_tasks = self
-                .sync_to_applied_mc_block_if_exist(
-                    store_res.last_collated_mc_block_id,
-                    store_res.applied_mc_queue_range,
+            // will cancel active collations and then run sync
+            return Ok(HandleBlockFromBcResult {
+                collator_tasks,
+                cancel_action: Some(ActionAfterCancel::SyncToAppliedMcBlock {
+                    trigger_block_id_short: block_id.as_short_id(),
+                    last_collated_mc_block_id: store_res.last_collated_mc_block_id,
+                    applied_range: store_res.applied_mc_queue_range,
                     process_state_update_mode,
-                )
-                .await?;
+                }),
+            });
         } else {
             // try to commit block if it was collated first
             if store_res.received_and_collated {
                 // NOTE: here commit will not cause on_block_accepted event
                 //      because block already exist in bc state
 
-                // NOTE: here master block subgraph could be already extracted,
-                //      sent to sync, and removed from cache, because validation task
-                //      could be finished after `store_received()` but before this point.
-
                 collator_tasks = self.commit_valid_master_block(&block_id).await?;
             }
         }
 
-        Ok(collator_tasks)
+        Ok(HandleBlockFromBcResult {
+            collator_tasks,
+            cancel_action: None,
+        })
     }
 
+    #[tracing::instrument(name = "sync_to_applied_mc_block", skip_all, fields(trigger_block_id = %trigger_block_id_short, applied_range = ?applied_range))]
     async fn sync_to_applied_mc_block_if_exist(
         self: &Arc<Self>,
+        trigger_block_id_short: BlockIdShort,
         last_collated_mc_block_id: Option<BlockId>,
         applied_range: Option<(BlockSeqno, BlockSeqno)>,
         process_state_update_mode: ProcessMcStateUpdateMode,
@@ -1474,18 +1358,22 @@ where
 
         if let Some(applied_range) = applied_range {
             let this = self.clone();
+            let span = tracing::Span::current();
 
             collator_tasks = tokio::task::spawn_blocking(move || {
+                let _ = span.enter();
+
                 this.sync_to_applied_mc_block(
-                    applied_range,
+                    trigger_block_id_short,
                     last_collated_mc_block_id,
+                    applied_range,
                     process_state_update_mode,
                 )
             })
             .await??;
         } else {
             tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                "sync_to_applied_mc_block: there is no received applied mc blocks in cache, \
+                "there is no received applied mc blocks in cache, \
                 will wait for next blocks from bc",
             );
         }
@@ -1496,11 +1384,12 @@ where
     /// Restores internals queue state,
     /// processes last applied mc state
     /// to run next blocks collation.
-    #[tracing::instrument(skip_all, fields(applied_range = ?applied_range))]
+    #[tracing::instrument(skip_all, fields(trigger_block_id = %trigger_block_id_short, applied_range = ?applied_range))]
     fn sync_to_applied_mc_block(
         &self,
-        applied_range: (BlockSeqno, BlockSeqno),
+        trigger_block_id_short: BlockIdShort,
         last_collated_mc_block_id: Option<BlockId>,
+        applied_range: (BlockSeqno, BlockSeqno),
         process_state_update_mode: ProcessMcStateUpdateMode,
     ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
         tracing::info!(target: tracing_targets::COLLATION_MANAGER,
@@ -2532,8 +2421,12 @@ where
                                 };
 
                             entry.insert(ActiveCollator {
+                                state: if collator.is_none() {
+                                    CollatorState::Active
+                                } else {
+                                    CollatorState::Waiting
+                                },
                                 collator,
-                                state: CollatorState::Active,
                                 cancel_collation: cancel_collation_notify,
                             });
                         }
@@ -3511,21 +3404,37 @@ where
     }
 }
 
-struct HandleBlockCandidateResult<C: Collator> {
+struct HandleCollatorTaskResult<C: Collator> {
     validator_task: Option<ValidatorJoinTask>,
     collator_tasks: Vec<CollatorJoinTask<C>>,
+    cancel_action: Option<ActionAfterCancel>,
 }
 
-impl<C: Collator> HandleBlockCandidateResult<C> {
+impl<C: Collator> HandleCollatorTaskResult<C> {
     fn empty() -> Self {
         Self {
             validator_task: None,
             collator_tasks: vec![],
+            cancel_action: None,
         }
     }
 }
 
-#[derive(Debug)]
+struct HandleBlockFromBcResult<C: Collator> {
+    collator_tasks: Vec<CollatorJoinTask<C>>,
+    cancel_action: Option<ActionAfterCancel>,
+}
+
+impl<C: Collator> HandleBlockFromBcResult<C> {
+    fn empty() -> Self {
+        Self {
+            collator_tasks: vec![],
+            cancel_action: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 enum ProcessMcStateUpdateMode {
     StartCollation { reset_collators: bool },
     RefreshSessionsOnly,

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -14,7 +14,7 @@ use tycho_util::{FastDashMap, FastHashMap};
 
 use self::blocks_cache::BlocksCache;
 use self::cancel_validation_runner::CancelValidationRunnerState;
-use self::collation_cancel::{ActionAfterCancel, CollationCancelHandle};
+use self::collation_cancel::{ActionAfterCancel, CollationCancelHandle, update_action_after};
 use self::state_event_listener::{ChannelStateEventListener, StateEvent};
 use self::state_update_handler::ProcessMcStateUpdateMode;
 use self::types::{
@@ -880,9 +880,7 @@ where
                 collator_tasks = res.collator_tasks;
             }
             // get the most actual action after cancel
-            if res.cancel_action.is_some() {
-                cancel_action = res.cancel_action;
-            }
+            update_action_after(&mut cancel_action, res.cancel_action);
         }
 
         Ok(HandleTaskResult {

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -725,10 +725,25 @@ where
 
         // should drop uncommitted queue state on block mismatch
         // because created messages are incorrect
-        let top_shards = self.blocks_cache.get_last_top_shards();
-        self.mq_adapter.clear_uncommitted_state(&top_shards)?;
+        self.clear_uncommitted_queue_state()?;
 
         Ok(())
+    }
+
+    fn clear_uncommitted_queue_state(&self) -> Result<()> {
+        Self::clear_uncommitted_queue_state_impl(&self.blocks_cache, &self.mq_adapter)
+    }
+
+    fn clear_uncommitted_queue_state_impl(
+        blocks_cache: &BlocksCache,
+        mq_adapter: &Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
+    ) -> Result<()> {
+        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+            "clear uncommitted queue state",
+        );
+
+        let top_shards = blocks_cache.get_last_top_shards();
+        mq_adapter.clear_uncommitted_state(&top_shards)
     }
 
     /// Process collated block candidate
@@ -1425,8 +1440,7 @@ where
                 // and applied mc block is MC100. But mempool will not contain all old externals used to collate
                 // the previous version of SC701. So the new diff will mismatch the old one and node will panic.
                 // So we need to remove all uncommitted queue diffs because we have new mismatched externals queue.
-                let top_shards = self.blocks_cache.get_last_top_shards();
-                self.mq_adapter.clear_uncommitted_state(&top_shards)?;
+                self.clear_uncommitted_queue_state()?;
             }
         }
 
@@ -1987,8 +2001,7 @@ where
                 // when we run sync by any reason we should drop uncommitted queue updates
                 // after restoring the required state
                 // to avoid panics if next block was already collated before an it is incorrect
-                let top_shards = blocks_cache.get_last_top_shards();
-                mq_adapter.clear_uncommitted_state(&top_shards)?;
+                Self::clear_uncommitted_queue_state_impl(blocks_cache, &mq_adapter)?;
 
                 res.last_mc_state = Some(last_mc_state);
                 res.prev_mc_state = prev_mc_state;

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -34,8 +34,8 @@ use self::types::{
 };
 use self::utils::find_us_in_collators_set;
 use crate::collator::{
-    Collator, CollatorContext, CollatorFactory, CollatorResult, DebugCollatorResult,
-    ForceMasterCollation,
+    CollationAbortReason, Collator, CollatorContext, CollatorFactory, CollatorResult,
+    DebugCollatorResult, ForceMasterCollation,
 };
 use crate::internal_queue::types::diff::{DiffZone, QueueDiffWithMessages};
 use crate::internal_queue::types::message::EnqueuedMessage;
@@ -590,6 +590,16 @@ where
                     .await?;
                 Ok(HandleTaskResult::with_tasks(None, collator_tasks))
             }
+            CollatorResult::Aborted(abort_ctx) => {
+                let collator_tasks = self
+                    .handle_collation_aborted(
+                        abort_ctx.prev_mc_block_id,
+                        abort_ctx.next_block_id_short,
+                        abort_ctx.reason,
+                    )
+                    .await?;
+                Ok(HandleTaskResult::with_tasks(None, collator_tasks))
+            }
             CollatorResult::Cancelled(cancel_ctx) => {
                 bail!(
                     "should not process `CollatorResult::Cancelled` in the main flow. cancel_ctx={:?}",
@@ -600,6 +610,58 @@ where
                 self.handle_collated_block_candidate(collation_result).await
             }
         }
+    }
+
+    #[tracing::instrument(skip_all, fields(next_block_id = %next_block_id_short))]
+    async fn handle_collation_aborted(
+        self: &Arc<Self>,
+        _prev_mc_block_id: BlockId,
+        next_block_id_short: BlockIdShort,
+        reason: CollationAbortReason,
+    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
+        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+            ?reason,
+            "start handle collation aborted",
+        );
+
+        // NOTE: when collation aborted it guarantees
+        //      that uncommitted queue diff was not saved
+        match reason {
+            CollationAbortReason::AnchorNotFound(_)
+            | CollationAbortReason::NextAnchorNotFound(_)
+            | CollationAbortReason::DiffNotFoundInQueue(_) => {
+                // mark collator as cancelled
+                self.set_collator_state(&next_block_id_short.shard, |ac| {
+                    ac.state = CollatorState::Cancelled;
+                });
+
+                // run sync if there are no active collations
+                if !self.has_active_collations() {
+                    tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+                        "no active collations in shards and masterchain, \
+                        will run sync to last applied mc block",
+                    );
+
+                    // get info about applied mc blocks in cache
+                    let (last_collated_mc_block_id, applied_range) = self
+                        .blocks_cache
+                        .get_last_collated_block_and_applied_mc_queue_range();
+
+                    // run sync if has applied mc blocks
+                    return self
+                        .sync_to_applied_mc_block_if_exist(
+                            next_block_id_short,
+                            last_collated_mc_block_id,
+                            applied_range,
+                            ProcessMcStateUpdateMode::StartCollation {
+                                reset_collators: true,
+                            },
+                        )
+                        .await;
+                }
+            }
+        }
+        Ok(vec![])
     }
 
     #[tracing::instrument(skip_all, fields(next_block_id = %next_block_id_short, ct = anchor_chain_time, ?force_mc_block))]

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -647,17 +647,19 @@ where
                         .blocks_cache
                         .get_last_collated_block_and_applied_mc_queue_range();
 
-                    // run sync if has applied mc blocks
-                    return self
-                        .sync_to_applied_mc_block_if_exist(
-                            next_block_id_short,
-                            last_collated_mc_block_id,
-                            applied_range,
-                            ProcessMcStateUpdateMode::StartCollation {
-                                reset_collators: true,
-                            },
-                        )
-                        .await;
+                    // run sync if has applied mc blocks and has not newer received
+                    if !self.has_newer_received_mc_block(applied_range) {
+                        return self
+                            .sync_to_applied_mc_block_if_exist(
+                                next_block_id_short,
+                                last_collated_mc_block_id,
+                                applied_range,
+                                ProcessMcStateUpdateMode::StartCollation {
+                                    reset_collators: true,
+                                },
+                            )
+                            .await;
+                    }
                 }
             }
         }
@@ -927,20 +929,8 @@ where
         // check if should sync to last applied mc block
         let should_sync_to_last_applied_mc_block = 'check_should_sync: {
             // do not sync to last applied mc block if newer already received
-            if let Some((_, applied_range_end)) = store_res.applied_mc_queue_range {
-                let last_received_mc_block_seqno = self.get_last_received_mc_block_seqno();
-                if matches!(
-                    last_received_mc_block_seqno,
-                    Some(last_received_seqno) if last_received_seqno.saturating_sub(applied_range_end) > 1
-                ) {
-                    tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                        last_received_mc_block_seqno,
-                        applied_range_end,
-                        "check_should_sync: should not sync to last applied mc block \
-                        because a newer one already received",
-                    );
-                    break 'check_should_sync false;
-                }
+            if self.has_newer_received_mc_block(store_res.applied_mc_queue_range) {
+                break 'check_should_sync false;
             }
 
             // should sync if collated block mismatched
@@ -1266,20 +1256,8 @@ where
             }
 
             // do not sync to last applied mc block if newer already received
-            if let Some((_, applied_range_end)) = store_res.applied_mc_queue_range {
-                let last_received_mc_block_seqno = self.get_last_received_mc_block_seqno();
-                if matches!(
-                    last_received_mc_block_seqno,
-                    Some(last_received_seqno) if last_received_seqno.saturating_sub(applied_range_end) > 1
-                ) {
-                    tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                        last_received_mc_block_seqno,
-                        received_is_key_block = is_key_block,
-                        "check_should_sync: should not sync to last applied mc block \
-                        because a newer one already received",
-                    );
-                    break 'check_should_sync false;
-                }
+            if self.has_newer_received_mc_block(store_res.applied_mc_queue_range) {
+                break 'check_should_sync false;
             }
 
             // should sync if collated block mismatched
@@ -2644,6 +2622,26 @@ where
     fn get_last_received_mc_block_seqno(&self) -> Option<BlockSeqno> {
         let guard = self.collation_sync_state.lock();
         guard.last_received_mc_block_seqno
+    }
+
+    fn has_newer_received_mc_block(&self, applied_range: Option<(u32, u32)>) -> bool {
+        if let Some((_, applied_range_end)) = applied_range {
+            let last_received_mc_block_seqno = self.get_last_received_mc_block_seqno();
+            if matches!(
+                last_received_mc_block_seqno,
+                Some(last_received_seqno) if last_received_seqno.saturating_sub(applied_range_end) > 1
+            ) {
+                tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+                    last_received_mc_block_seqno,
+                    applied_range_end,
+                    "check_should_sync: should not sync to last applied mc block \
+                    because a newer one already received",
+                );
+
+                return true;
+            }
+        }
+        false
     }
 
     fn update_last_synced_to_mc_block_id(&self, mc_block_id: BlockId) {

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -298,16 +298,12 @@ where
                     }
 
                     let res = self.handle_blocks_from_bc_batch(blocks_from_bc_batch).await?;
-                    for task in res.collator_tasks {
-                        collator_tasks.push(task);
-                    }
-
-                    // run collation cancel task if requested
-                    if let Some(action) = res.cancel_action {
-                        for task in collation_cancel_task.start_or_update(self, action, &mut collator_tasks).await? {
-                            collator_tasks.push(task);
-                        }
-                    }
+                    self.handle_new_collator_tasks_and_cancel_request(
+                        &mut collation_cancel_task,
+                        &mut collator_tasks,
+                        res.collator_tasks,
+                        res.cancel_action,
+                    ).await?;
                 },
                 // handle collator tasks
                 Some(collator_res) = collator_tasks.next(), if !collator_tasks.is_empty() => {
@@ -315,16 +311,12 @@ where
                     if let Some(task) = res.validator_task {
                         validator_tasks.push(task);
                     }
-                    for task in res.collator_tasks {
-                        collator_tasks.push(task);
-                    }
-
-                    // run collation cancel task if requested
-                    if let Some(action) = res.cancel_action {
-                        for task in collation_cancel_task.start_or_update(self, action, &mut collator_tasks).await? {
-                            collator_tasks.push(task);
-                        }
-                    }
+                    self.handle_new_collator_tasks_and_cancel_request(
+                        &mut collation_cancel_task,
+                        &mut collator_tasks,
+                        res.collator_tasks,
+                        res.cancel_action,
+                    ).await?;
                 }
                 // handle collation cancel task
                 Some(res) = collation_cancel_task.wait(), if !collation_cancel_task.is_empty() => {
@@ -342,9 +334,17 @@ where
                             );
                         }
                         Ok((block_id, validation_status)) => {
-                            for task in self.handle_validated_master_block(block_id, validation_status).await? {
-                                collator_tasks.push(task);
-                            }
+                            let new_collator_tasks = self.handle_validated_master_block(
+                                block_id,
+                                validation_status,
+                                collation_cancel_task.running_and_will_sync_after(),
+                            ).await?;
+                            self.handle_new_collator_tasks_and_cancel_request(
+                                &mut collation_cancel_task,
+                                &mut collator_tasks,
+                                new_collator_tasks,
+                                None,
+                            ).await?;
                         }
 
                     }
@@ -969,7 +969,7 @@ where
                 // NOTE: here commit will not cause on_block_accepted event
                 //      because block already exist in bc state
 
-                collator_tasks = self.commit_valid_master_block(&block_id).await?;
+                collator_tasks = self.commit_valid_master_block(&block_id, false).await?;
             } else {
                 let validator = self.validator.clone();
                 let validation_session_id = session_info.get_validation_session_id();
@@ -1328,7 +1328,7 @@ where
                 // NOTE: here commit will not cause on_block_accepted event
                 //      because block already exist in bc state
 
-                collator_tasks = self.commit_valid_master_block(&block_id).await?;
+                collator_tasks = self.commit_valid_master_block(&block_id, false).await?;
             }
         }
 
@@ -2103,6 +2103,7 @@ where
     async fn notify_to_mempool_and_process_delayed_mc_state_update(
         &self,
         block_id: &BlockId,
+        skip_process_delayed_mc_state_update: bool,
     ) -> Result<Option<(MempoolAnchorId, Vec<CollatorJoinTask<CF::Collator>>)>> {
         let mut delayed_mc_data = None;
         {
@@ -2122,14 +2123,20 @@ where
         if let Some(mc_data) = delayed_mc_data {
             self.notify_mc_state_update_to_mempool(mc_data.clone())
                 .await?;
-            let collator_tasks = self
-                .process_mc_state_update(
-                    mc_data.clone(),
-                    ProcessMcStateUpdateMode::StartCollation {
-                        reset_collators: false,
-                    },
-                )
-                .await?;
+
+            // validation may finish when collation cancel task is running,
+            // so we should not run new collation tasks
+            let mut collator_tasks = vec![];
+            if !skip_process_delayed_mc_state_update {
+                collator_tasks = self
+                    .process_mc_state_update(
+                        mc_data.clone(),
+                        ProcessMcStateUpdateMode::StartCollation {
+                            reset_collators: false,
+                        },
+                    )
+                    .await?;
+            }
 
             Ok(Some((mc_data.top_processed_to_anchor, collator_tasks)))
         } else {
@@ -2185,6 +2192,10 @@ where
         let _histogram = HistogramGuard::begin("tycho_collator_refresh_collation_sessions_time");
 
         let mut collator_tasks = vec![];
+
+        // NOTE: in case of processing delayed state update
+        //      after the validation of key block with consensus config changed
+        //      we may try to process the state that is older then already processed from bc
 
         // do not re-process this master block if it is lower then last processed or equal to it
         // but process a new version of block with the same seqno
@@ -3148,6 +3159,7 @@ where
         &self,
         block_id: BlockId,
         status: ValidationStatus,
+        skip_process_delayed_mc_state_update: bool,
     ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
         tracing::debug!(
             target: tracing_targets::COLLATION_MANAGER,
@@ -3166,7 +3178,9 @@ where
         }
 
         // process valid block
-        let collator_tasks = self.commit_valid_master_block(&block_id).await?;
+        let collator_tasks = self
+            .commit_valid_master_block(&block_id, skip_process_delayed_mc_state_update)
+            .await?;
 
         Ok(collator_tasks)
     }
@@ -3183,6 +3197,7 @@ where
     async fn commit_valid_master_block(
         &self,
         mc_block_id: &BlockId,
+        skip_process_delayed_mc_state_update: bool,
     ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
         tracing::debug!(
             target: tracing_targets::COLLATION_MANAGER,
@@ -3195,7 +3210,10 @@ where
 
         // we can process delayed master state update now
         let (mut top_processed_to_anchor_to_notify, collator_tasks) = self
-            .notify_to_mempool_and_process_delayed_mc_state_update(mc_block_id)
+            .notify_to_mempool_and_process_delayed_mc_state_update(
+                mc_block_id,
+                skip_process_delayed_mc_state_update,
+            )
             .await?
             .unzip();
 

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -560,7 +560,7 @@ where
     async fn handle_collator_task(
         self: &Arc<Self>,
         collator_task_res: Result<(Box<CF::Collator>, CollatorResult)>,
-    ) -> Result<HandleCollatorTaskResult<CF::Collator>> {
+    ) -> Result<HandleTaskResult<CF::Collator>> {
         let (collator, res) = collator_task_res?;
 
         tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
@@ -588,11 +588,7 @@ where
                         collation_config,
                     )
                     .await?;
-                Ok(HandleCollatorTaskResult {
-                    validator_task: None,
-                    collator_tasks,
-                    cancel_action: None,
-                })
+                Ok(HandleTaskResult::with_tasks(None, collator_tasks))
             }
             CollatorResult::Cancelled(cancel_ctx) => {
                 bail!(
@@ -761,7 +757,7 @@ where
     async fn handle_collated_block_candidate(
         self: &Arc<Self>,
         collation_result: BlockCollationResult,
-    ) -> Result<HandleCollatorTaskResult<CF::Collator>> {
+    ) -> Result<HandleTaskResult<CF::Collator>> {
         tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
             ct = collation_result.candidate.chain_time,
             processed_to_anchor_id = collation_result.candidate.processed_to_anchor_id,
@@ -800,7 +796,7 @@ where
 
                 self.set_collator_state(&block_id.shard, |ac| ac.state = CollatorState::Waiting);
 
-                return Ok(HandleCollatorTaskResult::empty());
+                return Ok(HandleTaskResult::empty());
             }
         };
 
@@ -937,26 +933,20 @@ where
         let mut collator_tasks = vec![];
         if should_sync_to_last_applied_mc_block {
             // before sync will cancel any active collations
-            Ok(HandleCollatorTaskResult {
-                validator_task: None,
-                collator_tasks: vec![],
-                cancel_action: Some(ActionAfterCancel::SyncToAppliedMcBlock {
+            Ok(HandleTaskResult::with_cancel(
+                ActionAfterCancel::SyncToAppliedMcBlock {
                     trigger_block_id_short: block_id.as_short_id(),
                     last_collated_mc_block_id: store_res.last_collated_mc_block_id,
                     applied_range: store_res.applied_mc_queue_range,
                     process_state_update_mode: ProcessMcStateUpdateMode::StartCollation {
                         reset_collators: true,
                     },
-                }),
-            })
+                },
+            ))
         } else if store_res.block_mismatch {
             // only cancel all active collations
             // when block mismatched and newer already received
-            Ok(HandleCollatorTaskResult {
-                validator_task: None,
-                collator_tasks: vec![],
-                cancel_action: Some(ActionAfterCancel::Noop),
-            })
+            Ok(HandleTaskResult::with_cancel(ActionAfterCancel::Noop))
         } else if block_id.is_masterchain() {
             // when candidate is master
 
@@ -1007,11 +997,7 @@ where
                     .await?;
             }
 
-            Ok(HandleCollatorTaskResult {
-                validator_task,
-                collator_tasks,
-                cancel_action: None,
-            })
+            Ok(HandleTaskResult::with_tasks(validator_task, collator_tasks))
         } else {
             // when candidate is shard
 
@@ -1038,11 +1024,7 @@ where
                 )
                 .await?;
 
-            Ok(HandleCollatorTaskResult {
-                validator_task: None,
-                collator_tasks,
-                cancel_action: None,
-            })
+            Ok(HandleTaskResult::with_tasks(None, collator_tasks))
         }
     }
 
@@ -1085,7 +1067,7 @@ where
     async fn handle_blocks_from_bc_batch(
         self: &Arc<Self>,
         batch: Vec<HandledBlockFromBcCtx>,
-    ) -> Result<HandleBlockFromBcResult<CF::Collator>> {
+    ) -> Result<HandleTaskResult<CF::Collator>> {
         // find last master block in buffer
         // will skip sync for all master blocks before it
         let mut last_mc_block_id_opt = None;
@@ -1140,7 +1122,8 @@ where
             }
         }
 
-        Ok(HandleBlockFromBcResult {
+        Ok(HandleTaskResult {
+            validator_task: None,
             collator_tasks,
             cancel_action,
         })
@@ -1157,7 +1140,7 @@ where
         self: &Arc<Self>,
         ctx: HandledBlockFromBcCtx,
         is_last_mc_block_in_batch: bool,
-    ) -> Result<HandleBlockFromBcResult<CF::Collator>> {
+    ) -> Result<HandleTaskResult<CF::Collator>> {
         tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
             "start processing block from bc",
         );
@@ -1179,7 +1162,7 @@ where
         else {
             // received block was not stored
             // because it is not newer than existed
-            return Ok(HandleBlockFromBcResult::empty());
+            return Ok(HandleTaskResult::empty());
         };
 
         if store_res.block_mismatch {
@@ -1200,13 +1183,10 @@ where
         if !block_id.is_masterchain() {
             if store_res.block_mismatch {
                 // should cancel all active collations when block mismatched
-                return Ok(HandleBlockFromBcResult {
-                    collator_tasks: vec![],
-                    cancel_action: Some(ActionAfterCancel::Noop),
-                });
+                return Ok(HandleTaskResult::with_cancel(ActionAfterCancel::Noop));
             } else {
                 // just do nothing otherwise
-                return Ok(HandleBlockFromBcResult::empty());
+                return Ok(HandleTaskResult::empty());
             }
         }
 
@@ -1334,22 +1314,18 @@ where
                 ProcessMcStateUpdateMode::RefreshSessionsOnly
             };
             // will cancel active collations and then run sync
-            Ok(HandleBlockFromBcResult {
-                collator_tasks: vec![],
-                cancel_action: Some(ActionAfterCancel::SyncToAppliedMcBlock {
+            Ok(HandleTaskResult::with_cancel(
+                ActionAfterCancel::SyncToAppliedMcBlock {
                     trigger_block_id_short: block_id.as_short_id(),
                     last_collated_mc_block_id: store_res.last_collated_mc_block_id,
                     applied_range: store_res.applied_mc_queue_range,
                     process_state_update_mode,
-                }),
-            })
+                },
+            ))
         } else if store_res.block_mismatch {
             // only cancel all active collations
             // when block mismatched and should not sync by any reason
-            Ok(HandleBlockFromBcResult {
-                collator_tasks: vec![],
-                cancel_action: Some(ActionAfterCancel::Noop),
-            })
+            Ok(HandleTaskResult::with_cancel(ActionAfterCancel::Noop))
         } else {
             let mut collator_tasks = vec![];
 
@@ -1361,10 +1337,7 @@ where
                 collator_tasks = self.commit_valid_master_block(&block_id, false).await?;
             }
 
-            Ok(HandleBlockFromBcResult {
-                collator_tasks,
-                cancel_action: None,
-            })
+            Ok(HandleTaskResult::with_tasks(None, collator_tasks))
         }
     }
 
@@ -3442,13 +3415,13 @@ where
     }
 }
 
-struct HandleCollatorTaskResult<C: Collator> {
+struct HandleTaskResult<C: Collator> {
     validator_task: Option<ValidatorJoinTask>,
     collator_tasks: Vec<CollatorJoinTask<C>>,
     cancel_action: Option<ActionAfterCancel>,
 }
 
-impl<C: Collator> HandleCollatorTaskResult<C> {
+impl<C: Collator> HandleTaskResult<C> {
     fn empty() -> Self {
         Self {
             validator_task: None,
@@ -3456,18 +3429,23 @@ impl<C: Collator> HandleCollatorTaskResult<C> {
             cancel_action: None,
         }
     }
-}
 
-struct HandleBlockFromBcResult<C: Collator> {
-    collator_tasks: Vec<CollatorJoinTask<C>>,
-    cancel_action: Option<ActionAfterCancel>,
-}
-
-impl<C: Collator> HandleBlockFromBcResult<C> {
-    fn empty() -> Self {
+    fn with_tasks(
+        validator_task: Option<ValidatorJoinTask>,
+        collator_tasks: Vec<CollatorJoinTask<C>>,
+    ) -> Self {
         Self {
-            collator_tasks: vec![],
+            validator_task,
+            collator_tasks,
             cancel_action: None,
+        }
+    }
+
+    fn with_cancel(cancel_action: ActionAfterCancel) -> Self {
+        Self {
+            validator_task: None,
+            collator_tasks: vec![],
+            cancel_action: Some(cancel_action),
         }
     }
 }

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -1,68 +1,57 @@
-use std::collections::{BTreeMap, VecDeque, hash_map};
 use std::sync::Arc;
 
-use ahash::HashMapExt;
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 use futures_util::StreamExt;
 use futures_util::stream::FuturesUnordered;
 use parking_lot::{Mutex, RwLock};
-use tokio::sync::Notify;
-use tokio_util::sync::CancellationToken;
-use tycho_block_util::block::{TopBlocks, ValidatorSubsetInfo, calc_next_block_id_short};
-use tycho_block_util::queue::{QueueKey, QueuePartitionIdx};
 use tycho_block_util::state::ShardStateStuff;
 use tycho_core::global_config::MempoolGlobalConfig;
-use tycho_core::storage::{LoadStateHint, StateNotFound};
 use tycho_crypto::ed25519::KeyPair;
-use tycho_types::models::{
-    BlockId, BlockIdShort, CollationConfig, GlobalCapabilities, ProcessedUptoInfo, ShardIdent,
-    ValidatorDescription,
-};
-use tycho_util::futures::{AwaitBlocking, JoinTask};
+use tycho_types::models::{BlockId, BlockIdShort, CollationConfig, ProcessedUptoInfo, ShardIdent};
+use tycho_util::futures::JoinTask;
 use tycho_util::metrics::HistogramGuard;
-use tycho_util::{DashMapEntry, FastDashMap, FastHashMap, FastHashSet};
+use tycho_util::{FastDashMap, FastHashMap};
 
 use self::blocks_cache::BlocksCache;
 use self::cancel_validation_runner::CancelValidationRunnerState;
 use self::collation_cancel::{ActionAfterCancel, CollationCancelHandle};
 use self::state_event_listener::{ChannelStateEventListener, StateEvent};
+use self::state_update_handler::ProcessMcStateUpdateMode;
 use self::types::{
-    ActiveCollator, ActiveSync, BlockCacheEntry, BlockCacheEntryData, BlockCacheKey,
-    BlockCacheStoreResult, CandidateStatus, CollatedBlockInfo, CollationState, CollationStatus,
-    CollationSyncState, CollatorJoinTask, CollatorState, HandledBlockFromBcCtx,
-    ImportedAnchorEvent, McBlockSubgraph, McBlockSubgraphExtract, NextCollationStep,
+    ActiveCollator, CollatedBlockInfo, CollationState, CollationStatus, CollationSyncState,
+    CollatorJoinTask, CollatorState, HandledBlockFromBcCtx, ImportedAnchorEvent, NextCollationStep,
     ValidatorJoinTask,
 };
-use self::utils::find_us_in_collators_set;
 use crate::collator::{
-    CollationAbortReason, Collator, CollatorContext, CollatorFactory, CollatorResult,
-    DebugCollatorResult, ForceMasterCollation,
+    CollationAbortReason, Collator, CollatorFactory, CollatorResult, DebugCollatorResult,
+    ForceMasterCollation,
 };
-use crate::internal_queue::types::diff::{DiffZone, QueueDiffWithMessages};
 use crate::internal_queue::types::message::EnqueuedMessage;
-use crate::internal_queue::types::stats::DiffStatistics;
-use crate::mempool::{MempoolAdapter, MempoolAdapterFactory, MempoolAnchorId, StateUpdateContext};
+use crate::mempool::{MempoolAdapter, MempoolAdapterFactory, MempoolAnchorId};
 use crate::queue_adapter::MessageQueueAdapter;
 use crate::state_node::{StateNodeAdapter, StateNodeAdapterFactory};
 use crate::tracing_targets;
 use crate::types::processed_upto::{
-    BlockSeqno, ProcessedUptoInfoExtension, ProcessedUptoInfoStuff, find_min_processed_to_by_shards,
+    BlockSeqno, ProcessedUptoInfoExtension, ProcessedUptoInfoStuff,
 };
 use crate::types::{
     BlockCollationResult, BlockIdExt, CollationSessionInfo, CollatorConfig, DebugDisplayOpt,
-    DebugIter, DisplayAsShortId, DisplayBlockIdsIntoIter, McData, ProcessedToByPartitions,
-    ShardDescriptionShort, ShardDescriptionShortExt, ShardHashesExt, TopBlockId, TopBlockIdUpdated,
+    DisplayAsShortId, McData, ShardDescriptionShortExt, ShardHashesExt, TopBlockId,
+    TopBlockIdUpdated,
 };
 use crate::utils::block::detect_top_processed_to_anchor;
-use crate::utils::shard::calc_split_merge_actions;
 use crate::utils::vset_cache::ValidatorSetCache;
-use crate::validator::{AddSession, ValidationStatus, Validator};
+use crate::validator::{ValidationStatus, Validator};
 
 mod active_collators;
 mod blocks_cache;
 mod cancel_validation_runner;
 mod collation_cancel;
+mod commit;
+mod msgs_queue;
 mod state_event_listener;
+mod state_update_handler;
+mod sync;
 mod types;
 mod utils;
 
@@ -369,27 +358,12 @@ where
             return Ok(());
         }
 
-        self.detect_top_processed_to_anchor_and_notify_mempool_impl(
-            state.block_id().seqno,
-            state
-                .shards()?
-                .as_vec()?
-                .into_iter()
-                .map(|(_, descr)| descr),
-            mc_processed_to_anchor_id,
-        )
-        .await
-    }
+        let mc_top_shards = state
+            .shards()?
+            .as_vec()?
+            .into_iter()
+            .map(|(_, descr)| descr);
 
-    async fn detect_top_processed_to_anchor_and_notify_mempool_impl<I>(
-        &self,
-        mc_block_seqno: BlockSeqno,
-        mc_top_shards: I,
-        mc_processed_to_anchor_id: MempoolAnchorId,
-    ) -> Result<()>
-    where
-        I: Iterator<Item = ShardDescriptionShort>,
-    {
         let top_processed_to_anchor =
             detect_top_processed_to_anchor(mc_top_shards, mc_processed_to_anchor_id);
 
@@ -400,10 +374,11 @@ where
 
         );
 
-        self.notify_top_processed_to_anchor_to_mempool(mc_block_seqno, top_processed_to_anchor)
-            .await?;
-
-        Ok(())
+        self.notify_top_processed_to_anchor_to_mempool(
+            state.block_id().seqno,
+            top_processed_to_anchor,
+        )
+        .await
     }
 
     async fn notify_top_processed_to_anchor_to_mempool(
@@ -424,138 +399,6 @@ where
             .clear_anchors_cache(top_processed_to_anchor)?;
 
         Ok(())
-    }
-
-    #[tracing::instrument(skip_all, fields(block_id = %block_id))]
-    fn commit_block_queue_diff(
-        mq_adapter: Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
-        block_id: &BlockId,
-        top_shard_blocks_info: &[TopBlockIdUpdated],
-        partitions: &FastHashSet<QueuePartitionIdx>,
-    ) -> Result<()> {
-        if !block_id.is_masterchain() {
-            return Ok(());
-        }
-
-        let _histogram = HistogramGuard::begin("tycho_collator_commit_queue_diffs_time");
-
-        let mut top_blocks = top_shard_blocks_info.to_vec();
-        top_blocks.push(TopBlockIdUpdated {
-            block: TopBlockId {
-                ref_by_mc_seqno: block_id.seqno,
-                block_id: *block_id,
-            },
-            updated: true,
-        });
-
-        if let Err(err) = mq_adapter.commit_diff(top_blocks, partitions) {
-            bail!(
-                "Error committing message queue diff of block ({}): {:?}",
-                block_id,
-                err,
-            )
-        }
-
-        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-            "message queue diff was committed",
-        );
-
-        Ok(())
-    }
-
-    /// Returns `BlockId` if diff was applied.
-    /// * `first_required_diffs` - contains ids of known first required diffs for queue for each shard
-    fn apply_block_queue_diff_from_entry_stuff(
-        state_node_adapter: &dyn StateNodeAdapter,
-        mq_adapter: Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
-        block_entry: &BlockCacheEntry,
-        min_processed_to: Option<&QueueKey>,
-        first_required_diffs: &mut FastHashMap<ShardIdent, BlockId>,
-    ) -> Result<Option<BlockId>> {
-        let block_id = block_entry.block_id;
-
-        // TODO: error if <
-        if block_entry.ref_by_mc_seqno <= state_node_adapter.zerostate_id().seqno {
-            return Ok(None);
-        }
-
-        let queue_diff = match &block_entry.data {
-            BlockCacheEntryData::Collated {
-                candidate_stuff, ..
-            } => &candidate_stuff.candidate.queue_diff_aug.data,
-            BlockCacheEntryData::Received { queue_diff, .. } => queue_diff,
-        };
-
-        // skip diff below min processed to
-        if let Some(min_pt) = min_processed_to
-            && queue_diff.as_ref().max_message <= *min_pt
-        {
-            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                "Skipping diff for block {}: max_message {} <= min_processed_to {}",
-                block_id.as_short_id(),
-                queue_diff.as_ref().max_message,
-                min_pt,
-            );
-            return Ok(None);
-        }
-
-        // skip already applied diff
-        if mq_adapter.is_diff_exists(&block_id.as_short_id())? {
-            tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
-                queue_diff_block_id = %block_id.as_short_id(),
-                "queue diff apply skipped because it is already applied",
-            );
-            // if diff for block from bc already applied
-            // then we should check sequense for each next diff
-            first_required_diffs.insert(block_id.shard, BlockId::default());
-            return Ok(None);
-        }
-
-        // load out_msg
-        let out_msgs = match &block_entry.data {
-            BlockCacheEntryData::Collated {
-                candidate_stuff, ..
-            } => &candidate_stuff
-                .candidate
-                .block
-                .data
-                .load_extra()?
-                .out_msg_description
-                .load()?,
-            BlockCacheEntryData::Received { out_msgs, .. } => &out_msgs.load()?,
-        };
-
-        let queue_diff_with_msgs = QueueDiffWithMessages::from_queue_diff(queue_diff, out_msgs)?;
-
-        let statistics = DiffStatistics::from_diff(
-            &queue_diff_with_msgs,
-            queue_diff.block_id().shard,
-            queue_diff.as_ref().min_message,
-            queue_diff.as_ref().max_message,
-        );
-
-        let check_sequence = match first_required_diffs.get(&block_id.shard).copied() {
-            None => {
-                // if first required diff was not detected before
-                // we consider that current is first
-                first_required_diffs.insert(block_id.shard, block_id);
-                None
-            }
-            Some(id) if id == block_id => None,
-            _ => Some(DiffZone::Both),
-        };
-
-        mq_adapter
-            .apply_diff(
-                queue_diff_with_msgs,
-                queue_diff.block_id().as_short_id(),
-                queue_diff.diff_hash(),
-                statistics,
-                check_sequence,
-            )
-            .context("apply_block_queue_diff_from_entry_stuff")?;
-
-        Ok(Some(block_id))
     }
 
     async fn handle_collator_task(
@@ -705,106 +548,6 @@ where
             ),
         )
         .await
-    }
-
-    /// 1. Check if should collate master
-    /// 2. And run master block collation
-    /// 3. Or run next collation attempt in current shard
-    async fn run_next_collation_step(
-        &self,
-        prev_mc_block_id: &BlockId,
-        shard_id: ShardIdent,
-        trigger_shard_block_id_opt: Option<BlockId>,
-        ctx: DetectNextCollationStepContext,
-    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
-        let next_step = Self::detect_next_collation_step(
-            &mut self.collation_sync_state.lock(),
-            self.active_collation_sessions
-                .read()
-                .keys()
-                .cloned()
-                .collect(),
-            shard_id,
-            ctx,
-        );
-
-        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-            next_step = ?next_step,
-            "detected next collation step",
-        );
-
-        let mut collator_tasks = vec![];
-
-        match next_step {
-            NextCollationStep::CollateMaster(next_mc_block_chain_time) => {
-                if !shard_id.is_masterchain() {
-                    // shard collator will wait and master collator will work
-                    self.set_collator_state(&shard_id, |ac| ac.state = CollatorState::Waiting);
-                }
-
-                if let Some(task) = self
-                    .run_mc_block_collation(
-                        prev_mc_block_id.get_next_id_short(),
-                        next_mc_block_chain_time,
-                        trigger_shard_block_id_opt,
-                    )
-                    .await?
-                {
-                    collator_tasks.push(task);
-                }
-            }
-            NextCollationStep::WaitForMasterStatus | NextCollationStep::WaitForShardStatus => {
-                // current shard collator will wait
-                self.set_collator_state(&shard_id, |ac| ac.state = CollatorState::Waiting);
-            }
-            NextCollationStep::ResumeAttemptsIn(shards_to_resume_attempts) => {
-                // if should not collate master block
-                // then continue collation by running `try_collate` that will
-                // - in masterchain: just import next anchor
-                // - in workchain: run next attempt to collate shard block
-                let mut current_shard_should_wait = true;
-                for shard_ident in shards_to_resume_attempts {
-                    if shard_ident == shard_id {
-                        current_shard_should_wait = false;
-                    }
-                    if let Some(task) = self.run_try_collate(&shard_ident).await? {
-                        collator_tasks.push(task);
-                    }
-                }
-                if current_shard_should_wait {
-                    self.set_collator_state(&shard_id, |ac| ac.state = CollatorState::Waiting);
-                }
-            }
-        }
-
-        Ok(collator_tasks)
-    }
-
-    fn handle_block_mismatch(&self, block_id: &BlockId) -> Result<()> {
-        let labels = [("workchain", block_id.shard.workchain().to_string())];
-        metrics::counter!("tycho_collator_block_mismatch_count", &labels).increment(1);
-
-        // should drop uncommitted queue state on block mismatch
-        // because created messages are incorrect
-        self.clear_uncommitted_queue_state()?;
-
-        Ok(())
-    }
-
-    fn clear_uncommitted_queue_state(&self) -> Result<()> {
-        Self::clear_uncommitted_queue_state_impl(&self.blocks_cache, &self.mq_adapter)
-    }
-
-    fn clear_uncommitted_queue_state_impl(
-        blocks_cache: &BlocksCache,
-        mq_adapter: &Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
-    ) -> Result<()> {
-        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-            "clear uncommitted queue state",
-        );
-
-        let top_shards = blocks_cache.get_last_top_shards();
-        mq_adapter.clear_uncommitted_state(&top_shards)
     }
 
     /// Process collated block candidate
@@ -1037,6 +780,17 @@ where
         }
     }
 
+    fn handle_block_mismatch(&self, block_id: &BlockId) -> Result<()> {
+        let labels = [("workchain", block_id.shard.workchain().to_string())];
+        metrics::counter!("tycho_collator_block_mismatch_count", &labels).increment(1);
+
+        // should drop uncommitted queue state on block mismatch
+        // because created messages are incorrect
+        self.clear_uncommitted_queue_state()?;
+
+        Ok(())
+    }
+
     /// Finish active sync if it is not finished yet
     /// and enqueue received block
     #[tracing::instrument(skip_all, fields(block_id = %ctx.state.block_id().as_short_id()))]
@@ -1261,469 +1015,6 @@ where
         }
     }
 
-    fn check_should_sync_to_last_applied_mc_block(
-        &self,
-        store_res: &BlockCacheStoreResult,
-        top_mc_block_id_for_next_collation: Option<BlockId>,
-        required_min_mc_block_delta: BlockSeqno,
-        is_key_block: Option<bool>,
-    ) -> bool {
-        // do not sync to last applied mc block if newer already received
-        if self.has_newer_received_mc_block(store_res.applied_mc_queue_range) {
-            return false;
-        }
-
-        // should sync if collated block mismatched
-        if store_res.block_mismatch {
-            return true;
-        }
-
-        let has_active_collations = self.has_active_collations();
-        let last_synced_to_mc_block_id = self
-            .get_last_synced_to_mc_block_id()
-            .map(|id| id.as_short_id().to_string());
-        let last_collated_mc_block_id = store_res
-            .last_collated_mc_block_id
-            .map(|id| id.as_short_id().to_string());
-        let last_processed_mc_block_id = self
-            .get_last_processed_mc_block_id()
-            .map(|id| id.as_short_id().to_string());
-
-        if let Some(top_mc_block_id_for_next_collation) = top_mc_block_id_for_next_collation {
-            // we can sync only when we have any applied block ahead
-            if let Some((_, applied_range_end)) = store_res.applied_mc_queue_range {
-                // check if should sync according to master block delta
-                let applied_range_end_delta =
-                    applied_range_end.saturating_sub(top_mc_block_id_for_next_collation.seqno);
-
-                if applied_range_end_delta < required_min_mc_block_delta {
-                    tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                        last_synced_to_mc_block_id = ?last_synced_to_mc_block_id,
-                        last_collated_mc_block_id = ?last_collated_mc_block_id,
-                        last_processed_mc_block_id = ?last_processed_mc_block_id,
-                        has_active_collations,
-                        is_key_block = ?is_key_block,
-                        "check_should_sync: should wait for next collated own mc block: \
-                        last applied ({}) ahead of top for collation ({}) on {} < {}",
-                        applied_range_end, top_mc_block_id_for_next_collation.seqno,
-                        applied_range_end_delta, required_min_mc_block_delta,
-                    );
-                    false
-                } else {
-                    tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                        last_synced_to_mc_block_id = ?last_synced_to_mc_block_id,
-                        last_collated_mc_block_id = ?last_collated_mc_block_id,
-                        last_processed_mc_block_id = ?last_processed_mc_block_id,
-                        has_active_collations,
-                        is_key_block = ?is_key_block,
-                        "check_should_sync: should sync to last applied mc block from bc: \
-                        last applied ({}) ahead of top for collation ({}) on {} >= {}",
-                        applied_range_end, top_mc_block_id_for_next_collation.seqno,
-                        applied_range_end_delta, required_min_mc_block_delta,
-                    );
-                    true
-                }
-            } else {
-                // should collate next own mc block because no applied ahead
-                tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                    last_synced_to_mc_block_id = ?last_synced_to_mc_block_id,
-                    last_collated_mc_block_id = ?last_collated_mc_block_id,
-                    last_processed_mc_block_id = ?last_processed_mc_block_id,
-                    has_active_collations,
-                    is_key_block = ?is_key_block,
-                    "check_should_sync: should collate next own mc block after because nothing applied ahead",
-                );
-                false
-            }
-        } else {
-            tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                last_synced_to_mc_block_id = ?last_synced_to_mc_block_id,
-                last_collated_mc_block_id = ?last_collated_mc_block_id,
-                last_processed_mc_block_id = ?last_processed_mc_block_id,
-                has_active_collations,
-                is_key_block = ?is_key_block,
-                "check_should_sync: should sync to last applied mc block when no last collated or prev sync to",
-            );
-            true
-        }
-    }
-
-    #[tracing::instrument(name = "sync_to_applied_mc_block", skip_all, fields(trigger_block_id = %trigger_block_id_short, applied_range = ?applied_range))]
-    async fn sync_to_applied_mc_block_if_exist(
-        self: &Arc<Self>,
-        trigger_block_id_short: BlockIdShort,
-        last_collated_mc_block_id: Option<BlockId>,
-        applied_range: Option<(BlockSeqno, BlockSeqno)>,
-        process_state_update_mode: ProcessMcStateUpdateMode,
-    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
-        let mut collator_tasks = vec![];
-
-        if let Some(applied_range) = applied_range {
-            let this = self.clone();
-            let span = tracing::Span::current();
-
-            collator_tasks = tokio::task::spawn_blocking(move || {
-                let _ = span.enter();
-
-                this.sync_to_applied_mc_block(
-                    trigger_block_id_short,
-                    last_collated_mc_block_id,
-                    applied_range,
-                    process_state_update_mode,
-                )
-            })
-            .await??;
-        } else {
-            tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                "there is no received applied mc blocks in cache, \
-                will wait for next blocks from bc",
-            );
-        }
-
-        Ok(collator_tasks)
-    }
-
-    /// Restores internals queue state,
-    /// processes last applied mc state
-    /// to run next blocks collation.
-    #[tracing::instrument(skip_all, fields(trigger_block_id = %trigger_block_id_short, applied_range = ?applied_range))]
-    fn sync_to_applied_mc_block(
-        &self,
-        trigger_block_id_short: BlockIdShort,
-        last_collated_mc_block_id: Option<BlockId>,
-        applied_range: (BlockSeqno, BlockSeqno),
-        process_state_update_mode: ProcessMcStateUpdateMode,
-    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
-        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-            "start sync to applied mc block",
-        );
-
-        let _histogram = HistogramGuard::begin("tycho_collator_sync_to_applied_mc_block_time");
-        metrics::counter!("tycho_collator_sync_to_applied_mc_block_count").increment(1);
-
-        let first_applied_mc_block_key = BlockIdShort {
-            shard: ShardIdent::MASTERCHAIN,
-            seqno: applied_range.0,
-        };
-        let last_applied_mc_block_key = BlockIdShort {
-            shard: ShardIdent::MASTERCHAIN,
-            seqno: applied_range.1,
-        };
-
-        // store active sync info with cancellation token
-        let cancelled = self.set_active_sync_info(last_applied_mc_block_key.seqno)?;
-        tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
-            "cancel sync: sync_to_applied_mc_block: set_active_sync_info for seqno={}",
-            last_applied_mc_block_key.seqno,
-        );
-        scopeguard::defer!({
-            self.clean_active_sync_info();
-            tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
-                "cancel sync: sync_to_applied_mc_block: active_sync_info cleaned",
-            );
-        });
-
-        // gc blocks from cache when sync finished
-        scopeguard::defer!(self.blocks_cache.gc_prev_blocks());
-
-        // we need to drop uncommitted internal messages from the queue
-        // when mempool config override has genesis higher then in the last consensus info
-        if let Some(mp_cfg_override) = &self.mempool_config_override {
-            let last_consesus_info = self
-                .blocks_cache
-                .get_consensus_info_for_mc_block(&last_applied_mc_block_key)?;
-            if mp_cfg_override
-                .genesis_info
-                .overrides(&last_consesus_info.genesis_info)
-            {
-                tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                    prev_genesis_start_round = last_consesus_info.genesis_info.start_round,
-                    prev_genesis_time_millis = last_consesus_info.genesis_info.genesis_millis,
-                    new_genesis_start_round = mp_cfg_override.genesis_info.start_round,
-                    new_genesis_time_millis = mp_cfg_override.genesis_info.genesis_millis,
-                    "will drop uncommitted internal messages from queue on new genesis",
-                );
-
-                // E.g. we have applied mc block MC100 and collated some shard blocks after it (SC701, SC702)
-                // so we have uncommitted queue diffs from these shard blocks SC701, SC702.
-                // On restart from genesis we will start to collate SC701* again because last validated
-                // and applied mc block is MC100. But mempool will not contain all old externals used to collate
-                // the previous version of SC701. So the new diff will mismatch the old one and node will panic.
-                // So we need to remove all uncommitted queue diffs because we have new mismatched externals queue.
-                self.clear_uncommitted_queue_state()?;
-            }
-        }
-
-        // get internals processed_to from master and all shards
-        // for last applied master block
-        let all_shards_processed_to_by_partitions =
-            Self::get_all_shards_processed_to_by_partitions_for_mc_block(
-                &last_applied_mc_block_key,
-                &self.blocks_cache,
-                self.state_node_adapter.clone(),
-            )
-            .await_blocking()?;
-
-        // find internals min processed_to
-        let min_processed_to_by_shards =
-            find_min_processed_to_by_shards(&all_shards_processed_to_by_partitions);
-
-        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-            ?min_processed_to_by_shards,
-        );
-
-        // find first applied mc block and tail shard blocks and get previous
-        let before_tail_block_ids = self
-            .blocks_cache
-            .read_before_tail_ids_of_mc_block(&first_applied_mc_block_key)?;
-
-        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-            tail_block_ids = ?before_tail_block_ids
-                .iter()
-                .map(|(shard_id, (id, prev_ids))| {
-                    format!(
-                        "({}, id={:?}, prev_ids={})",
-                        shard_id,
-                        id.as_ref().map(DisplayAsShortId),
-                        DisplayBlockIdsIntoIter(prev_ids),
-                    )
-                }).collect::<Vec<_>>().as_slice(),
-        );
-
-        // metrics - sync is running
-        for shard in before_tail_block_ids.keys() {
-            let labels = [("workchain", shard.workchain().to_string())];
-            metrics::gauge!("tycho_collator_sync_is_running", &labels).set(1);
-        }
-
-        // if `fast_sync` is enabled then we will skip already applied queue diffs
-        let queue_diffs_applied_to_top_blocks = if self.config.fast_sync
-            && let Some(applied_to_mc_block_id) =
-                self.get_queue_diffs_applied_to_mc_block_id(last_collated_mc_block_id)?
-        {
-            // BACKWARD COMPATIBILITY: `last_committed_mc_block_id` will not exist in queue storage
-            // in previous version. We will receive None and will use all required diffs to restore the queue
-
-            // NOTE: when the node started to sync from a persistent state with a bunch of archives after it,
-            //      the `last_collated_mc_block_id` will be None, and `applied_to_mc_block_id` will be equal
-            //      to the top block of the persistent state - init block. But the persistent state can be already
-            //      removed because of the long history after it when collator starts to sync by recent blocks.
-            //      So we will not able to read top blocks ids and will fallback the full sync.
-
-            // collect top blocks queue diffs already applied to
-            Self::get_top_blocks_seqno(
-                &applied_to_mc_block_id,
-                &self.blocks_cache,
-                self.state_node_adapter.clone(),
-            )
-            .await_blocking()?
-        } else {
-            None
-        };
-        if queue_diffs_applied_to_top_blocks.is_some() {
-            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                ?queue_diffs_applied_to_top_blocks,
-                "will use fast sync to restore queue",
-            );
-        }
-
-        // restore queue state and return latest applied master state
-        let queue_restore_res = Self::restore_queue(
-            &self.blocks_cache,
-            self.state_node_adapter.clone(),
-            self.mq_adapter.clone(),
-            applied_range.0,
-            min_processed_to_by_shards,
-            before_tail_block_ids,
-            queue_diffs_applied_to_top_blocks.unwrap_or_default(),
-        )
-        .await_blocking()?;
-
-        let Some(last_mc_state) = queue_restore_res.last_mc_state else {
-            tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                last_applied_mc_block_id = %BlockIdShort {
-                    shard: ShardIdent::MASTERCHAIN,
-                    seqno: applied_range.1,
-                },
-                "sync_to_applied_mc_block: unable to sync to last applied mc block, \
-                need to receive next blocks from bc",
-            );
-            return Ok(vec![]);
-        };
-
-        // process latest master state: notify mempool and refresh collation session
-        let last_mc_block_id = *last_mc_state.block_id();
-
-        // HACK: do not need to set master block latest chain time from zerostate when using mempool stub
-        //      because anchors from stub have older chain time than in zerostate and it will brake collation
-        if last_mc_block_id.seqno > self.state_node_adapter.zerostate_id().seqno {
-            Self::renew_mc_block_latest_chain_time(
-                &mut self.collation_sync_state.lock(),
-                last_mc_state.get_gen_chain_time(),
-            );
-        }
-
-        Self::reset_collation_sync_status(&mut self.collation_sync_state.lock());
-
-        // update last "synced to" info
-        self.update_last_synced_to_mc_block_id(last_mc_block_id);
-
-        // reset top shard blocks info
-        // because next we will start to collate new shard blocks after the sync
-        self.blocks_cache.reset_top_shard_blocks_additional_info();
-
-        let mc_data = Self::build_mc_data(
-            &self.state_node_adapter,
-            last_mc_state,
-            queue_restore_res.prev_mc_state,
-            queue_restore_res.prev_mc_block_id,
-            all_shards_processed_to_by_partitions,
-        )?;
-
-        self.blocks_cache
-            .remove_next_collated_blocks_from_cache(&queue_restore_res.synced_to_blocks_keys);
-
-        // notify state update to mempool
-        self.notify_mc_state_update_to_mempool(mc_data.clone())
-            .await_blocking()?;
-
-        // when sync cancelled we do not exist sync but skip collation
-        let process_state_update_mode = if cancelled.is_cancelled() {
-            ProcessMcStateUpdateMode::SkipProcess
-        } else {
-            process_state_update_mode
-        };
-
-        let collator_tasks = self
-            .process_mc_state_update(mc_data.clone(), process_state_update_mode)
-            .await_blocking()?;
-
-        // handle top processed to anchor in mempool
-        self.notify_top_processed_to_anchor_to_mempool(
-            mc_data.block_id.seqno,
-            mc_data.top_processed_to_anchor,
-        )
-        .await_blocking()?;
-
-        // report last "synced to" blocks to metrics
-        for synced_to_block_id in queue_restore_res.synced_to_blocks_keys {
-            let labels = [
-                (
-                    "workchain",
-                    synced_to_block_id.shard.workchain().to_string(),
-                ),
-                ("src", "02_synced_to".to_string()),
-            ];
-            metrics::gauge!("tycho_last_block_seqno", &labels).set(synced_to_block_id.seqno);
-        }
-
-        Ok(collator_tasks)
-    }
-
-    /// Builds `McData` from provided parts.
-    /// Tries to load the previous mc state from storage when passed `None`.
-    fn build_mc_data(
-        state_node_adapter: &Arc<dyn StateNodeAdapter>,
-        last_mc_state: ShardStateStuff,
-        prev_mc_state: Option<ShardStateStuff>,
-        prev_mc_block_id: Option<BlockId>,
-        all_shards_processed_to_by_partitions: FastHashMap<
-            ShardIdent,
-            (bool, ProcessedToByPartitions),
-        >,
-    ) -> Result<Arc<McData>> {
-        let prev_mc_state = match (prev_mc_state, prev_mc_block_id) {
-            (Some(mc_state), _) => Some(mc_state),
-            (None, None) => None,
-            (None, Some(prev_mc_block_id)) if prev_mc_block_id.seqno <= state_node_adapter.zerostate_id().seqno => None,
-            // NOTE: Use zero epoch here since we don't need to reuse these states.
-            (None, Some(prev_mc_block_id)) => state_node_adapter
-                .load_state(0, &prev_mc_block_id, Default::default())
-                .await_blocking()
-                .map_err(|err| {
-                    tracing::warn!(target: tracing_targets::COLLATION_MANAGER,
-                        prev_mc_block_id = %prev_mc_block_id.as_short_id(),
-                        error = ?err,
-                        "failed to load previous mc state to build mc data, continue without prev_mc_data",
-                    );
-                    err
-                }).ok(),
-        };
-
-        McData::load_from_state(
-            &last_mc_state,
-            prev_mc_state.as_ref(),
-            all_shards_processed_to_by_partitions,
-        )
-    }
-
-    async fn get_all_shards_processed_to_by_partitions_for_mc_block(
-        mc_block_key: &BlockCacheKey,
-        blocks_cache: &BlocksCache,
-        state_node_adapter: Arc<dyn StateNodeAdapter>,
-    ) -> Result<FastHashMap<ShardIdent, (bool, ProcessedToByPartitions)>> {
-        let mut result = FastHashMap::default();
-
-        let zerostate_mc_seqno = blocks_cache.zerostate_mc_seqno();
-        if mc_block_key.seqno <= zerostate_mc_seqno {
-            return Ok(result);
-        }
-
-        let from_cache = blocks_cache.get_top_blocks_processed_to_by_partitions(mc_block_key)?;
-
-        for (top_block_id, item) in from_cache {
-            let processed_to = match item.by {
-                Some(processed_to) => processed_to,
-                None => {
-                    if item.ref_by_mc_seqno <= zerostate_mc_seqno {
-                        FastHashMap::default()
-                    } else {
-                        // get from state
-                        let state = state_node_adapter
-                            .load_state(mc_block_key.seqno, &top_block_id, LoadStateHint {
-                                // State must already be applied at this point.
-                                allow_ignore_direct: false,
-                            })
-                            .await?;
-                        let processed_upto = state.state().processed_upto.load()?;
-                        let processed_upto = ProcessedUptoInfoStuff::try_from(processed_upto)?;
-                        processed_upto.get_internals_processed_to_by_partitions()
-                    }
-                }
-            };
-
-            result.insert(top_block_id.shard, (item.updated, processed_to));
-        }
-
-        Ok(result)
-    }
-
-    // Returns top master block id upto which all queue diffs applied
-    fn get_queue_diffs_applied_to_mc_block_id(
-        &self,
-        last_collated_mc_block_id: Option<BlockId>,
-    ) -> Result<Option<BlockId>> {
-        let last_queue_comitted_on = self.mq_adapter.get_last_committed_mc_block_id()?;
-        let last_collated_or_synced_to =
-            self.get_top_mc_block_id_for_next_collation(last_collated_mc_block_id);
-
-        let mc_block_id = match (last_queue_comitted_on, last_collated_or_synced_to) {
-            (Some(last_queue_comitted_on), Some(last_collated_or_synced_to)) => {
-                // return last collated if it exists (or last "synced to")
-                // if above mc block on which the queue was committed
-                if last_collated_or_synced_to.seqno >= last_queue_comitted_on.seqno {
-                    Some(last_collated_or_synced_to)
-                } else {
-                    Some(last_queue_comitted_on)
-                }
-            }
-            (Some(mc_block_id), _) | (_, Some(mc_block_id)) => Some(mc_block_id),
-            _ => None,
-        };
-
-        Ok(mc_block_id)
-    }
-
     /// Return last collated if it is ahead of last received and "synced to".
     /// Or last received and "synced to" if it is ahead of last correct collated.
     /// Last collated may be incorrect but we don not know this until we receive block from bc.
@@ -1753,921 +1044,6 @@ where
         }
     }
 
-    #[tracing::instrument(skip_all, fields(from_mc_block_seqno))]
-    async fn restore_queue(
-        blocks_cache: &BlocksCache,
-        state_node_adapter: Arc<dyn StateNodeAdapter>,
-        mq_adapter: Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
-        from_mc_block_seqno: u32,
-        min_processed_to_by_shards: BTreeMap<ShardIdent, QueueKey>,
-        before_tail_block_ids: BTreeMap<ShardIdent, (Option<BlockId>, Vec<BlockId>)>,
-        queue_diffs_applied_to_top_blocks: FastHashMap<ShardIdent, u32>,
-    ) -> Result<RestoreQueueResult> {
-        let mut res = RestoreQueueResult::default();
-
-        // load init block (from persistent state) to check if required diff was already applied from persistent
-        let init_mc_block_id = state_node_adapter.load_init_block_id();
-        let mut init_mc_block_reached_on = FastHashMap::new();
-
-        // try load required previous queue diffs
-        let mut first_required_diffs = FastHashMap::new();
-        for (shard_id, min_processed_to) in &min_processed_to_by_shards {
-            let mut prev_queue_diffs = vec![];
-            let Some((_, prev_block_ids)) = before_tail_block_ids.get(shard_id) else {
-                continue;
-            };
-            let mut prev_block_ids: VecDeque<_> = prev_block_ids.iter().cloned().collect();
-
-            while let Some(prev_block_id) = prev_block_ids.pop_front() {
-                // NOTE: We don't skip prev block ids for shard zerostates because
-                // it is quite hard to propagate `ref_by_mc_seqno` here (we construct
-                // prev ids based just on `BlockId` here). There seems to be no problems
-                // with that because we are checking `init_mc_block_reached` using
-                // the handle data so zerostate ids will be skipped in any case.
-                // This check is just to not change the old behavior just in case.
-                if prev_block_id.seqno == 0
-                    || prev_block_id.is_masterchain()
-                        && prev_block_id.seqno <= state_node_adapter.zerostate_id().seqno
-                {
-                    continue;
-                }
-
-                // if diff is below top applied then skip
-                if let Some(border) = queue_diffs_applied_to_top_blocks.get(shard_id)
-                    && prev_block_id.seqno <= *border
-                {
-                    tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                        prev_block_id = %prev_block_id.as_short_id(),
-                        top_applied_seqno = border,
-                        "previous queue diff skipped because it below top applied",
-                    );
-                    continue;
-                }
-
-                // if diff is before init block (from persistent state)
-                // we do not need to apply it because queue was already restored from persistent
-                if let Some(init_mc_block_id) = init_mc_block_id {
-                    let mut skip_diff = false;
-                    if prev_block_id.is_masterchain() {
-                        if prev_block_id.seqno <= init_mc_block_id.seqno {
-                            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                                prev_block_id = %prev_block_id.as_short_id(),
-                                init_mc_block_id = %init_mc_block_id.as_short_id(),
-                                "master block queue diff apply skipped because it is below init block from persistent state",
-                            );
-                            skip_diff = true;
-                        }
-                    } else {
-                        // check if we already reached init mc block before
-                        let mut init_mc_block_reached = matches!(
-                            init_mc_block_reached_on.get(&prev_block_id.shard),
-                            Some(reached_seqno) if prev_block_id.seqno <= *reached_seqno,
-                        );
-                        if !init_mc_block_reached {
-                            // for shard block we should check it's `ref_by_mc_seqno`
-                            let prev_ref_by_mc_seqno = state_node_adapter
-                                .get_ref_by_mc_seqno(&prev_block_id)
-                                .await?
-                                .unwrap();
-                            init_mc_block_reached = prev_ref_by_mc_seqno <= init_mc_block_id.seqno;
-                            if init_mc_block_reached {
-                                init_mc_block_reached_on
-                                    .insert(prev_block_id.shard, prev_block_id.seqno);
-                            }
-                        }
-                        if init_mc_block_reached {
-                            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                                prev_block_id = %prev_block_id.as_short_id(),
-                                init_mc_block_id = %init_mc_block_id.as_short_id(),
-                                "shard block queue diff apply skipped because it is below init block from persistent state",
-                            );
-                            skip_diff = true;
-                        }
-                    }
-                    if skip_diff {
-                        // if current diff is below init block
-                        // then we should check sequense for each next diff
-                        first_required_diffs.insert(prev_block_id.shard, BlockId::default());
-                        continue;
-                    }
-                }
-
-                // load diff to check if it is required
-                let Some(queue_diff_stuff) = state_node_adapter.load_diff(&prev_block_id).await?
-                else {
-                    tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                        prev_block_id = %prev_block_id,
-                        "unable to load prev diff to sync queue state, cancel sync",
-                    );
-
-                    // metrics - sync finished
-                    for shard in before_tail_block_ids.keys() {
-                        let labels = [("workchain", shard.workchain().to_string())];
-                        metrics::gauge!("tycho_collator_sync_is_running", &labels).set(0);
-                    }
-
-                    return Ok(res);
-                };
-                let diff_required = &queue_diff_stuff.as_ref().max_message > min_processed_to;
-                tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                    diff_block_id = %prev_block_id.as_short_id(),
-                    diff_required,
-                    max_message = %queue_diff_stuff.as_ref().max_message,
-                    min_processed_to = %min_processed_to,
-                    "check if diff required to restore queue working state on sync:",
-                );
-                if diff_required {
-                    // if next diff is not required
-                    // then current will be the first required
-                    first_required_diffs.insert(prev_block_id.shard, prev_block_id);
-
-                    let block_stuff = state_node_adapter
-                        .load_block(&prev_block_id)
-                        .await?
-                        .unwrap();
-                    let out_msgs = block_stuff.load_extra()?.out_msg_description.load()?;
-
-                    let queue_diff_with_messages =
-                        QueueDiffWithMessages::from_queue_diff(&queue_diff_stuff, &out_msgs)?;
-
-                    prev_queue_diffs.push((
-                        queue_diff_with_messages,
-                        *queue_diff_stuff.diff_hash(),
-                        prev_block_id,
-                        queue_diff_stuff.as_ref().min_message,
-                        queue_diff_stuff.as_ref().max_message,
-                    ));
-
-                    let prev_ids_info = block_stuff.construct_prev_id()?;
-                    prev_block_ids.push_back(prev_ids_info.0);
-                    if let Some(id) = prev_ids_info.1 {
-                        prev_block_ids.push_back(id);
-                    }
-                }
-            }
-
-            // apply required previous queue diffs for each shard
-            while let Some((diff, diff_hash, block_id, min_message, max_message)) =
-                prev_queue_diffs.pop()
-            {
-                let statistics =
-                    DiffStatistics::from_diff(&diff, block_id.shard, min_message, max_message);
-
-                // we can skip the sequense check for the first required diff only
-                let check_sequence = match first_required_diffs.get(&block_id.shard) {
-                    Some(id) if *id == block_id => None,
-                    _ => Some(DiffZone::Both),
-                };
-
-                mq_adapter
-                    .apply_diff(
-                        diff,
-                        block_id.as_short_id(),
-                        &diff_hash,
-                        statistics,
-                        check_sequence,
-                    )
-                    .context("sync_to_applied_mc_block")?;
-
-                res.applied_diffs_ids.insert(block_id);
-            }
-        }
-
-        // will track last mc state and previous before it
-        let mut prev_mc_state = None;
-        let mut last_mc_state;
-
-        // extract all recevied blocks, apply required diffs
-        // and return latest master state
-        loop {
-            // pop first applied mc block and sync
-            // actually we can sync more mc blocks than known in applied_range
-            // because we can receive new blocks from bc during sync
-            let (mc_block_subgraph_extract, is_last) =
-                blocks_cache.pop_front_applied_mc_block_subgraph(from_mc_block_seqno)?;
-
-            let subgraph = match mc_block_subgraph_extract {
-                McBlockSubgraphExtract::Extracted(subgraph) => subgraph,
-                McBlockSubgraphExtract::AlreadyExtracted => {
-                    bail!("mc block subgraph extract result cannot be AlreadyExtracted")
-                }
-            };
-
-            let mc_block_entry = &subgraph.master_block;
-
-            // apply queue diffs from blocks above zerostate seqno
-            // skip cached diffs below min_processed_to
-            if subgraph.master_block.block_id.seqno > state_node_adapter.zerostate_id().seqno {
-                for block_entry in [mc_block_entry]
-                    .into_iter()
-                    .chain(subgraph.shard_blocks.iter())
-                {
-                    // if diff is below top applied then skip
-                    if let Some(border) =
-                        queue_diffs_applied_to_top_blocks.get(&block_entry.block_id.shard)
-                        && block_entry.block_id.seqno <= *border
-                    {
-                        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                            received_block_id = %block_entry.block_id.as_short_id(),
-                            top_applied_seqno = border,
-                            "queue diff apply skipped because it is below top applied",
-                        );
-                        continue;
-                    }
-
-                    let min_processed_to =
-                        min_processed_to_by_shards.get(&block_entry.block_id.shard);
-
-                    if let Some(applied_diff_block_id) =
-                        Self::apply_block_queue_diff_from_entry_stuff(
-                            state_node_adapter.as_ref(),
-                            mq_adapter.clone(),
-                            block_entry,
-                            min_processed_to,
-                            &mut first_required_diffs,
-                        )?
-                    {
-                        res.applied_diffs_ids.insert(applied_diff_block_id);
-                    }
-                }
-            }
-
-            // we can gc to current master block when diffs were applied
-            let to_blocks_keys = mc_block_entry.get_top_blocks_keys()?;
-            blocks_cache.set_gc_to_boundary(&to_blocks_keys);
-
-            last_mc_state = mc_block_entry.cached_state()?.clone();
-
-            // on sync finish we commit diffs
-            if is_last {
-                let partitions = subgraph.get_partitions();
-                Self::commit_block_queue_diff(
-                    mq_adapter.clone(),
-                    &mc_block_entry.block_id,
-                    &mc_block_entry.top_shard_blocks_info,
-                    &partitions,
-                )?;
-
-                // when we run sync by any reason we should drop uncommitted queue updates
-                // after restoring the required state
-                // to avoid panics if next block was already collated before an it is incorrect
-                Self::clear_uncommitted_queue_state_impl(blocks_cache, &mq_adapter)?;
-
-                res.last_mc_state = Some(last_mc_state);
-                res.prev_mc_state = prev_mc_state;
-                res.prev_mc_block_id = mc_block_entry.prev_blocks_ids.first().copied();
-                res.synced_to_blocks_keys.extend(to_blocks_keys.into_iter());
-
-                return Ok(res);
-            }
-
-            prev_mc_state = Some(last_mc_state.clone());
-        }
-    }
-
-    fn get_last_processed_mc_block_id(&self) -> Option<BlockId> {
-        *self.last_processed_mc_block_id.lock()
-    }
-
-    fn check_should_process_and_update_last_processed_mc_block(&self, block_id: &BlockId) -> bool {
-        let mut guard = self.last_processed_mc_block_id.lock();
-        let last_processed_mc_block_id_opt = guard.as_ref();
-        let (seqno_delta, is_equal) =
-            Self::compare_mc_block_with(block_id, last_processed_mc_block_id_opt);
-        if seqno_delta < 0 || is_equal {
-            false
-        } else {
-            guard.replace(*block_id);
-            true
-        }
-    }
-
-    /// Returns: (seqno delta from other, true - if equal).
-    /// If `other_mc_block_id_opt` is none, returns : (0, false)
-    fn compare_mc_block_with(
-        mc_block_id: &BlockId,
-        other_mc_block_id_opt: Option<&BlockId>,
-    ) -> (i32, bool) {
-        let (seqno_delta, is_equal) = match other_mc_block_id_opt {
-            None => {
-                tracing::info!(
-                    target: tracing_targets::COLLATION_MANAGER,
-                    "other mc block is None: current {} other ({:?}): is_equal = false, seqno_delta = 0",
-                    mc_block_id.as_short_id(),
-                    other_mc_block_id_opt.map(|b| b.as_short_id()),
-                );
-                (0, false)
-            }
-            Some(other_mc_block_id) => (
-                mc_block_id.seqno as i32 - other_mc_block_id.seqno as i32,
-                mc_block_id == other_mc_block_id,
-            ),
-        };
-        if seqno_delta < 0 || is_equal {
-            tracing::info!(
-                target: tracing_targets::COLLATION_MANAGER,
-                "mc block is NOT AHEAD of other: current {} other ({:?}): is_equal = {}, seqno_delta = {}",
-                mc_block_id.as_short_id(),
-                other_mc_block_id_opt.map(|b| b.as_short_id()),
-                is_equal, seqno_delta,
-            );
-        }
-        (seqno_delta, is_equal)
-    }
-
-    async fn process_mc_state_update(
-        &self,
-        mc_data: Arc<McData>,
-        mode: ProcessMcStateUpdateMode,
-    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
-        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-            ?mode,
-            "will process master state update",
-        );
-
-        let mut collator_tasks = vec![];
-
-        if !matches!(mode, ProcessMcStateUpdateMode::SkipProcess) {
-            let block_global = mc_data.config.get_global_version()?;
-            if self.config.supported_block_version >= block_global.version
-                && block_global
-                    .capabilities
-                    .is_subset_of(self.config.supported_capabilities)
-            {
-                collator_tasks = self.refresh_collation_sessions(mc_data, mode).await?;
-            } else {
-                tracing::warn!(target: tracing_targets::COLLATION_MANAGER,
-                    collator_supported_block_version = self.config.supported_block_version,
-                    mc_block_version = block_global.version,
-                    collator_supported_capabilities = ?self.config.supported_capabilities,
-                    mc_block_capabilities = ?block_global.capabilities,
-                    "Refresh collation sessions is skipped: collator does not support mc block version or capabilities",
-                );
-            }
-        }
-
-        Ok(collator_tasks)
-    }
-
-    /// Returns top processed to anchor id if delayed state was processed
-    async fn notify_to_mempool_and_process_delayed_mc_state_update(
-        &self,
-        block_id: &BlockId,
-        skip_process_delayed_mc_state_update: bool,
-    ) -> Result<Option<(MempoolAnchorId, Vec<CollatorJoinTask<CF::Collator>>)>> {
-        let mut delayed_mc_data = None;
-        {
-            let mut guard = self.delayed_mc_state_update.lock();
-            if let Some(mc_data) = guard.clone()
-                && mc_data.block_id <= *block_id
-            {
-                // process delayed mc state only if committed block is equal
-                if mc_data.block_id == *block_id {
-                    delayed_mc_data = Some(mc_data);
-                }
-
-                // remove delayed mc state even if committed block is ahead
-                *guard = None;
-            }
-        }
-        if let Some(mc_data) = delayed_mc_data {
-            self.notify_mc_state_update_to_mempool(mc_data.clone())
-                .await?;
-
-            // validation may finish when collation cancel task is running,
-            // so we should not run new collation tasks
-            let mut collator_tasks = vec![];
-            if !skip_process_delayed_mc_state_update {
-                collator_tasks = self
-                    .process_mc_state_update(
-                        mc_data.clone(),
-                        ProcessMcStateUpdateMode::StartCollation {
-                            reset_collators: false,
-                        },
-                    )
-                    .await?;
-            }
-
-            Ok(Some((mc_data.top_processed_to_anchor, collator_tasks)))
-        } else {
-            Ok(None)
-        }
-    }
-
-    async fn notify_mc_state_update_to_mempool(&self, mc_data: Arc<McData>) -> Result<()> {
-        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-            block_id = %mc_data.block_id.as_short_id(),
-            "will notify master state update to mempool",
-        );
-
-        let prev_validator_set = self
-            .validator_set_cache
-            .get_prev_validator_set(&mc_data.config)?;
-        let current_validator_set = self
-            .validator_set_cache
-            .get_current_validator_set(&mc_data.config)?;
-        let next_validator_set = self
-            .validator_set_cache
-            .get_next_validator_set(&mc_data.config)?;
-
-        let cx = Box::new(StateUpdateContext {
-            mc_block_id: mc_data.block_id,
-            mc_block_chain_time: mc_data.gen_chain_time,
-            top_processed_to_anchor_id: mc_data.top_processed_to_anchor,
-            consensus_info: mc_data.consensus_info,
-            shuffle_validators: mc_data.config.get_collation_config()?.shuffle_mc_validators,
-            consensus_config: mc_data.config.get_consensus_config()?,
-            prev_validator_set,
-            current_validator_set,
-            next_validator_set,
-        });
-
-        self.mpool_adapter.handle_mc_state_update(cx).await
-    }
-
-    /// Get shards and validator set info from the master state,
-    /// then start missing collation sessions, finish outdated, resume actual.
-    /// Start/stop/resume collators and validators.
-    #[tracing::instrument(skip_all)]
-    async fn refresh_collation_sessions(
-        &self,
-        mc_data: Arc<McData>,
-        mode: ProcessMcStateUpdateMode,
-    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
-        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-            "Start refresh collation sessions by mc state ({})...",
-            mc_data.block_id.as_short_id(),
-        );
-
-        let _histogram = HistogramGuard::begin("tycho_collator_refresh_collation_sessions_time");
-
-        let mut collator_tasks = vec![];
-
-        // NOTE: in case of processing delayed state update
-        //      after the validation of key block with consensus config changed
-        //      we may try to process the state that is older then already processed from bc
-
-        // do not re-process this master block if it is lower then last processed or equal to it
-        // but process a new version of block with the same seqno
-        if !self.check_should_process_and_update_last_processed_mc_block(&mc_data.block_id) {
-            return Ok(collator_tasks);
-        }
-
-        tracing::trace!(target: tracing_targets::COLLATION_MANAGER, "mc_data: {:?}", mc_data);
-
-        // get new shards info from updated master state
-        let mut new_shards_info = FastHashMap::default();
-        new_shards_info.insert(ShardIdent::MASTERCHAIN, vec![mc_data.block_id]);
-        for (shard_id, descr) in mc_data.shards.iter() {
-            let top_block_id = descr.get_block_id(*shard_id);
-            // TODO: consider split and merge
-            new_shards_info.insert(*shard_id, vec![top_block_id]);
-        }
-
-        // apply split/merge actions
-        self.apply_split_merge_actions(&new_shards_info)?;
-
-        // find out the actual collation session start round from master state
-        let current_session_seqno = mc_data.validator_info.catchain_seqno;
-
-        // we need full validators set to define the subset for each session and to check if current node should collate
-        let full_validators_set = mc_data.config.get_current_validator_set()?;
-        tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
-            "full_validators_set: since={}, until={}, main={}, total_weight={}, list={:?}",
-            full_validators_set.utime_since, full_validators_set.utime_until,
-            full_validators_set.main, full_validators_set.total_weight,
-            DebugIter(full_validators_set.list.iter().map(|i| i.public_key)),
-        );
-        let collation_config = mc_data.config.get_collation_config()?;
-        let mut subset_cache = FastHashMap::new();
-        let mut get_validator_subset = |shard_id| match subset_cache.entry(shard_id) {
-            hash_map::Entry::Occupied(entry) => {
-                let (subset, hash_short): &(Arc<FastHashMap<[u8; 32], ValidatorDescription>>, u32) =
-                    entry.get();
-                Result::<_>::Ok((subset.clone(), *hash_short))
-            }
-            hash_map::Entry::Vacant(entry) => {
-                let (subset, hash_short) = full_validators_set
-                    .compute_mc_subset(current_session_seqno, collation_config.shuffle_mc_validators)
-                    .ok_or_else(|| anyhow!(
-                        "Error calculating subset of validators for session (shard_id = {}, seqno = {})",
-                        ShardIdent::MASTERCHAIN,
-                        current_session_seqno,
-                    ))?;
-
-                let subset: FastHashMap<_, _> = subset
-                    .into_iter()
-                    .map(|vldr| (vldr.public_key.into(), vldr))
-                    .collect();
-                let subset = Arc::new(subset);
-
-                entry.insert((subset.clone(), hash_short));
-                Ok((subset, hash_short))
-            }
-        };
-
-        // detect sessions and collators to start and to finish
-        let mut sessions_to_keep = Vec::new();
-        let mut sessions_to_start = Vec::new();
-        let mut to_finish_sessions = Vec::new();
-        let mut to_stop_collators = Vec::new();
-        {
-            let mut active_collation_sessions_guard = self.active_collation_sessions.write();
-            let mut missed_shards_ids: FastHashSet<_> =
-                active_collation_sessions_guard.keys().cloned().collect();
-            for (shard_id, block_ids) in new_shards_info {
-                missed_shards_ids.remove(&shard_id);
-
-                // check if current node is in subset
-                let (subset, hash_short) = get_validator_subset(shard_id)?;
-                let local_pubkey = find_us_in_collators_set(&self.keypair, &subset);
-
-                if local_pubkey.is_none() {
-                    tracing::debug!(
-                        target: tracing_targets::COLLATION_MANAGER,
-                        public_key = %self.keypair.public_key,
-                        current_session_seqno,
-                        hash_short,
-                        "Current node was not authorized to collate shard {}. Use TRACE to see subset",
-                        shard_id,
-                    );
-                    tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
-                        subset = ?DebugIter(subset.values()),
-                        "Current node was not authorized to collate shard {}",
-                        shard_id,
-                    );
-                    metrics::gauge!("tycho_node_in_current_vset").set(0);
-                } else {
-                    metrics::gauge!("tycho_node_in_current_vset").set(1);
-                }
-
-                match active_collation_sessions_guard.entry(shard_id) {
-                    hash_map::Entry::Occupied(entry) => {
-                        let existing_session_info = entry.get().clone();
-                        if local_pubkey.is_some() {
-                            // start new session when seqno changed or subset changed for the same seqno
-                            if existing_session_info.collators().short_hash == hash_short
-                                && existing_session_info.seqno() == current_session_seqno
-                            {
-                                sessions_to_keep.push((shard_id, existing_session_info, block_ids));
-                            } else {
-                                to_finish_sessions.push(entry.remove());
-                                sessions_to_start.push((shard_id, block_ids));
-                            }
-                        } else {
-                            to_finish_sessions.push(entry.remove());
-                            if let Some((_, collator)) = self.active_collators.remove(&shard_id) {
-                                to_stop_collators.push((existing_session_info, collator));
-                            }
-                        }
-                    }
-                    hash_map::Entry::Vacant(_) => {
-                        if local_pubkey.is_some() {
-                            sessions_to_start.push((shard_id, block_ids));
-                        }
-                    }
-                }
-            }
-
-            // if we still have some active sessions that do not match with new shards and validator subset
-            // then we need to finish them and stop their collators
-            for shard_id in missed_shards_ids {
-                if let Some(existing_session_info) =
-                    active_collation_sessions_guard.remove(&shard_id)
-                {
-                    to_finish_sessions.push(existing_session_info.clone());
-                    if let Some((_, collator)) = self.active_collators.remove(&shard_id) {
-                        to_stop_collators.push((existing_session_info, collator));
-                    }
-                }
-            }
-        }
-
-        if !sessions_to_start.is_empty() {
-            tracing::info!(
-                target: tracing_targets::COLLATION_MANAGER,
-                "Will start new collation sessions: {:?}",
-                DebugIter(sessions_to_start.iter().map(|(s, _)| (s, current_session_seqno))),
-            );
-        }
-
-        // we may have sessions to finish, collators to stop, and sessions to start,
-        // and we start missing collators for new sessions
-        for (shard_id, prev_blocks_ids) in sessions_to_start {
-            let (subset, hash_short) = get_validator_subset(shard_id)?;
-
-            let new_session_info = Arc::new(CollationSessionInfo::new(
-                shard_id,
-                current_session_seqno,
-                ValidatorSubsetInfo {
-                    validators: subset.values().cloned().collect(),
-                    short_hash: hash_short,
-                },
-                Some(self.keypair.clone()),
-            ));
-
-            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                "new_session_info: {:?}",
-                new_session_info,
-            );
-
-            let next_block_id_short = calc_next_block_id_short(&prev_blocks_ids);
-
-            match self.active_collators.entry(shard_id) {
-                DashMapEntry::Occupied(_) => {
-                    tracing::info!(
-                        target: tracing_targets::COLLATION_MANAGER,
-                        "Active collator exists for collation session {:?}. Will resume it",
-                        new_session_info.id(),
-                    );
-                    sessions_to_keep.push((shard_id, new_session_info.clone(), prev_blocks_ids));
-                }
-                DashMapEntry::Vacant(entry) => {
-                    tracing::info!(
-                        target: tracing_targets::COLLATION_MANAGER,
-                        "There is no active collator for collation session {:?}. Will start it",
-                        new_session_info.id(),
-                    );
-
-                    let cancel_collation_notify = Arc::new(Notify::new());
-
-                    match self
-                        .collator_factory
-                        .create(CollatorContext {
-                            mq_adapter: self.mq_adapter.clone(),
-                            mpool_adapter: self.mpool_adapter.clone(),
-                            state_node_adapter: self.state_node_adapter.clone(),
-                            config: self.config.clone(),
-                            collation_session: new_session_info.clone(),
-                            zerostate_id: *self.state_node_adapter.zerostate_id(),
-                            shard_id,
-                            prev_blocks_ids: prev_blocks_ids.clone(),
-                            mempool_config_override: self.mempool_config_override.clone(),
-                            cancel_collation: cancel_collation_notify.clone(),
-                        })
-                        .await
-                    {
-                        Err(err) => {
-                            tracing::error!(target: tracing_targets::COLLATION_MANAGER,
-                                session_id = ?new_session_info.id(),
-                                ?err,
-                                "error creating collator"
-                            );
-                            // return error to stop node
-                            return Err(err);
-                        }
-                        Ok(collator) => {
-                            let collator = Box::new(collator);
-
-                            // init collator
-                            let collator =
-                                if let ProcessMcStateUpdateMode::StartCollation { .. } = mode {
-                                    let init_collator_task = JoinTask::new(
-                                        collator.init(prev_blocks_ids, mc_data.clone()),
-                                    );
-                                    collator_tasks.push(init_collator_task);
-                                    None
-                                } else {
-                                    Some(collator)
-                                };
-
-                            entry.insert(ActiveCollator {
-                                state: if collator.is_none() {
-                                    CollatorState::Active
-                                } else {
-                                    CollatorState::Waiting
-                                },
-                                collator,
-                                cancel_collation: cancel_collation_notify,
-                            });
-                        }
-                    }
-                }
-            }
-
-            // need to add validation session only for masterchain blocks, shard blocks are not being validated
-            if shard_id.is_masterchain() {
-                self.validator.add_session(AddSession {
-                    shard_ident: shard_id,
-                    session_id: new_session_info.get_validation_session_id(),
-                    start_block_seqno: next_block_id_short.seqno,
-                    validators: &new_session_info.collators().validators,
-                })?;
-            }
-
-            self.active_collation_sessions
-                .write()
-                .insert(shard_id, new_session_info);
-        }
-
-        tracing::debug!(
-            target: tracing_targets::COLLATION_MANAGER,
-            "Will keep existing collation sessions: {:?}",
-            DebugIter(sessions_to_keep.iter().map(|(_, s, _)| s.id())),
-        );
-
-        // update master state in existing collators and resume collation
-        for (shard_id, new_session_info, prev_blocks_ids) in sessions_to_keep {
-            if let ProcessMcStateUpdateMode::StartCollation { reset_collators } = mode {
-                let collator = self
-                    .take_collator_and_set_state_if(
-                        &shard_id,
-                        |_| true,
-                        |ac| ac.state = CollatorState::Active,
-                    )
-                    .with_context(|| {
-                        format!(
-                            "Collator for shard should exist for active session {:?}",
-                            new_session_info.id()
-                        )
-                    })?
-                    .context("an empty check should pass")?;
-                tracing::debug!(
-                    target: tracing_targets::COLLATION_MANAGER,
-                    "Resuming collation attempts in shard session {:?}",
-                    new_session_info.id(),
-                );
-                // resume collation
-                let resume_collation_task = JoinTask::new(collator.resume_collation(
-                    mc_data.clone(),
-                    reset_collators,
-                    new_session_info,
-                    prev_blocks_ids,
-                ));
-                collator_tasks.push(resume_collation_task);
-            } else {
-                // just reset collator state
-                self.set_collator_state(&shard_id, |ac| ac.state = CollatorState::Waiting);
-            }
-        }
-
-        // finish outdated collation sessions
-        if !to_finish_sessions.is_empty() {
-            tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                "Will finish outdated collation sessions: {:?}",
-                DebugIter(to_finish_sessions.iter().map(|s| s.id())),
-            );
-        }
-
-        // stop dangling collators
-        if !to_stop_collators.is_empty() {
-            tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                "Will stop collators for sessions that we do not serve: {:?}",
-                DebugIter(to_stop_collators.iter().map(|(s, _)| s.id())),
-            );
-        }
-
-        Ok(collator_tasks)
-
-        // finally we will have initialized `active_collation_sessions`
-        // and `active_collators` which run async block collations processes
-    }
-
-    fn apply_split_merge_actions(
-        &self,
-        new_shards_info: &FastHashMap<ShardIdent, Vec<BlockId>>,
-    ) -> Result<()> {
-        let active_shards_ids: Vec<_> = self
-            .active_collation_sessions
-            .read()
-            .keys()
-            .cloned()
-            .collect();
-        let new_shards_ids: Vec<&ShardIdent> = new_shards_info.keys().collect();
-
-        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-            "Detecting split/merge actions to move from current shards {:?} to new shards {:?}...",
-            active_shards_ids.as_slice(),
-            new_shards_ids.as_slice(),
-        );
-
-        let split_merge_actions = calc_split_merge_actions(&active_shards_ids, new_shards_ids)?;
-        if !split_merge_actions.is_empty() {
-            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                "Detected split/merge actions: {:?}",
-                split_merge_actions,
-            );
-        }
-
-        Ok(())
-    }
-
-    fn set_active_sync_info(&self, target_mc_block_seqno: BlockSeqno) -> Result<CancellationToken> {
-        let mut guard = self.collation_sync_state.lock();
-        if let Some(active_sync) = &guard.active_sync_to_applied {
-            bail!(
-                "previous sync_to_applied_mc_block should be finished \
-                before: previous seqno={}, target seqno={}",
-                active_sync.target_mc_block_seqno,
-                target_mc_block_seqno,
-            )
-        }
-
-        let cancelled = CancellationToken::new();
-        guard.active_sync_to_applied = Some(ActiveSync {
-            target_mc_block_seqno,
-            cancelled: cancelled.clone(),
-        });
-
-        Ok(cancelled)
-    }
-
-    fn clean_active_sync_info(&self) {
-        let mut guard = self.collation_sync_state.lock();
-        guard.active_sync_to_applied = None;
-    }
-
-    fn update_last_received_mc_block_seqno(&self, received_block_id: &BlockId) {
-        if !received_block_id.is_masterchain() {
-            return;
-        }
-
-        let mut guard = self.collation_sync_state.lock();
-        guard.last_received_mc_block_seqno = Some(received_block_id.seqno);
-    }
-
-    fn get_last_received_mc_block_seqno(&self) -> Option<BlockSeqno> {
-        let guard = self.collation_sync_state.lock();
-        guard.last_received_mc_block_seqno
-    }
-
-    fn has_newer_received_mc_block(&self, applied_range: Option<(u32, u32)>) -> bool {
-        if let Some((_, applied_range_end)) = applied_range {
-            let last_received_mc_block_seqno = self.get_last_received_mc_block_seqno();
-            if matches!(
-                last_received_mc_block_seqno,
-                Some(last_received_seqno) if last_received_seqno.saturating_sub(applied_range_end) > 1
-            ) {
-                tracing::info!(target: tracing_targets::COLLATION_MANAGER,
-                    last_received_mc_block_seqno,
-                    applied_range_end,
-                    "check_should_sync: should not sync to last applied mc block \
-                    because a newer one already received",
-                );
-
-                return true;
-            }
-        }
-        false
-    }
-
-    fn update_last_synced_to_mc_block_id(&self, mc_block_id: BlockId) {
-        let mut guard = self.collation_sync_state.lock();
-        guard.last_synced_to_mc_block_id = Some(mc_block_id);
-    }
-
-    fn get_last_synced_to_mc_block_id(&self) -> Option<BlockId> {
-        let guard = self.collation_sync_state.lock();
-        guard.last_synced_to_mc_block_id
-    }
-
-    /// Returns `true` if active sync was cancelled
-    fn finish_active_sync_to_applied(&self, received_block_id: &BlockId) -> bool {
-        // can finish active sync only if new master block received
-        if !received_block_id.is_masterchain() {
-            return false;
-        }
-
-        let guard = self.collation_sync_state.lock();
-
-        // call to finish active sync if it exists and received block is newer
-        if let Some(active_sync_info) = &guard.active_sync_to_applied {
-            // call to finish active sync if new block is far ahead
-            if received_block_id
-                .seqno
-                .saturating_sub(active_sync_info.target_mc_block_seqno)
-                >= self.config.min_mc_block_delta_from_bc_to_sync
-            {
-                tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                    prev_target_block_id = %BlockIdShort {
-                        shard: ShardIdent::MASTERCHAIN,
-                        seqno: active_sync_info.target_mc_block_seqno,
-                    },
-                    "cancel sync: will force finish previous sync \
-                    to applied master block if not started to process state update",
-                );
-                active_sync_info.cancelled.cancel();
-                return true;
-            } else {
-                // otherwise allow to handle newer block from bc when previous process started
-                tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
-                    prev_target_block_id = %BlockIdShort {
-                        shard: ShardIdent::MASTERCHAIN,
-                        seqno: active_sync_info.target_mc_block_seqno,
-                    },
-                    "cancel sync: will not force finish previous sync \
-                    to applied master block, because new block is not far ahead",
-                );
-            }
-        } else {
-            tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
-                "cancel sync: route_handle_block_from_bc: no active sync to cancel",
-            );
-        }
-
-        false
-    }
-
     /// Set master block latest chain time to calc next interval for master block collation.
     /// Prune all cached chain times for all shards upto current
     fn renew_mc_block_latest_chain_time(guard: &mut CollationSyncState, chain_time: u64) {
@@ -2683,18 +1059,77 @@ where
         }
     }
 
-    /// Reset collation status from `WaitForMasterStatus` to `AttemptsInProgress` for every shard.
-    ///
-    /// Use this method before resuming collation after sync to avoid ambiguous situations.
-    /// If any shard has collation status `WaitForMasterStatus` and sync was executed,
-    /// when master collation check was finished first then it will run one more resume for shard,
-    /// so we will have two parallel collations for shard that will cause panic further.
-    fn reset_collation_sync_status(guard: &mut CollationSyncState) {
-        for (_, collation_state) in guard.states.iter_mut() {
-            if collation_state.status == CollationStatus::WaitForMasterStatus {
-                collation_state.status = CollationStatus::AttemptsInProgress;
+    /// 1. Check if should collate master
+    /// 2. And run master block collation
+    /// 3. Or run next collation attempt in current shard
+    async fn run_next_collation_step(
+        &self,
+        prev_mc_block_id: &BlockId,
+        shard_id: ShardIdent,
+        trigger_shard_block_id_opt: Option<BlockId>,
+        ctx: DetectNextCollationStepContext,
+    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
+        let next_step = Self::detect_next_collation_step(
+            &mut self.collation_sync_state.lock(),
+            self.active_collation_sessions
+                .read()
+                .keys()
+                .cloned()
+                .collect(),
+            shard_id,
+            ctx,
+        );
+
+        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+            next_step = ?next_step,
+            "detected next collation step",
+        );
+
+        let mut collator_tasks = vec![];
+
+        match next_step {
+            NextCollationStep::CollateMaster(next_mc_block_chain_time) => {
+                if !shard_id.is_masterchain() {
+                    // shard collator will wait and master collator will work
+                    self.set_collator_state(&shard_id, |ac| ac.state = CollatorState::Waiting);
+                }
+
+                if let Some(task) = self
+                    .run_mc_block_collation(
+                        prev_mc_block_id.get_next_id_short(),
+                        next_mc_block_chain_time,
+                        trigger_shard_block_id_opt,
+                    )
+                    .await?
+                {
+                    collator_tasks.push(task);
+                }
+            }
+            NextCollationStep::WaitForMasterStatus | NextCollationStep::WaitForShardStatus => {
+                // current shard collator will wait
+                self.set_collator_state(&shard_id, |ac| ac.state = CollatorState::Waiting);
+            }
+            NextCollationStep::ResumeAttemptsIn(shards_to_resume_attempts) => {
+                // if should not collate master block
+                // then continue collation by running `try_collate` that will
+                // - in masterchain: just import next anchor
+                // - in workchain: run next attempt to collate shard block
+                let mut current_shard_should_wait = true;
+                for shard_ident in shards_to_resume_attempts {
+                    if shard_ident == shard_id {
+                        current_shard_should_wait = false;
+                    }
+                    if let Some(task) = self.run_try_collate(&shard_ident).await? {
+                        collator_tasks.push(task);
+                    }
+                }
+                if current_shard_should_wait {
+                    self.set_collator_state(&shard_id, |ac| ac.state = CollatorState::Waiting);
+                }
             }
         }
+
+        Ok(collator_tasks)
     }
 
     /// 1. Store collation status for current shard
@@ -3214,232 +1649,6 @@ where
 
         Ok(collator_tasks)
     }
-
-    /// Try to commit validated and valid master block
-    /// if it was not already committed before
-    /// 1. Check if master block is valid
-    /// 2. Extract master block subgraph with shard blocks
-    /// 3. Send to sync
-    /// 4. Commit queue diff
-    /// 5. Clean up from cache
-    /// 6. Process delayed master state update if exists
-    /// 7. Notify top processed anchor to mempool if block commited by received from bc
-    async fn commit_valid_master_block(
-        &self,
-        mc_block_id: &BlockId,
-        skip_process_delayed_mc_state_update: bool,
-    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
-        tracing::debug!(
-            target: tracing_targets::COLLATION_MANAGER,
-            "Start to commit validated and valid master block ({})...",
-            mc_block_id.as_short_id(),
-        );
-
-        // gc blocks from cache when commit finished
-        scopeguard::defer!(self.blocks_cache.gc_prev_blocks());
-
-        // we can process delayed master state update now
-        let (mut top_processed_to_anchor_to_notify, collator_tasks) = self
-            .notify_to_mempool_and_process_delayed_mc_state_update(
-                mc_block_id,
-                skip_process_delayed_mc_state_update,
-            )
-            .await?
-            .unzip();
-
-        let histogram = HistogramGuard::begin("tycho_collator_commit_valid_master_block_time");
-        let histogram_extract =
-            HistogramGuard::begin("tycho_collator_extract_master_block_subgraph_time");
-        let mut extract_elapsed = Default::default();
-        let mut sync_elapsed = Default::default();
-
-        // extract master block with all shard blocks if valid, and process them
-        match self
-            .blocks_cache
-            .extract_mc_block_subgraph_for_sync(mc_block_id)
-        {
-            McBlockSubgraphExtract::Extracted(subgraph) => {
-                extract_elapsed = histogram_extract.finish();
-
-                let partitions = subgraph.get_partitions();
-
-                let McBlockSubgraph {
-                    master_block,
-                    shard_blocks,
-                } = subgraph;
-
-                // we can gc upto to current master block after commit
-                // because we do not need to commit all previous blocks
-                // because all previous blocks are already in bc state
-                // and all previous diffs already committed by current one
-                let to_blocks_keys = master_block.get_top_blocks_keys()?;
-                self.blocks_cache.set_gc_to_boundary(&to_blocks_keys);
-
-                // send to sync only if was not received from bc
-                if matches!(&master_block.data, BlockCacheEntryData::Collated {
-                    received_after_collation: false,
-                    ..
-                }) {
-                    let histogram =
-                        HistogramGuard::begin("tycho_collator_send_blocks_to_sync_time");
-
-                    self.send_block_to_sync(master_block.data)?;
-
-                    for shard_block in shard_blocks {
-                        self.send_block_to_sync(shard_block.data)?;
-                    }
-
-                    sync_elapsed = histogram.finish();
-                    tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                        total = sync_elapsed.as_millis(),
-                        "send_blocks_to_sync timings",
-                    );
-
-                    // if current master block was not applied to bc state yet
-                    // then we should not notify top processed to anchor to mempool now
-                    // because we are not sure that block will be applied
-                    // and should wait until block_accepted event is received
-                    top_processed_to_anchor_to_notify = None;
-                } else {
-                    // if current block was committed by received one
-                    // then `on_block_accepted` will not be called further
-                    // so we need to notify `top_processed_to_anchor` to mempool here
-                    top_processed_to_anchor_to_notify = master_block.top_processed_to_anchor;
-                }
-
-                let _histogram =
-                    HistogramGuard::begin("tycho_collator_send_blocks_to_sync_commit_diffs_time");
-
-                Self::commit_block_queue_diff(
-                    self.mq_adapter.clone(),
-                    &master_block.block_id,
-                    &master_block.top_shard_blocks_info,
-                    &partitions,
-                )?;
-            }
-            McBlockSubgraphExtract::AlreadyExtracted => {
-                tracing::debug!(
-                    target: tracing_targets::COLLATION_MANAGER,
-                    "Master block subgraph is already extracted and cleaned up from cache ({}). Do nothing",
-                    mc_block_id.as_short_id(),
-                );
-            }
-        }
-
-        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-            total = histogram.finish().as_millis(),
-            extract_subgraph = extract_elapsed.as_millis(),
-            sync = sync_elapsed.as_millis(),
-            "commit_valid_master_block timings",
-        );
-
-        // report last processed anchor to mempool
-        if let Some(top_processed_to_anchor) = top_processed_to_anchor_to_notify {
-            self.notify_top_processed_to_anchor_to_mempool(
-                mc_block_id.seqno,
-                top_processed_to_anchor,
-            )
-            .await?;
-        }
-
-        Ok(collator_tasks.unwrap_or_default())
-    }
-
-    fn send_block_to_sync(&self, data: BlockCacheEntryData) -> Result<()> {
-        let candidate_stuff = match data {
-            BlockCacheEntryData::Collated {
-                candidate_stuff,
-                status,
-                received_after_collation: false,
-                ..
-            } if status != CandidateStatus::Synced => candidate_stuff,
-            _ => return Ok(()),
-        };
-
-        let block_id = *candidate_stuff.candidate.block.id();
-        self.state_node_adapter
-            .accept_block(candidate_stuff.into_block_for_sync())?;
-        tracing::debug!(
-            target: tracing_targets::COLLATION_MANAGER,
-            "Block was successfully sent to sync ({})",
-            block_id,
-        );
-        Ok(())
-    }
-
-    /// Collect top blocks seqno from all shards by master block id. Master block seqno included.
-    /// Returns None when unable to read related top shard blocks info.
-    async fn get_top_blocks_seqno(
-        mc_block_id: &BlockId,
-        blocks_cache: &BlocksCache,
-        state_node_adapter: Arc<dyn StateNodeAdapter>,
-    ) -> Result<Option<FastHashMap<ShardIdent, BlockSeqno>>> {
-        let mut result = FastHashMap::default();
-
-        result.insert(mc_block_id.shard, mc_block_id.seqno);
-
-        // try get top shard blocks from cache first
-        if let Some(top_shard_blocks) = blocks_cache.get_top_shard_blocks(mc_block_id.as_short_id())
-        {
-            result.extend(top_shard_blocks);
-            return Ok(Some(result));
-        }
-
-        // then try read from state
-        match state_node_adapter
-            .load_state(mc_block_id.seqno, mc_block_id, Default::default())
-            .await
-        {
-            Err(err) => match err.downcast_ref::<StateNotFound>() {
-                Some(_) => {
-                    tracing::warn!(target: tracing_targets::COLLATION_MANAGER,
-                        %mc_block_id,
-                        "master state not found in get_top_blocks_seqno",
-                    );
-                }
-                _ => {
-                    tracing::warn!(target: tracing_targets::COLLATION_MANAGER,
-                        ?err,
-                        "error loading master state in get_top_blocks_seqno",
-                    );
-                }
-            },
-            Ok(state) => {
-                for item in state.shards()?.latest_blocks() {
-                    let top_sb = item?;
-                    result.insert(top_sb.shard, top_sb.seqno);
-                }
-                return Ok(Some(result));
-            }
-        }
-
-        // finally try read from block data
-        match state_node_adapter.load_block(mc_block_id).await {
-            Err(err) => {
-                tracing::warn!(target: tracing_targets::COLLATION_MANAGER,
-                    %mc_block_id,
-                    ?err,
-                    "error loading master block in get_top_blocks_seqno",
-                );
-            }
-            Ok(None) => {
-                tracing::warn!(target: tracing_targets::COLLATION_MANAGER,
-                    %mc_block_id,
-                    "master block was not found in get_top_blocks_seqno",
-                );
-            }
-            Ok(Some(mc_block_stuff)) => {
-                let top_blocks = TopBlocks::from_mc_block(&mc_block_stuff)?;
-                for top_sb in top_blocks.shard_heights().iter() {
-                    result.insert(top_sb.shard, top_sb.seqno);
-                }
-                return Ok(Some(result));
-            }
-        }
-
-        // unable to load related shard blocks info, return None
-        Ok(None)
-    }
 }
 
 struct HandleTaskResult<C: Collator> {
@@ -3474,37 +1683,6 @@ impl<C: Collator> HandleTaskResult<C> {
             collator_tasks: vec![],
             cancel_action: Some(cancel_action),
         }
-    }
-}
-
-#[derive(Debug, Clone)]
-enum ProcessMcStateUpdateMode {
-    StartCollation { reset_collators: bool },
-    RefreshSessionsOnly,
-    SkipProcess,
-}
-
-#[derive(Default)]
-struct RestoreQueueResult {
-    last_mc_state: Option<ShardStateStuff>,
-    prev_mc_state: Option<ShardStateStuff>,
-    prev_mc_block_id: Option<BlockId>,
-    synced_to_blocks_keys: Vec<BlockCacheKey>,
-    applied_diffs_ids: FastHashSet<BlockId>,
-}
-
-// TODO: Move into `tycho_types`.
-trait GlobalCapabilitiesExt {
-    /// Checks whether this capabilities set is fully
-    /// included into `other` (comparing raw bits to include unnamed variants).
-    fn is_subset_of(&self, other: GlobalCapabilities) -> bool;
-}
-
-impl GlobalCapabilitiesExt for GlobalCapabilities {
-    fn is_subset_of(&self, other: GlobalCapabilities) -> bool {
-        let this = self.into_inner();
-        let other = other.into_inner();
-        this & !other == 0
     }
 }
 

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -48,8 +48,8 @@ use crate::types::processed_upto::{
     BlockSeqno, ProcessedUptoInfoExtension, ProcessedUptoInfoStuff, find_min_processed_to_by_shards,
 };
 use crate::types::{
-    BlockCollationResult, BlockIdExt, CollationSessionInfo, CollatorConfig, DebugIter,
-    DisplayAsShortId, DisplayBlockIdsIntoIter, McData, ProcessedToByPartitions,
+    BlockCollationResult, BlockIdExt, CollationSessionInfo, CollatorConfig, DebugDisplayOpt,
+    DebugIter, DisplayAsShortId, DisplayBlockIdsIntoIter, McData, ProcessedToByPartitions,
     ShardDescriptionShort, ShardDescriptionShortExt, ShardHashesExt, TopBlockId, TopBlockIdUpdated,
 };
 use crate::utils::block::detect_top_processed_to_anchor;
@@ -1735,8 +1735,8 @@ where
         let last_synced_to_mc_block_id = self.get_last_synced_to_mc_block_id();
 
         tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-            ?last_synced_to_mc_block_id,
-            ?last_collated_mc_block_id,
+            last_synced_to_mc_block_id = ?DebugDisplayOpt(&last_synced_to_mc_block_id),
+            last_collated_mc_block_id = ?DebugDisplayOpt(&last_collated_mc_block_id),,
         );
 
         match (last_synced_to_mc_block_id, last_collated_mc_block_id) {

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -949,6 +949,14 @@ where
                     },
                 }),
             })
+        } else if store_res.block_mismatch {
+            // only cancel all active collations
+            // when block mismatched and newer already received
+            Ok(HandleCollatorTaskResult {
+                validator_task: None,
+                collator_tasks: vec![],
+                cancel_action: Some(ActionAfterCancel::Noop),
+            })
         } else if block_id.is_masterchain() {
             // when candidate is master
 
@@ -1188,9 +1196,18 @@ where
             );
         }
 
-        // there is no any possible action with a shard block
+        // we cannot sync to applied shard block
         if !block_id.is_masterchain() {
-            return Ok(HandleBlockFromBcResult::empty());
+            if store_res.block_mismatch {
+                // should cancel all active collations when block mismatched
+                return Ok(HandleBlockFromBcResult {
+                    collator_tasks: vec![],
+                    cancel_action: Some(ActionAfterCancel::Noop),
+                });
+            } else {
+                // just do nothing otherwise
+                return Ok(HandleBlockFromBcResult::empty());
+            }
         }
 
         // check if received is a key block
@@ -1221,6 +1238,11 @@ where
                     );
                     break 'check_should_sync false;
                 }
+            }
+
+            // should sync if collated block mismatched
+            if store_res.block_mismatch {
+                break 'check_should_sync true;
             }
 
             // check if should sync
@@ -1302,7 +1324,6 @@ where
         };
 
         // run sync or commit block
-        let mut collator_tasks = vec![];
         if should_sync_to_last_applied_mc_block {
             // should only refresh collation sessions when sync on key block
             let process_state_update_mode = if is_last_mc_block_in_batch {
@@ -1313,16 +1334,25 @@ where
                 ProcessMcStateUpdateMode::RefreshSessionsOnly
             };
             // will cancel active collations and then run sync
-            return Ok(HandleBlockFromBcResult {
-                collator_tasks,
+            Ok(HandleBlockFromBcResult {
+                collator_tasks: vec![],
                 cancel_action: Some(ActionAfterCancel::SyncToAppliedMcBlock {
                     trigger_block_id_short: block_id.as_short_id(),
                     last_collated_mc_block_id: store_res.last_collated_mc_block_id,
                     applied_range: store_res.applied_mc_queue_range,
                     process_state_update_mode,
                 }),
-            });
+            })
+        } else if store_res.block_mismatch {
+            // only cancel all active collations
+            // when block mismatched and should not sync by any reason
+            Ok(HandleBlockFromBcResult {
+                collator_tasks: vec![],
+                cancel_action: Some(ActionAfterCancel::Noop),
+            })
         } else {
+            let mut collator_tasks = vec![];
+
             // try to commit block if it was collated first
             if store_res.received_and_collated {
                 // NOTE: here commit will not cause on_block_accepted event
@@ -1330,12 +1360,12 @@ where
 
                 collator_tasks = self.commit_valid_master_block(&block_id, false).await?;
             }
-        }
 
-        Ok(HandleBlockFromBcResult {
-            collator_tasks,
-            cancel_action: None,
-        })
+            Ok(HandleBlockFromBcResult {
+                collator_tasks,
+                cancel_action: None,
+            })
+        }
     }
 
     #[tracing::instrument(name = "sync_to_applied_mc_block", skip_all, fields(trigger_block_id = %trigger_block_id_short, applied_range = ?applied_range))]

--- a/collator/src/manager/msgs_queue.rs
+++ b/collator/src/manager/msgs_queue.rs
@@ -1,0 +1,527 @@
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::Arc;
+
+use ahash::HashMapExt;
+use anyhow::{Context, Result, bail};
+use tycho_block_util::queue::{QueueKey, QueuePartitionIdx};
+use tycho_block_util::state::ShardStateStuff;
+use tycho_core::storage::LoadStateHint;
+use tycho_types::models::{BlockId, ShardIdent};
+use tycho_util::metrics::HistogramGuard;
+use tycho_util::{FastHashMap, FastHashSet};
+
+use super::CollationManager;
+use super::blocks_cache::BlocksCache;
+use super::types::{BlockCacheEntry, BlockCacheEntryData, BlockCacheKey, McBlockSubgraphExtract};
+use crate::collator::CollatorFactory;
+use crate::internal_queue::types::diff::{DiffZone, QueueDiffWithMessages};
+use crate::internal_queue::types::message::EnqueuedMessage;
+use crate::internal_queue::types::stats::DiffStatistics;
+use crate::queue_adapter::MessageQueueAdapter;
+use crate::state_node::StateNodeAdapter;
+use crate::tracing_targets;
+use crate::types::processed_upto::ProcessedUptoInfoStuff;
+use crate::types::{ProcessedToByPartitions, TopBlockId, TopBlockIdUpdated};
+use crate::validator::Validator;
+
+impl<CF, V> CollationManager<CF, V>
+where
+    CF: CollatorFactory,
+    V: Validator,
+{
+    pub(super) fn clear_uncommitted_queue_state(&self) -> Result<()> {
+        Self::clear_uncommitted_queue_state_impl(&self.blocks_cache, &self.mq_adapter)
+    }
+
+    fn clear_uncommitted_queue_state_impl(
+        blocks_cache: &BlocksCache,
+        mq_adapter: &Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
+    ) -> Result<()> {
+        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+            "clear uncommitted queue state",
+        );
+
+        let top_shards = blocks_cache.get_last_top_shards();
+        mq_adapter.clear_uncommitted_state(&top_shards)
+    }
+
+    pub(super) async fn get_all_shards_processed_to_by_partitions_for_mc_block(
+        mc_block_key: &BlockCacheKey,
+        blocks_cache: &BlocksCache,
+        state_node_adapter: Arc<dyn StateNodeAdapter>,
+    ) -> Result<FastHashMap<ShardIdent, (bool, ProcessedToByPartitions)>> {
+        let mut result = FastHashMap::default();
+
+        let zerostate_mc_seqno = blocks_cache.zerostate_mc_seqno();
+        if mc_block_key.seqno <= zerostate_mc_seqno {
+            return Ok(result);
+        }
+
+        let from_cache = blocks_cache.get_top_blocks_processed_to_by_partitions(mc_block_key)?;
+
+        for (top_block_id, item) in from_cache {
+            let processed_to = match item.by {
+                Some(processed_to) => processed_to,
+                None => {
+                    if item.ref_by_mc_seqno <= zerostate_mc_seqno {
+                        FastHashMap::default()
+                    } else {
+                        // get from state
+                        let state = state_node_adapter
+                            .load_state(mc_block_key.seqno, &top_block_id, LoadStateHint {
+                                // State must already be applied at this point.
+                                allow_ignore_direct: false,
+                            })
+                            .await?;
+                        let processed_upto = state.state().processed_upto.load()?;
+                        let processed_upto = ProcessedUptoInfoStuff::try_from(processed_upto)?;
+                        processed_upto.get_internals_processed_to_by_partitions()
+                    }
+                }
+            };
+
+            result.insert(top_block_id.shard, (item.updated, processed_to));
+        }
+
+        Ok(result)
+    }
+
+    // Returns top master block id upto which all queue diffs applied
+    pub(super) fn get_queue_diffs_applied_to_mc_block_id(
+        &self,
+        last_collated_mc_block_id: Option<BlockId>,
+    ) -> Result<Option<BlockId>> {
+        let last_queue_comitted_on = self.mq_adapter.get_last_committed_mc_block_id()?;
+        let last_collated_or_synced_to =
+            self.get_top_mc_block_id_for_next_collation(last_collated_mc_block_id);
+
+        let mc_block_id = match (last_queue_comitted_on, last_collated_or_synced_to) {
+            (Some(last_queue_comitted_on), Some(last_collated_or_synced_to)) => {
+                // return last collated if it exists (or last "synced to")
+                // if above mc block on which the queue was committed
+                if last_collated_or_synced_to.seqno >= last_queue_comitted_on.seqno {
+                    Some(last_collated_or_synced_to)
+                } else {
+                    Some(last_queue_comitted_on)
+                }
+            }
+            (Some(mc_block_id), _) | (_, Some(mc_block_id)) => Some(mc_block_id),
+            _ => None,
+        };
+
+        Ok(mc_block_id)
+    }
+
+    #[tracing::instrument(skip_all, fields(from_mc_block_seqno))]
+    pub(super) async fn restore_queue(
+        blocks_cache: &BlocksCache,
+        state_node_adapter: Arc<dyn StateNodeAdapter>,
+        mq_adapter: Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
+        from_mc_block_seqno: u32,
+        min_processed_to_by_shards: BTreeMap<ShardIdent, QueueKey>,
+        before_tail_block_ids: BTreeMap<ShardIdent, (Option<BlockId>, Vec<BlockId>)>,
+        queue_diffs_applied_to_top_blocks: FastHashMap<ShardIdent, u32>,
+    ) -> Result<RestoreQueueResult> {
+        let mut res = RestoreQueueResult::default();
+
+        // load init block (from persistent state) to check if required diff was already applied from persistent
+        let init_mc_block_id = state_node_adapter.load_init_block_id();
+        let mut init_mc_block_reached_on = FastHashMap::new();
+
+        // try load required previous queue diffs
+        let mut first_required_diffs = FastHashMap::new();
+        for (shard_id, min_processed_to) in &min_processed_to_by_shards {
+            let mut prev_queue_diffs = vec![];
+            let Some((_, prev_block_ids)) = before_tail_block_ids.get(shard_id) else {
+                continue;
+            };
+            let mut prev_block_ids: VecDeque<_> = prev_block_ids.iter().cloned().collect();
+
+            while let Some(prev_block_id) = prev_block_ids.pop_front() {
+                // NOTE: We don't skip prev block ids for shard zerostates because
+                // it is quite hard to propagate `ref_by_mc_seqno` here (we construct
+                // prev ids based just on `BlockId` here). There seems to be no problems
+                // with that because we are checking `init_mc_block_reached` using
+                // the handle data so zerostate ids will be skipped in any case.
+                // This check is just to not change the old behavior just in case.
+                if prev_block_id.seqno == 0
+                    || prev_block_id.is_masterchain()
+                        && prev_block_id.seqno <= state_node_adapter.zerostate_id().seqno
+                {
+                    continue;
+                }
+
+                // if diff is below top applied then skip
+                if let Some(border) = queue_diffs_applied_to_top_blocks.get(shard_id)
+                    && prev_block_id.seqno <= *border
+                {
+                    tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                        prev_block_id = %prev_block_id.as_short_id(),
+                        top_applied_seqno = border,
+                        "previous queue diff skipped because it below top applied",
+                    );
+                    continue;
+                }
+
+                // if diff is before init block (from persistent state)
+                // we do not need to apply it because queue was already restored from persistent
+                if let Some(init_mc_block_id) = init_mc_block_id {
+                    let mut skip_diff = false;
+                    if prev_block_id.is_masterchain() {
+                        if prev_block_id.seqno <= init_mc_block_id.seqno {
+                            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                                prev_block_id = %prev_block_id.as_short_id(),
+                                init_mc_block_id = %init_mc_block_id.as_short_id(),
+                                "master block queue diff apply skipped because it is below init block from persistent state",
+                            );
+                            skip_diff = true;
+                        }
+                    } else {
+                        // check if we already reached init mc block before
+                        let mut init_mc_block_reached = matches!(
+                            init_mc_block_reached_on.get(&prev_block_id.shard),
+                            Some(reached_seqno) if prev_block_id.seqno <= *reached_seqno,
+                        );
+                        if !init_mc_block_reached {
+                            // for shard block we should check it's `ref_by_mc_seqno`
+                            let prev_ref_by_mc_seqno = state_node_adapter
+                                .get_ref_by_mc_seqno(&prev_block_id)
+                                .await?
+                                .unwrap();
+                            init_mc_block_reached = prev_ref_by_mc_seqno <= init_mc_block_id.seqno;
+                            if init_mc_block_reached {
+                                init_mc_block_reached_on
+                                    .insert(prev_block_id.shard, prev_block_id.seqno);
+                            }
+                        }
+                        if init_mc_block_reached {
+                            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                                prev_block_id = %prev_block_id.as_short_id(),
+                                init_mc_block_id = %init_mc_block_id.as_short_id(),
+                                "shard block queue diff apply skipped because it is below init block from persistent state",
+                            );
+                            skip_diff = true;
+                        }
+                    }
+                    if skip_diff {
+                        // if current diff is below init block
+                        // then we should check sequense for each next diff
+                        first_required_diffs.insert(prev_block_id.shard, BlockId::default());
+                        continue;
+                    }
+                }
+
+                // load diff to check if it is required
+                let Some(queue_diff_stuff) = state_node_adapter.load_diff(&prev_block_id).await?
+                else {
+                    tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                        prev_block_id = %prev_block_id,
+                        "unable to load prev diff to sync queue state, cancel sync",
+                    );
+
+                    // metrics - sync finished
+                    for shard in before_tail_block_ids.keys() {
+                        let labels = [("workchain", shard.workchain().to_string())];
+                        metrics::gauge!("tycho_collator_sync_is_running", &labels).set(0);
+                    }
+
+                    return Ok(res);
+                };
+                let diff_required = &queue_diff_stuff.as_ref().max_message > min_processed_to;
+                tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                    diff_block_id = %prev_block_id.as_short_id(),
+                    diff_required,
+                    max_message = %queue_diff_stuff.as_ref().max_message,
+                    min_processed_to = %min_processed_to,
+                    "check if diff required to restore queue working state on sync:",
+                );
+                if diff_required {
+                    // if next diff is not required
+                    // then current will be the first required
+                    first_required_diffs.insert(prev_block_id.shard, prev_block_id);
+
+                    let block_stuff = state_node_adapter
+                        .load_block(&prev_block_id)
+                        .await?
+                        .unwrap();
+                    let out_msgs = block_stuff.load_extra()?.out_msg_description.load()?;
+
+                    let queue_diff_with_messages =
+                        QueueDiffWithMessages::from_queue_diff(&queue_diff_stuff, &out_msgs)?;
+
+                    prev_queue_diffs.push((
+                        queue_diff_with_messages,
+                        *queue_diff_stuff.diff_hash(),
+                        prev_block_id,
+                        queue_diff_stuff.as_ref().min_message,
+                        queue_diff_stuff.as_ref().max_message,
+                    ));
+
+                    let prev_ids_info = block_stuff.construct_prev_id()?;
+                    prev_block_ids.push_back(prev_ids_info.0);
+                    if let Some(id) = prev_ids_info.1 {
+                        prev_block_ids.push_back(id);
+                    }
+                }
+            }
+
+            // apply required previous queue diffs for each shard
+            while let Some((diff, diff_hash, block_id, min_message, max_message)) =
+                prev_queue_diffs.pop()
+            {
+                let statistics =
+                    DiffStatistics::from_diff(&diff, block_id.shard, min_message, max_message);
+
+                // we can skip the sequense check for the first required diff only
+                let check_sequence = match first_required_diffs.get(&block_id.shard) {
+                    Some(id) if *id == block_id => None,
+                    _ => Some(DiffZone::Both),
+                };
+
+                mq_adapter
+                    .apply_diff(
+                        diff,
+                        block_id.as_short_id(),
+                        &diff_hash,
+                        statistics,
+                        check_sequence,
+                    )
+                    .context("sync_to_applied_mc_block")?;
+
+                res.applied_diffs_ids.insert(block_id);
+            }
+        }
+
+        // will track last mc state and previous before it
+        let mut prev_mc_state = None;
+        let mut last_mc_state;
+
+        // extract all recevied blocks, apply required diffs
+        // and return latest master state
+        loop {
+            // pop first applied mc block and sync
+            // actually we can sync more mc blocks than known in applied_range
+            // because we can receive new blocks from bc during sync
+            let (mc_block_subgraph_extract, is_last) =
+                blocks_cache.pop_front_applied_mc_block_subgraph(from_mc_block_seqno)?;
+
+            let subgraph = match mc_block_subgraph_extract {
+                McBlockSubgraphExtract::Extracted(subgraph) => subgraph,
+                McBlockSubgraphExtract::AlreadyExtracted => {
+                    bail!("mc block subgraph extract result cannot be AlreadyExtracted")
+                }
+            };
+
+            let mc_block_entry = &subgraph.master_block;
+
+            // apply queue diffs from blocks above zerostate seqno
+            // skip cached diffs below min_processed_to
+            if subgraph.master_block.block_id.seqno > state_node_adapter.zerostate_id().seqno {
+                for block_entry in [mc_block_entry]
+                    .into_iter()
+                    .chain(subgraph.shard_blocks.iter())
+                {
+                    // if diff is below top applied then skip
+                    if let Some(border) =
+                        queue_diffs_applied_to_top_blocks.get(&block_entry.block_id.shard)
+                        && block_entry.block_id.seqno <= *border
+                    {
+                        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                            received_block_id = %block_entry.block_id.as_short_id(),
+                            top_applied_seqno = border,
+                            "queue diff apply skipped because it is below top applied",
+                        );
+                        continue;
+                    }
+
+                    let min_processed_to =
+                        min_processed_to_by_shards.get(&block_entry.block_id.shard);
+
+                    if let Some(applied_diff_block_id) =
+                        Self::apply_block_queue_diff_from_entry_stuff(
+                            state_node_adapter.as_ref(),
+                            mq_adapter.clone(),
+                            block_entry,
+                            min_processed_to,
+                            &mut first_required_diffs,
+                        )?
+                    {
+                        res.applied_diffs_ids.insert(applied_diff_block_id);
+                    }
+                }
+            }
+
+            // we can gc to current master block when diffs were applied
+            let to_blocks_keys = mc_block_entry.get_top_blocks_keys()?;
+            blocks_cache.set_gc_to_boundary(&to_blocks_keys);
+
+            last_mc_state = mc_block_entry.cached_state()?.clone();
+
+            // on sync finish we commit diffs
+            if is_last {
+                let partitions = subgraph.get_partitions();
+                Self::commit_block_queue_diff(
+                    mq_adapter.clone(),
+                    &mc_block_entry.block_id,
+                    &mc_block_entry.top_shard_blocks_info,
+                    &partitions,
+                )?;
+
+                // when we run sync by any reason we should drop uncommitted queue updates
+                // after restoring the required state
+                // to avoid panics if next block was already collated before an it is incorrect
+                Self::clear_uncommitted_queue_state_impl(blocks_cache, &mq_adapter)?;
+
+                res.last_mc_state = Some(last_mc_state);
+                res.prev_mc_state = prev_mc_state;
+                res.prev_mc_block_id = mc_block_entry.prev_blocks_ids.first().copied();
+                res.synced_to_blocks_keys.extend(to_blocks_keys.into_iter());
+
+                return Ok(res);
+            }
+
+            prev_mc_state = Some(last_mc_state.clone());
+        }
+    }
+
+    /// Returns `BlockId` if diff was applied.
+    /// * `first_required_diffs` - contains ids of known first required diffs for queue for each shard
+    fn apply_block_queue_diff_from_entry_stuff(
+        state_node_adapter: &dyn StateNodeAdapter,
+        mq_adapter: Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
+        block_entry: &BlockCacheEntry,
+        min_processed_to: Option<&QueueKey>,
+        first_required_diffs: &mut FastHashMap<ShardIdent, BlockId>,
+    ) -> Result<Option<BlockId>> {
+        let block_id = block_entry.block_id;
+
+        // TODO: error if <
+        if block_entry.ref_by_mc_seqno <= state_node_adapter.zerostate_id().seqno {
+            return Ok(None);
+        }
+
+        let queue_diff = match &block_entry.data {
+            BlockCacheEntryData::Collated {
+                candidate_stuff, ..
+            } => &candidate_stuff.candidate.queue_diff_aug.data,
+            BlockCacheEntryData::Received { queue_diff, .. } => queue_diff,
+        };
+
+        // skip diff below min processed to
+        if let Some(min_pt) = min_processed_to
+            && queue_diff.as_ref().max_message <= *min_pt
+        {
+            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                "Skipping diff for block {}: max_message {} <= min_processed_to {}",
+                block_id.as_short_id(),
+                queue_diff.as_ref().max_message,
+                min_pt,
+            );
+            return Ok(None);
+        }
+
+        // skip already applied diff
+        if mq_adapter.is_diff_exists(&block_id.as_short_id())? {
+            tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
+                queue_diff_block_id = %block_id.as_short_id(),
+                "queue diff apply skipped because it is already applied",
+            );
+            // if diff for block from bc already applied
+            // then we should check sequense for each next diff
+            first_required_diffs.insert(block_id.shard, BlockId::default());
+            return Ok(None);
+        }
+
+        // load out_msg
+        let out_msgs = match &block_entry.data {
+            BlockCacheEntryData::Collated {
+                candidate_stuff, ..
+            } => &candidate_stuff
+                .candidate
+                .block
+                .data
+                .load_extra()?
+                .out_msg_description
+                .load()?,
+            BlockCacheEntryData::Received { out_msgs, .. } => &out_msgs.load()?,
+        };
+
+        let queue_diff_with_msgs = QueueDiffWithMessages::from_queue_diff(queue_diff, out_msgs)?;
+
+        let statistics = DiffStatistics::from_diff(
+            &queue_diff_with_msgs,
+            queue_diff.block_id().shard,
+            queue_diff.as_ref().min_message,
+            queue_diff.as_ref().max_message,
+        );
+
+        let check_sequence = match first_required_diffs.get(&block_id.shard).copied() {
+            None => {
+                // if first required diff was not detected before
+                // we consider that current is first
+                first_required_diffs.insert(block_id.shard, block_id);
+                None
+            }
+            Some(id) if id == block_id => None,
+            _ => Some(DiffZone::Both),
+        };
+
+        mq_adapter
+            .apply_diff(
+                queue_diff_with_msgs,
+                queue_diff.block_id().as_short_id(),
+                queue_diff.diff_hash(),
+                statistics,
+                check_sequence,
+            )
+            .context("apply_block_queue_diff_from_entry_stuff")?;
+
+        Ok(Some(block_id))
+    }
+
+    #[tracing::instrument(skip_all, fields(block_id = %block_id))]
+    pub(super) fn commit_block_queue_diff(
+        mq_adapter: Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
+        block_id: &BlockId,
+        top_shard_blocks_info: &[TopBlockIdUpdated],
+        partitions: &FastHashSet<QueuePartitionIdx>,
+    ) -> Result<()> {
+        if !block_id.is_masterchain() {
+            return Ok(());
+        }
+
+        let _histogram = HistogramGuard::begin("tycho_collator_commit_queue_diffs_time");
+
+        let mut top_blocks = top_shard_blocks_info.to_vec();
+        top_blocks.push(TopBlockIdUpdated {
+            block: TopBlockId {
+                ref_by_mc_seqno: block_id.seqno,
+                block_id: *block_id,
+            },
+            updated: true,
+        });
+
+        if let Err(err) = mq_adapter.commit_diff(top_blocks, partitions) {
+            bail!(
+                "Error committing message queue diff of block ({}): {:?}",
+                block_id,
+                err,
+            )
+        }
+
+        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+            "message queue diff was committed",
+        );
+
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct RestoreQueueResult {
+    pub last_mc_state: Option<ShardStateStuff>,
+    pub prev_mc_state: Option<ShardStateStuff>,
+    pub prev_mc_block_id: Option<BlockId>,
+    pub synced_to_blocks_keys: Vec<BlockCacheKey>,
+    pub applied_diffs_ids: FastHashSet<BlockId>,
+}

--- a/collator/src/manager/state_update_handler.rs
+++ b/collator/src/manager/state_update_handler.rs
@@ -1,0 +1,575 @@
+use std::collections::hash_map;
+use std::sync::Arc;
+
+use ahash::HashMapExt;
+use anyhow::{Context, Result, anyhow};
+use tokio::sync::Notify;
+use tycho_block_util::block::{ValidatorSubsetInfo, calc_next_block_id_short};
+use tycho_types::models::{BlockId, GlobalCapabilities, ShardIdent, ValidatorDescription};
+use tycho_util::futures::JoinTask;
+use tycho_util::metrics::HistogramGuard;
+use tycho_util::{DashMapEntry, FastHashMap, FastHashSet};
+
+use super::CollationManager;
+use super::types::{ActiveCollator, CollatorJoinTask, CollatorState};
+use super::utils::find_us_in_collators_set;
+use crate::collator::{Collator, CollatorContext, CollatorFactory};
+use crate::mempool::{MempoolAnchorId, StateUpdateContext};
+use crate::tracing_targets;
+use crate::types::{CollationSessionInfo, DebugIter, McData, ShardDescriptionShortExt};
+use crate::utils::shard::calc_split_merge_actions;
+use crate::validator::{AddSession, Validator};
+
+impl<CF, V> CollationManager<CF, V>
+where
+    CF: CollatorFactory,
+    V: Validator,
+{
+    /// Returns top processed to anchor id if delayed state was processed
+    pub(super) async fn notify_to_mempool_and_process_delayed_mc_state_update(
+        &self,
+        block_id: &BlockId,
+        skip_process_delayed_mc_state_update: bool,
+    ) -> Result<Option<(MempoolAnchorId, Vec<CollatorJoinTask<CF::Collator>>)>> {
+        let mut delayed_mc_data = None;
+        {
+            let mut guard = self.delayed_mc_state_update.lock();
+            if let Some(mc_data) = guard.clone()
+                && mc_data.block_id <= *block_id
+            {
+                // process delayed mc state only if committed block is equal
+                if mc_data.block_id == *block_id {
+                    delayed_mc_data = Some(mc_data);
+                }
+
+                // remove delayed mc state even if committed block is ahead
+                *guard = None;
+            }
+        }
+        if let Some(mc_data) = delayed_mc_data {
+            self.notify_mc_state_update_to_mempool(mc_data.clone())
+                .await?;
+
+            // validation may finish when collation cancel task is running,
+            // so we should not run new collation tasks
+            let mut collator_tasks = vec![];
+            if !skip_process_delayed_mc_state_update {
+                collator_tasks = self
+                    .process_mc_state_update(
+                        mc_data.clone(),
+                        ProcessMcStateUpdateMode::StartCollation {
+                            reset_collators: false,
+                        },
+                    )
+                    .await?;
+            }
+
+            Ok(Some((mc_data.top_processed_to_anchor, collator_tasks)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub(super) async fn notify_mc_state_update_to_mempool(
+        &self,
+        mc_data: Arc<McData>,
+    ) -> Result<()> {
+        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+            block_id = %mc_data.block_id.as_short_id(),
+            "will notify master state update to mempool",
+        );
+
+        let prev_validator_set = self
+            .validator_set_cache
+            .get_prev_validator_set(&mc_data.config)?;
+        let current_validator_set = self
+            .validator_set_cache
+            .get_current_validator_set(&mc_data.config)?;
+        let next_validator_set = self
+            .validator_set_cache
+            .get_next_validator_set(&mc_data.config)?;
+
+        let cx = Box::new(StateUpdateContext {
+            mc_block_id: mc_data.block_id,
+            mc_block_chain_time: mc_data.gen_chain_time,
+            top_processed_to_anchor_id: mc_data.top_processed_to_anchor,
+            consensus_info: mc_data.consensus_info,
+            shuffle_validators: mc_data.config.get_collation_config()?.shuffle_mc_validators,
+            consensus_config: mc_data.config.get_consensus_config()?,
+            prev_validator_set,
+            current_validator_set,
+            next_validator_set,
+        });
+
+        self.mpool_adapter.handle_mc_state_update(cx).await
+    }
+
+    pub(super) async fn process_mc_state_update(
+        &self,
+        mc_data: Arc<McData>,
+        mode: ProcessMcStateUpdateMode,
+    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
+        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+            ?mode,
+            "will process master state update",
+        );
+
+        let mut collator_tasks = vec![];
+
+        if !matches!(mode, ProcessMcStateUpdateMode::SkipProcess) {
+            let block_global = mc_data.config.get_global_version()?;
+            if self.config.supported_block_version >= block_global.version
+                && block_global
+                    .capabilities
+                    .is_subset_of(self.config.supported_capabilities)
+            {
+                collator_tasks = self.refresh_collation_sessions(mc_data, mode).await?;
+            } else {
+                tracing::warn!(target: tracing_targets::COLLATION_MANAGER,
+                    collator_supported_block_version = self.config.supported_block_version,
+                    mc_block_version = block_global.version,
+                    collator_supported_capabilities = ?self.config.supported_capabilities,
+                    mc_block_capabilities = ?block_global.capabilities,
+                    "Refresh collation sessions is skipped: collator does not support mc block version or capabilities",
+                );
+            }
+        }
+
+        Ok(collator_tasks)
+    }
+
+    /// Get shards and validator set info from the master state,
+    /// then start missing collation sessions, finish outdated, resume actual.
+    /// Start/stop/resume collators and validators.
+    #[tracing::instrument(skip_all)]
+    async fn refresh_collation_sessions(
+        &self,
+        mc_data: Arc<McData>,
+        mode: ProcessMcStateUpdateMode,
+    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
+        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+            "Start refresh collation sessions by mc state ({})...",
+            mc_data.block_id.as_short_id(),
+        );
+
+        let _histogram = HistogramGuard::begin("tycho_collator_refresh_collation_sessions_time");
+
+        let mut collator_tasks = vec![];
+
+        // NOTE: in case of processing delayed state update
+        //      after the validation of key block with consensus config changed
+        //      we may try to process the state that is older then already processed from bc
+
+        // do not re-process this master block if it is lower then last processed or equal to it
+        // but process a new version of block with the same seqno
+        if !self.check_should_process_and_update_last_processed_mc_block(&mc_data.block_id) {
+            return Ok(collator_tasks);
+        }
+
+        tracing::trace!(target: tracing_targets::COLLATION_MANAGER, "mc_data: {:?}", mc_data);
+
+        // get new shards info from updated master state
+        let mut new_shards_info = FastHashMap::default();
+        new_shards_info.insert(ShardIdent::MASTERCHAIN, vec![mc_data.block_id]);
+        for (shard_id, descr) in mc_data.shards.iter() {
+            let top_block_id = descr.get_block_id(*shard_id);
+            // TODO: consider split and merge
+            new_shards_info.insert(*shard_id, vec![top_block_id]);
+        }
+
+        // apply split/merge actions
+        self.apply_split_merge_actions(&new_shards_info)?;
+
+        // find out the actual collation session start round from master state
+        let current_session_seqno = mc_data.validator_info.catchain_seqno;
+
+        // we need full validators set to define the subset for each session and to check if current node should collate
+        let full_validators_set = mc_data.config.get_current_validator_set()?;
+        tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
+            "full_validators_set: since={}, until={}, main={}, total_weight={}, list={:?}",
+            full_validators_set.utime_since, full_validators_set.utime_until,
+            full_validators_set.main, full_validators_set.total_weight,
+            DebugIter(full_validators_set.list.iter().map(|i| i.public_key)),
+        );
+        let collation_config = mc_data.config.get_collation_config()?;
+        let mut subset_cache = FastHashMap::new();
+        let mut get_validator_subset = |shard_id| match subset_cache.entry(shard_id) {
+            hash_map::Entry::Occupied(entry) => {
+                let (subset, hash_short): &(Arc<FastHashMap<[u8; 32], ValidatorDescription>>, u32) =
+                    entry.get();
+                Result::<_>::Ok((subset.clone(), *hash_short))
+            }
+            hash_map::Entry::Vacant(entry) => {
+                let (subset, hash_short) = full_validators_set
+                    .compute_mc_subset(current_session_seqno, collation_config.shuffle_mc_validators)
+                    .ok_or_else(|| anyhow!(
+                        "Error calculating subset of validators for session (shard_id = {}, seqno = {})",
+                        ShardIdent::MASTERCHAIN,
+                        current_session_seqno,
+                    ))?;
+
+                let subset: FastHashMap<_, _> = subset
+                    .into_iter()
+                    .map(|vldr| (vldr.public_key.into(), vldr))
+                    .collect();
+                let subset = Arc::new(subset);
+
+                entry.insert((subset.clone(), hash_short));
+                Ok((subset, hash_short))
+            }
+        };
+
+        // detect sessions and collators to start and to finish
+        let mut sessions_to_keep = Vec::new();
+        let mut sessions_to_start = Vec::new();
+        let mut to_finish_sessions = Vec::new();
+        let mut to_stop_collators = Vec::new();
+        {
+            let mut active_collation_sessions_guard = self.active_collation_sessions.write();
+            let mut missed_shards_ids: FastHashSet<_> =
+                active_collation_sessions_guard.keys().cloned().collect();
+            for (shard_id, block_ids) in new_shards_info {
+                missed_shards_ids.remove(&shard_id);
+
+                // check if current node is in subset
+                let (subset, hash_short) = get_validator_subset(shard_id)?;
+                let local_pubkey = find_us_in_collators_set(&self.keypair, &subset);
+
+                if local_pubkey.is_none() {
+                    tracing::debug!(
+                        target: tracing_targets::COLLATION_MANAGER,
+                        public_key = %self.keypair.public_key,
+                        current_session_seqno,
+                        hash_short,
+                        "Current node was not authorized to collate shard {}. Use TRACE to see subset",
+                        shard_id,
+                    );
+                    tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
+                        subset = ?DebugIter(subset.values()),
+                        "Current node was not authorized to collate shard {}",
+                        shard_id,
+                    );
+                    metrics::gauge!("tycho_node_in_current_vset").set(0);
+                } else {
+                    metrics::gauge!("tycho_node_in_current_vset").set(1);
+                }
+
+                match active_collation_sessions_guard.entry(shard_id) {
+                    hash_map::Entry::Occupied(entry) => {
+                        let existing_session_info = entry.get().clone();
+                        if local_pubkey.is_some() {
+                            // start new session when seqno changed or subset changed for the same seqno
+                            if existing_session_info.collators().short_hash == hash_short
+                                && existing_session_info.seqno() == current_session_seqno
+                            {
+                                sessions_to_keep.push((shard_id, existing_session_info, block_ids));
+                            } else {
+                                to_finish_sessions.push(entry.remove());
+                                sessions_to_start.push((shard_id, block_ids));
+                            }
+                        } else {
+                            to_finish_sessions.push(entry.remove());
+                            if let Some((_, collator)) = self.active_collators.remove(&shard_id) {
+                                to_stop_collators.push((existing_session_info, collator));
+                            }
+                        }
+                    }
+                    hash_map::Entry::Vacant(_) => {
+                        if local_pubkey.is_some() {
+                            sessions_to_start.push((shard_id, block_ids));
+                        }
+                    }
+                }
+            }
+
+            // if we still have some active sessions that do not match with new shards and validator subset
+            // then we need to finish them and stop their collators
+            for shard_id in missed_shards_ids {
+                if let Some(existing_session_info) =
+                    active_collation_sessions_guard.remove(&shard_id)
+                {
+                    to_finish_sessions.push(existing_session_info.clone());
+                    if let Some((_, collator)) = self.active_collators.remove(&shard_id) {
+                        to_stop_collators.push((existing_session_info, collator));
+                    }
+                }
+            }
+        }
+
+        if !sessions_to_start.is_empty() {
+            tracing::info!(
+                target: tracing_targets::COLLATION_MANAGER,
+                "Will start new collation sessions: {:?}",
+                DebugIter(sessions_to_start.iter().map(|(s, _)| (s, current_session_seqno))),
+            );
+        }
+
+        // we may have sessions to finish, collators to stop, and sessions to start,
+        // and we start missing collators for new sessions
+        for (shard_id, prev_blocks_ids) in sessions_to_start {
+            let (subset, hash_short) = get_validator_subset(shard_id)?;
+
+            let new_session_info = Arc::new(CollationSessionInfo::new(
+                shard_id,
+                current_session_seqno,
+                ValidatorSubsetInfo {
+                    validators: subset.values().cloned().collect(),
+                    short_hash: hash_short,
+                },
+                Some(self.keypair.clone()),
+            ));
+
+            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                "new_session_info: {:?}",
+                new_session_info,
+            );
+
+            let next_block_id_short = calc_next_block_id_short(&prev_blocks_ids);
+
+            match self.active_collators.entry(shard_id) {
+                DashMapEntry::Occupied(_) => {
+                    tracing::info!(
+                        target: tracing_targets::COLLATION_MANAGER,
+                        "Active collator exists for collation session {:?}. Will resume it",
+                        new_session_info.id(),
+                    );
+                    sessions_to_keep.push((shard_id, new_session_info.clone(), prev_blocks_ids));
+                }
+                DashMapEntry::Vacant(entry) => {
+                    tracing::info!(
+                        target: tracing_targets::COLLATION_MANAGER,
+                        "There is no active collator for collation session {:?}. Will start it",
+                        new_session_info.id(),
+                    );
+
+                    let cancel_collation_notify = Arc::new(Notify::new());
+
+                    match self
+                        .collator_factory
+                        .create(CollatorContext {
+                            mq_adapter: self.mq_adapter.clone(),
+                            mpool_adapter: self.mpool_adapter.clone(),
+                            state_node_adapter: self.state_node_adapter.clone(),
+                            config: self.config.clone(),
+                            collation_session: new_session_info.clone(),
+                            zerostate_id: *self.state_node_adapter.zerostate_id(),
+                            shard_id,
+                            prev_blocks_ids: prev_blocks_ids.clone(),
+                            mempool_config_override: self.mempool_config_override.clone(),
+                            cancel_collation: cancel_collation_notify.clone(),
+                        })
+                        .await
+                    {
+                        Err(err) => {
+                            tracing::error!(target: tracing_targets::COLLATION_MANAGER,
+                                session_id = ?new_session_info.id(),
+                                ?err,
+                                "error creating collator"
+                            );
+                            // return error to stop node
+                            return Err(err);
+                        }
+                        Ok(collator) => {
+                            let collator = Box::new(collator);
+
+                            // init collator
+                            let collator =
+                                if let ProcessMcStateUpdateMode::StartCollation { .. } = mode {
+                                    let init_collator_task = JoinTask::new(
+                                        collator.init(prev_blocks_ids, mc_data.clone()),
+                                    );
+                                    collator_tasks.push(init_collator_task);
+                                    None
+                                } else {
+                                    Some(collator)
+                                };
+
+                            entry.insert(ActiveCollator {
+                                state: if collator.is_none() {
+                                    CollatorState::Active
+                                } else {
+                                    CollatorState::Waiting
+                                },
+                                collator,
+                                cancel_collation: cancel_collation_notify,
+                            });
+                        }
+                    }
+                }
+            }
+
+            // need to add validation session only for masterchain blocks, shard blocks are not being validated
+            if shard_id.is_masterchain() {
+                self.validator.add_session(AddSession {
+                    shard_ident: shard_id,
+                    session_id: new_session_info.get_validation_session_id(),
+                    start_block_seqno: next_block_id_short.seqno,
+                    validators: &new_session_info.collators().validators,
+                })?;
+            }
+
+            self.active_collation_sessions
+                .write()
+                .insert(shard_id, new_session_info);
+        }
+
+        tracing::debug!(
+            target: tracing_targets::COLLATION_MANAGER,
+            "Will keep existing collation sessions: {:?}",
+            DebugIter(sessions_to_keep.iter().map(|(_, s, _)| s.id())),
+        );
+
+        // update master state in existing collators and resume collation
+        for (shard_id, new_session_info, prev_blocks_ids) in sessions_to_keep {
+            if let ProcessMcStateUpdateMode::StartCollation { reset_collators } = mode {
+                let collator = self
+                    .take_collator_and_set_state_if(
+                        &shard_id,
+                        |_| true,
+                        |ac| ac.state = CollatorState::Active,
+                    )
+                    .with_context(|| {
+                        format!(
+                            "Collator for shard should exist for active session {:?}",
+                            new_session_info.id()
+                        )
+                    })?
+                    .context("an empty check should pass")?;
+                tracing::debug!(
+                    target: tracing_targets::COLLATION_MANAGER,
+                    "Resuming collation attempts in shard session {:?}",
+                    new_session_info.id(),
+                );
+                // resume collation
+                let resume_collation_task = JoinTask::new(collator.resume_collation(
+                    mc_data.clone(),
+                    reset_collators,
+                    new_session_info,
+                    prev_blocks_ids,
+                ));
+                collator_tasks.push(resume_collation_task);
+            } else {
+                // just reset collator state
+                self.set_collator_state(&shard_id, |ac| ac.state = CollatorState::Waiting);
+            }
+        }
+
+        // finish outdated collation sessions
+        if !to_finish_sessions.is_empty() {
+            tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+                "Will finish outdated collation sessions: {:?}",
+                DebugIter(to_finish_sessions.iter().map(|s| s.id())),
+            );
+        }
+
+        // stop dangling collators
+        if !to_stop_collators.is_empty() {
+            tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+                "Will stop collators for sessions that we do not serve: {:?}",
+                DebugIter(to_stop_collators.iter().map(|(s, _)| s.id())),
+            );
+        }
+
+        Ok(collator_tasks)
+
+        // finally we will have initialized `active_collation_sessions`
+        // and `active_collators` which run async block collations processes
+    }
+
+    fn check_should_process_and_update_last_processed_mc_block(&self, block_id: &BlockId) -> bool {
+        let mut guard = self.last_processed_mc_block_id.lock();
+        let last_processed_mc_block_id_opt = guard.as_ref();
+        let (seqno_delta, is_equal) =
+            Self::compare_mc_block_with(block_id, last_processed_mc_block_id_opt);
+        if seqno_delta < 0 || is_equal {
+            false
+        } else {
+            guard.replace(*block_id);
+            true
+        }
+    }
+
+    /// Returns: (seqno delta from other, true - if equal).
+    /// If `other_mc_block_id_opt` is none, returns : (0, false)
+    fn compare_mc_block_with(
+        mc_block_id: &BlockId,
+        other_mc_block_id_opt: Option<&BlockId>,
+    ) -> (i32, bool) {
+        let (seqno_delta, is_equal) = match other_mc_block_id_opt {
+            None => {
+                tracing::info!(
+                    target: tracing_targets::COLLATION_MANAGER,
+                    "other mc block is None: current {} other ({:?}): is_equal = false, seqno_delta = 0",
+                    mc_block_id.as_short_id(),
+                    other_mc_block_id_opt.map(|b| b.as_short_id()),
+                );
+                (0, false)
+            }
+            Some(other_mc_block_id) => (
+                mc_block_id.seqno as i32 - other_mc_block_id.seqno as i32,
+                mc_block_id == other_mc_block_id,
+            ),
+        };
+        if seqno_delta < 0 || is_equal {
+            tracing::info!(
+                target: tracing_targets::COLLATION_MANAGER,
+                "mc block is NOT AHEAD of other: current {} other ({:?}): is_equal = {}, seqno_delta = {}",
+                mc_block_id.as_short_id(),
+                other_mc_block_id_opt.map(|b| b.as_short_id()),
+                is_equal, seqno_delta,
+            );
+        }
+        (seqno_delta, is_equal)
+    }
+
+    fn apply_split_merge_actions(
+        &self,
+        new_shards_info: &FastHashMap<ShardIdent, Vec<BlockId>>,
+    ) -> Result<()> {
+        let active_shards_ids: Vec<_> = self
+            .active_collation_sessions
+            .read()
+            .keys()
+            .cloned()
+            .collect();
+        let new_shards_ids: Vec<&ShardIdent> = new_shards_info.keys().collect();
+
+        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+            "Detecting split/merge actions to move from current shards {:?} to new shards {:?}...",
+            active_shards_ids.as_slice(),
+            new_shards_ids.as_slice(),
+        );
+
+        let split_merge_actions = calc_split_merge_actions(&active_shards_ids, new_shards_ids)?;
+        if !split_merge_actions.is_empty() {
+            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                "Detected split/merge actions: {:?}",
+                split_merge_actions,
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum ProcessMcStateUpdateMode {
+    StartCollation { reset_collators: bool },
+    RefreshSessionsOnly,
+    SkipProcess,
+}
+
+// TODO: Move into `tycho_types`.
+pub trait GlobalCapabilitiesExt {
+    /// Checks whether this capabilities set is fully
+    /// included into `other` (comparing raw bits to include unnamed variants).
+    fn is_subset_of(&self, other: GlobalCapabilities) -> bool;
+}
+
+impl GlobalCapabilitiesExt for GlobalCapabilities {
+    fn is_subset_of(&self, other: GlobalCapabilities) -> bool {
+        let this = self.into_inner();
+        let other = other.into_inner();
+        this & !other == 0
+    }
+}

--- a/collator/src/manager/sync.rs
+++ b/collator/src/manager/sync.rs
@@ -222,17 +222,13 @@ where
         false
     }
 
-    /// Reset collation status from `WaitForMasterStatus` to `AttemptsInProgress` for every shard.
+    /// Reset collation statuses to `AttemptsInProgress`.
     ///
-    /// Use this method before resuming collation after sync to avoid ambiguous situations.
-    /// If any shard has collation status `WaitForMasterStatus` and sync was executed,
-    /// when master collation check was finished first then it will run one more resume for shard,
-    /// so we will have two parallel collations for shard that will cause panic further.
+    /// After sync resumes collators, the next `detect_next_collation_step` must not
+    /// use stale pre-sync statuses to start or resume a collator that is already in use.
     fn reset_collation_sync_status(guard: &mut CollationSyncState) {
         for (_, collation_state) in guard.states.iter_mut() {
-            if collation_state.status == CollationStatus::WaitForMasterStatus {
-                collation_state.status = CollationStatus::AttemptsInProgress;
-            }
+            collation_state.status = CollationStatus::AttemptsInProgress;
         }
     }
 

--- a/collator/src/manager/sync.rs
+++ b/collator/src/manager/sync.rs
@@ -1,0 +1,637 @@
+use std::sync::Arc;
+
+use anyhow::{Result, bail};
+use tokio_util::sync::CancellationToken;
+use tycho_block_util::block::TopBlocks;
+use tycho_block_util::state::ShardStateStuff;
+use tycho_core::storage::StateNotFound;
+use tycho_types::models::{BlockId, BlockIdShort, ShardIdent};
+use tycho_util::FastHashMap;
+use tycho_util::futures::AwaitBlocking;
+use tycho_util::metrics::HistogramGuard;
+
+use super::CollationManager;
+use super::blocks_cache::BlocksCache;
+use super::state_update_handler::ProcessMcStateUpdateMode;
+use super::types::{
+    ActiveSync, BlockCacheStoreResult, CollationStatus, CollationSyncState, CollatorJoinTask,
+};
+use crate::collator::CollatorFactory;
+use crate::state_node::StateNodeAdapter;
+use crate::tracing_targets;
+use crate::types::processed_upto::{BlockSeqno, find_min_processed_to_by_shards};
+use crate::types::{DisplayAsShortId, DisplayBlockIdsIntoIter, McData, ProcessedToByPartitions};
+use crate::validator::Validator;
+
+impl<CF, V> CollationManager<CF, V>
+where
+    CF: CollatorFactory,
+    V: Validator,
+{
+    // HELPERS
+
+    pub(super) fn update_last_received_mc_block_seqno(&self, received_block_id: &BlockId) {
+        if !received_block_id.is_masterchain() {
+            return;
+        }
+
+        let mut guard = self.collation_sync_state.lock();
+        guard.last_received_mc_block_seqno = Some(received_block_id.seqno);
+    }
+
+    fn get_last_received_mc_block_seqno(&self) -> Option<BlockSeqno> {
+        let guard = self.collation_sync_state.lock();
+        guard.last_received_mc_block_seqno
+    }
+
+    pub(super) fn has_newer_received_mc_block(&self, applied_range: Option<(u32, u32)>) -> bool {
+        if let Some((_, applied_range_end)) = applied_range {
+            let last_received_mc_block_seqno = self.get_last_received_mc_block_seqno();
+            if matches!(
+                last_received_mc_block_seqno,
+                Some(last_received_seqno) if last_received_seqno.saturating_sub(applied_range_end) > 1
+            ) {
+                tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+                    last_received_mc_block_seqno,
+                    applied_range_end,
+                    "check_should_sync: should not sync to last applied mc block \
+                    because a newer one already received",
+                );
+
+                return true;
+            }
+        }
+        false
+    }
+
+    fn update_last_synced_to_mc_block_id(&self, mc_block_id: BlockId) {
+        let mut guard = self.collation_sync_state.lock();
+        guard.last_synced_to_mc_block_id = Some(mc_block_id);
+    }
+
+    pub(super) fn get_last_synced_to_mc_block_id(&self) -> Option<BlockId> {
+        let guard = self.collation_sync_state.lock();
+        guard.last_synced_to_mc_block_id
+    }
+
+    /// Collect top blocks seqno from all shards by master block id. Master block seqno included.
+    /// Returns None when unable to read related top shard blocks info.
+    pub(super) async fn get_top_blocks_seqno(
+        mc_block_id: &BlockId,
+        blocks_cache: &BlocksCache,
+        state_node_adapter: Arc<dyn StateNodeAdapter>,
+    ) -> Result<Option<FastHashMap<ShardIdent, BlockSeqno>>> {
+        let mut result = FastHashMap::default();
+
+        result.insert(mc_block_id.shard, mc_block_id.seqno);
+
+        // try get top shard blocks from cache first
+        if let Some(top_shard_blocks) = blocks_cache.get_top_shard_blocks(mc_block_id.as_short_id())
+        {
+            result.extend(top_shard_blocks);
+            return Ok(Some(result));
+        }
+
+        // then try read from state
+        match state_node_adapter
+            .load_state(mc_block_id.seqno, mc_block_id, Default::default())
+            .await
+        {
+            Err(err) => match err.downcast_ref::<StateNotFound>() {
+                Some(_) => {
+                    tracing::warn!(target: tracing_targets::COLLATION_MANAGER,
+                        %mc_block_id,
+                        "master state not found in get_top_blocks_seqno",
+                    );
+                }
+                _ => {
+                    tracing::warn!(target: tracing_targets::COLLATION_MANAGER,
+                        ?err,
+                        "error loading master state in get_top_blocks_seqno",
+                    );
+                }
+            },
+            Ok(state) => {
+                for item in state.shards()?.latest_blocks() {
+                    let top_sb = item?;
+                    result.insert(top_sb.shard, top_sb.seqno);
+                }
+                return Ok(Some(result));
+            }
+        }
+
+        // finally try read from block data
+        match state_node_adapter.load_block(mc_block_id).await {
+            Err(err) => {
+                tracing::warn!(target: tracing_targets::COLLATION_MANAGER,
+                    %mc_block_id,
+                    ?err,
+                    "error loading master block in get_top_blocks_seqno",
+                );
+            }
+            Ok(None) => {
+                tracing::warn!(target: tracing_targets::COLLATION_MANAGER,
+                    %mc_block_id,
+                    "master block was not found in get_top_blocks_seqno",
+                );
+            }
+            Ok(Some(mc_block_stuff)) => {
+                let top_blocks = TopBlocks::from_mc_block(&mc_block_stuff)?;
+                for top_sb in top_blocks.shard_heights().iter() {
+                    result.insert(top_sb.shard, top_sb.seqno);
+                }
+                return Ok(Some(result));
+            }
+        }
+
+        // unable to load related shard blocks info, return None
+        Ok(None)
+    }
+
+    // SYNC LOCK
+
+    fn set_active_sync_info(&self, target_mc_block_seqno: BlockSeqno) -> Result<CancellationToken> {
+        let mut guard = self.collation_sync_state.lock();
+        if let Some(active_sync) = &guard.active_sync_to_applied {
+            bail!(
+                "previous sync_to_applied_mc_block should be finished \
+                before: previous seqno={}, target seqno={}",
+                active_sync.target_mc_block_seqno,
+                target_mc_block_seqno,
+            )
+        }
+
+        let cancelled = CancellationToken::new();
+        guard.active_sync_to_applied = Some(ActiveSync {
+            target_mc_block_seqno,
+            cancelled: cancelled.clone(),
+        });
+
+        Ok(cancelled)
+    }
+
+    fn clean_active_sync_info(&self) {
+        let mut guard = self.collation_sync_state.lock();
+        guard.active_sync_to_applied = None;
+    }
+
+    /// Returns `true` if active sync was cancelled
+    pub(super) fn finish_active_sync_to_applied(&self, received_block_id: &BlockId) -> bool {
+        // can finish active sync only if new master block received
+        if !received_block_id.is_masterchain() {
+            return false;
+        }
+
+        let guard = self.collation_sync_state.lock();
+
+        // call to finish active sync if it exists and received block is newer
+        if let Some(active_sync_info) = &guard.active_sync_to_applied {
+            // call to finish active sync if new block is far ahead
+            if received_block_id
+                .seqno
+                .saturating_sub(active_sync_info.target_mc_block_seqno)
+                >= self.config.min_mc_block_delta_from_bc_to_sync
+            {
+                tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                    prev_target_block_id = %BlockIdShort {
+                        shard: ShardIdent::MASTERCHAIN,
+                        seqno: active_sync_info.target_mc_block_seqno,
+                    },
+                    "cancel sync: will force finish previous sync \
+                    to applied master block if not started to process state update",
+                );
+                active_sync_info.cancelled.cancel();
+                return true;
+            } else {
+                // otherwise allow to handle newer block from bc when previous process started
+                tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
+                    prev_target_block_id = %BlockIdShort {
+                        shard: ShardIdent::MASTERCHAIN,
+                        seqno: active_sync_info.target_mc_block_seqno,
+                    },
+                    "cancel sync: will not force finish previous sync \
+                    to applied master block, because new block is not far ahead",
+                );
+            }
+        } else {
+            tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
+                "cancel sync: route_handle_block_from_bc: no active sync to cancel",
+            );
+        }
+
+        false
+    }
+
+    /// Reset collation status from `WaitForMasterStatus` to `AttemptsInProgress` for every shard.
+    ///
+    /// Use this method before resuming collation after sync to avoid ambiguous situations.
+    /// If any shard has collation status `WaitForMasterStatus` and sync was executed,
+    /// when master collation check was finished first then it will run one more resume for shard,
+    /// so we will have two parallel collations for shard that will cause panic further.
+    fn reset_collation_sync_status(guard: &mut CollationSyncState) {
+        for (_, collation_state) in guard.states.iter_mut() {
+            if collation_state.status == CollationStatus::WaitForMasterStatus {
+                collation_state.status = CollationStatus::AttemptsInProgress;
+            }
+        }
+    }
+
+    // HANDLERS
+
+    pub(super) fn check_should_sync_to_last_applied_mc_block(
+        &self,
+        store_res: &BlockCacheStoreResult,
+        top_mc_block_id_for_next_collation: Option<BlockId>,
+        required_min_mc_block_delta: BlockSeqno,
+        is_key_block: Option<bool>,
+    ) -> bool {
+        // do not sync to last applied mc block if newer already received
+        if self.has_newer_received_mc_block(store_res.applied_mc_queue_range) {
+            return false;
+        }
+
+        // should sync if collated block mismatched
+        if store_res.block_mismatch {
+            return true;
+        }
+
+        let has_active_collations = self.has_active_collations();
+        let last_synced_to_mc_block_id = self
+            .get_last_synced_to_mc_block_id()
+            .map(|id| id.as_short_id().to_string());
+        let last_collated_mc_block_id = store_res
+            .last_collated_mc_block_id
+            .map(|id| id.as_short_id().to_string());
+        let last_processed_mc_block_id = self
+            .last_processed_mc_block_id
+            .lock()
+            .map(|id| id.as_short_id().to_string());
+
+        if let Some(top_mc_block_id_for_next_collation) = top_mc_block_id_for_next_collation {
+            // we can sync only when we have any applied block ahead
+            if let Some((_, applied_range_end)) = store_res.applied_mc_queue_range {
+                // check if should sync according to master block delta
+                let applied_range_end_delta =
+                    applied_range_end.saturating_sub(top_mc_block_id_for_next_collation.seqno);
+
+                if applied_range_end_delta < required_min_mc_block_delta {
+                    tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                        last_synced_to_mc_block_id = ?last_synced_to_mc_block_id,
+                        last_collated_mc_block_id = ?last_collated_mc_block_id,
+                        last_processed_mc_block_id = ?last_processed_mc_block_id,
+                        has_active_collations,
+                        is_key_block = ?is_key_block,
+                        "check_should_sync: should wait for next collated own mc block: \
+                        last applied ({}) ahead of top for collation ({}) on {} < {}",
+                        applied_range_end, top_mc_block_id_for_next_collation.seqno,
+                        applied_range_end_delta, required_min_mc_block_delta,
+                    );
+                    false
+                } else {
+                    tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+                        last_synced_to_mc_block_id = ?last_synced_to_mc_block_id,
+                        last_collated_mc_block_id = ?last_collated_mc_block_id,
+                        last_processed_mc_block_id = ?last_processed_mc_block_id,
+                        has_active_collations,
+                        is_key_block = ?is_key_block,
+                        "check_should_sync: should sync to last applied mc block from bc: \
+                        last applied ({}) ahead of top for collation ({}) on {} >= {}",
+                        applied_range_end, top_mc_block_id_for_next_collation.seqno,
+                        applied_range_end_delta, required_min_mc_block_delta,
+                    );
+                    true
+                }
+            } else {
+                // should collate next own mc block because no applied ahead
+                tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                    last_synced_to_mc_block_id = ?last_synced_to_mc_block_id,
+                    last_collated_mc_block_id = ?last_collated_mc_block_id,
+                    last_processed_mc_block_id = ?last_processed_mc_block_id,
+                    has_active_collations,
+                    is_key_block = ?is_key_block,
+                    "check_should_sync: should collate next own mc block after because nothing applied ahead",
+                );
+                false
+            }
+        } else {
+            tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+                last_synced_to_mc_block_id = ?last_synced_to_mc_block_id,
+                last_collated_mc_block_id = ?last_collated_mc_block_id,
+                last_processed_mc_block_id = ?last_processed_mc_block_id,
+                has_active_collations,
+                is_key_block = ?is_key_block,
+                "check_should_sync: should sync to last applied mc block when no last collated or prev sync to",
+            );
+            true
+        }
+    }
+
+    #[tracing::instrument(name = "sync_to_applied_mc_block", skip_all, fields(trigger_block_id = %trigger_block_id_short, applied_range = ?applied_range))]
+    pub(super) async fn sync_to_applied_mc_block_if_exist(
+        self: &Arc<Self>,
+        trigger_block_id_short: BlockIdShort,
+        last_collated_mc_block_id: Option<BlockId>,
+        applied_range: Option<(BlockSeqno, BlockSeqno)>,
+        process_state_update_mode: ProcessMcStateUpdateMode,
+    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
+        let mut collator_tasks = vec![];
+
+        if let Some(applied_range) = applied_range {
+            let this = self.clone();
+            let span = tracing::Span::current();
+
+            collator_tasks = tokio::task::spawn_blocking(move || {
+                let _ = span.enter();
+
+                this.sync_to_applied_mc_block(
+                    trigger_block_id_short,
+                    last_collated_mc_block_id,
+                    applied_range,
+                    process_state_update_mode,
+                )
+            })
+            .await??;
+        } else {
+            tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+                "there is no received applied mc blocks in cache, \
+                will wait for next blocks from bc",
+            );
+        }
+
+        Ok(collator_tasks)
+    }
+
+    /// Restores internals queue state,
+    /// processes last applied mc state
+    /// to run next blocks collation.
+    #[tracing::instrument(skip_all, fields(trigger_block_id = %trigger_block_id_short, applied_range = ?applied_range))]
+    fn sync_to_applied_mc_block(
+        &self,
+        trigger_block_id_short: BlockIdShort,
+        last_collated_mc_block_id: Option<BlockId>,
+        applied_range: (BlockSeqno, BlockSeqno),
+        process_state_update_mode: ProcessMcStateUpdateMode,
+    ) -> Result<Vec<CollatorJoinTask<CF::Collator>>> {
+        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+            "start sync to applied mc block",
+        );
+
+        let _histogram = HistogramGuard::begin("tycho_collator_sync_to_applied_mc_block_time");
+        metrics::counter!("tycho_collator_sync_to_applied_mc_block_count").increment(1);
+
+        let first_applied_mc_block_key = BlockIdShort {
+            shard: ShardIdent::MASTERCHAIN,
+            seqno: applied_range.0,
+        };
+        let last_applied_mc_block_key = BlockIdShort {
+            shard: ShardIdent::MASTERCHAIN,
+            seqno: applied_range.1,
+        };
+
+        // store active sync info with cancellation token
+        let cancelled = self.set_active_sync_info(last_applied_mc_block_key.seqno)?;
+        tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
+            "cancel sync: sync_to_applied_mc_block: set_active_sync_info for seqno={}",
+            last_applied_mc_block_key.seqno,
+        );
+        scopeguard::defer!({
+            self.clean_active_sync_info();
+            tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
+                "cancel sync: sync_to_applied_mc_block: active_sync_info cleaned",
+            );
+        });
+
+        // gc blocks from cache when sync finished
+        scopeguard::defer!(self.blocks_cache.gc_prev_blocks());
+
+        // we need to drop uncommitted internal messages from the queue
+        // when mempool config override has genesis higher then in the last consensus info
+        if let Some(mp_cfg_override) = &self.mempool_config_override {
+            let last_consesus_info = self
+                .blocks_cache
+                .get_consensus_info_for_mc_block(&last_applied_mc_block_key)?;
+            if mp_cfg_override
+                .genesis_info
+                .overrides(&last_consesus_info.genesis_info)
+            {
+                tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+                    prev_genesis_start_round = last_consesus_info.genesis_info.start_round,
+                    prev_genesis_time_millis = last_consesus_info.genesis_info.genesis_millis,
+                    new_genesis_start_round = mp_cfg_override.genesis_info.start_round,
+                    new_genesis_time_millis = mp_cfg_override.genesis_info.genesis_millis,
+                    "will drop uncommitted internal messages from queue on new genesis",
+                );
+
+                // E.g. we have applied mc block MC100 and collated some shard blocks after it (SC701, SC702)
+                // so we have uncommitted queue diffs from these shard blocks SC701, SC702.
+                // On restart from genesis we will start to collate SC701* again because last validated
+                // and applied mc block is MC100. But mempool will not contain all old externals used to collate
+                // the previous version of SC701. So the new diff will mismatch the old one and node will panic.
+                // So we need to remove all uncommitted queue diffs because we have new mismatched externals queue.
+                self.clear_uncommitted_queue_state()?;
+            }
+        }
+
+        // get internals processed_to from master and all shards
+        // for last applied master block
+        let all_shards_processed_to_by_partitions =
+            Self::get_all_shards_processed_to_by_partitions_for_mc_block(
+                &last_applied_mc_block_key,
+                &self.blocks_cache,
+                self.state_node_adapter.clone(),
+            )
+            .await_blocking()?;
+
+        // find internals min processed_to
+        let min_processed_to_by_shards =
+            find_min_processed_to_by_shards(&all_shards_processed_to_by_partitions);
+
+        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+            ?min_processed_to_by_shards,
+        );
+
+        // find first applied mc block and tail shard blocks and get previous
+        let before_tail_block_ids = self
+            .blocks_cache
+            .read_before_tail_ids_of_mc_block(&first_applied_mc_block_key)?;
+
+        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+            tail_block_ids = ?before_tail_block_ids
+                .iter()
+                .map(|(shard_id, (id, prev_ids))| {
+                    format!(
+                        "({}, id={:?}, prev_ids={})",
+                        shard_id,
+                        id.as_ref().map(DisplayAsShortId),
+                        DisplayBlockIdsIntoIter(prev_ids),
+                    )
+                }).collect::<Vec<_>>().as_slice(),
+        );
+
+        // metrics - sync is running
+        for shard in before_tail_block_ids.keys() {
+            let labels = [("workchain", shard.workchain().to_string())];
+            metrics::gauge!("tycho_collator_sync_is_running", &labels).set(1);
+        }
+
+        // if `fast_sync` is enabled then we will skip already applied queue diffs
+        let queue_diffs_applied_to_top_blocks = if self.config.fast_sync
+            && let Some(applied_to_mc_block_id) =
+                self.get_queue_diffs_applied_to_mc_block_id(last_collated_mc_block_id)?
+        {
+            // BACKWARD COMPATIBILITY: `last_committed_mc_block_id` will not exist in queue storage
+            // in previous version. We will receive None and will use all required diffs to restore the queue
+
+            // NOTE: when the node started to sync from a persistent state with a bunch of archives after it,
+            //      the `last_collated_mc_block_id` will be None, and `applied_to_mc_block_id` will be equal
+            //      to the top block of the persistent state - init block. But the persistent state can be already
+            //      removed because of the long history after it when collator starts to sync by recent blocks.
+            //      So we will not able to read top blocks ids and will fallback the full sync.
+
+            // collect top blocks queue diffs already applied to
+            Self::get_top_blocks_seqno(
+                &applied_to_mc_block_id,
+                &self.blocks_cache,
+                self.state_node_adapter.clone(),
+            )
+            .await_blocking()?
+        } else {
+            None
+        };
+        if queue_diffs_applied_to_top_blocks.is_some() {
+            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                ?queue_diffs_applied_to_top_blocks,
+                "will use fast sync to restore queue",
+            );
+        }
+
+        // restore queue state and return latest applied master state
+        let queue_restore_res = Self::restore_queue(
+            &self.blocks_cache,
+            self.state_node_adapter.clone(),
+            self.mq_adapter.clone(),
+            applied_range.0,
+            min_processed_to_by_shards,
+            before_tail_block_ids,
+            queue_diffs_applied_to_top_blocks.unwrap_or_default(),
+        )
+        .await_blocking()?;
+
+        let Some(last_mc_state) = queue_restore_res.last_mc_state else {
+            tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+                last_applied_mc_block_id = %BlockIdShort {
+                    shard: ShardIdent::MASTERCHAIN,
+                    seqno: applied_range.1,
+                },
+                "sync_to_applied_mc_block: unable to sync to last applied mc block, \
+                need to receive next blocks from bc",
+            );
+            return Ok(vec![]);
+        };
+
+        // process latest master state: notify mempool and refresh collation session
+        let last_mc_block_id = *last_mc_state.block_id();
+
+        // HACK: do not need to set master block latest chain time from zerostate when using mempool stub
+        //      because anchors from stub have older chain time than in zerostate and it will brake collation
+        if last_mc_block_id.seqno > self.state_node_adapter.zerostate_id().seqno {
+            Self::renew_mc_block_latest_chain_time(
+                &mut self.collation_sync_state.lock(),
+                last_mc_state.get_gen_chain_time(),
+            );
+        }
+
+        Self::reset_collation_sync_status(&mut self.collation_sync_state.lock());
+
+        // update last "synced to" info
+        self.update_last_synced_to_mc_block_id(last_mc_block_id);
+
+        // reset top shard blocks info
+        // because next we will start to collate new shard blocks after the sync
+        self.blocks_cache.reset_top_shard_blocks_additional_info();
+
+        let mc_data = Self::build_mc_data(
+            &self.state_node_adapter,
+            last_mc_state,
+            queue_restore_res.prev_mc_state,
+            queue_restore_res.prev_mc_block_id,
+            all_shards_processed_to_by_partitions,
+        )?;
+
+        self.blocks_cache
+            .remove_next_collated_blocks_from_cache(&queue_restore_res.synced_to_blocks_keys);
+
+        // notify state update to mempool
+        self.notify_mc_state_update_to_mempool(mc_data.clone())
+            .await_blocking()?;
+
+        // when sync cancelled we do not exist sync but skip collation
+        let process_state_update_mode = if cancelled.is_cancelled() {
+            ProcessMcStateUpdateMode::SkipProcess
+        } else {
+            process_state_update_mode
+        };
+
+        let collator_tasks = self
+            .process_mc_state_update(mc_data.clone(), process_state_update_mode)
+            .await_blocking()?;
+
+        // handle top processed to anchor in mempool
+        self.notify_top_processed_to_anchor_to_mempool(
+            mc_data.block_id.seqno,
+            mc_data.top_processed_to_anchor,
+        )
+        .await_blocking()?;
+
+        // report last "synced to" blocks to metrics
+        for synced_to_block_id in queue_restore_res.synced_to_blocks_keys {
+            let labels = [
+                (
+                    "workchain",
+                    synced_to_block_id.shard.workchain().to_string(),
+                ),
+                ("src", "02_synced_to".to_string()),
+            ];
+            metrics::gauge!("tycho_last_block_seqno", &labels).set(synced_to_block_id.seqno);
+        }
+
+        Ok(collator_tasks)
+    }
+
+    /// Builds `McData` from provided parts.
+    /// Tries to load the previous mc state from storage when passed `None`.
+    fn build_mc_data(
+        state_node_adapter: &Arc<dyn StateNodeAdapter>,
+        last_mc_state: ShardStateStuff,
+        prev_mc_state: Option<ShardStateStuff>,
+        prev_mc_block_id: Option<BlockId>,
+        all_shards_processed_to_by_partitions: FastHashMap<
+            ShardIdent,
+            (bool, ProcessedToByPartitions),
+        >,
+    ) -> Result<Arc<McData>> {
+        let prev_mc_state = match (prev_mc_state, prev_mc_block_id) {
+            (Some(mc_state), _) => Some(mc_state),
+            (None, None) => None,
+            (None, Some(prev_mc_block_id)) if prev_mc_block_id.seqno <= state_node_adapter.zerostate_id().seqno => None,
+            // NOTE: Use zero epoch here since we don't need to reuse these states.
+            (None, Some(prev_mc_block_id)) => state_node_adapter
+                .load_state(0, &prev_mc_block_id, Default::default())
+                .await_blocking()
+                .map_err(|err| {
+                    tracing::warn!(target: tracing_targets::COLLATION_MANAGER,
+                        prev_mc_block_id = %prev_mc_block_id.as_short_id(),
+                        error = ?err,
+                        "failed to load previous mc state to build mc data, continue without prev_mc_data",
+                    );
+                    err
+                }).ok(),
+        };
+
+        McData::load_from_state(
+            &last_mc_state,
+            prev_mc_state.as_ref(),
+            all_shards_processed_to_by_partitions,
+        )
+    }
+}

--- a/collator/src/manager/tests/manager_tests.rs
+++ b/collator/src/manager/tests/manager_tests.rs
@@ -24,7 +24,7 @@ use tycho_types::models::{
 };
 use tycho_util::{FastDashMap, FastHashMap, FastHashSet};
 
-use super::{BlockCacheStoreResult, BlockSeqno, CollationManager, DetectNextCollationStepContext};
+use super::{BlockSeqno, CollationManager, DetectNextCollationStepContext};
 use crate::collator::{
     CollatorStdImplFactory, ForceMasterCollation, ShardDescriptionExt as _, TestInternalMessage,
     TestMessageFactory,
@@ -34,7 +34,7 @@ use crate::internal_queue::types::message::{EnqueuedMessage, InternalMessageValu
 use crate::internal_queue::types::router::PartitionRouter;
 use crate::internal_queue::types::stats::DiffStatistics;
 use crate::manager::blocks_cache::BlocksCache;
-use crate::manager::types::{CollationSyncState, NextCollationStep};
+use crate::manager::types::{BlockCacheStoreResult, CollationSyncState, NextCollationStep};
 use crate::manager::{
     CollatedBlockInfo, CollationStatus, GlobalCapabilitiesExt, McBlockSubgraphExtract,
 };

--- a/collator/src/manager/tests/manager_tests.rs
+++ b/collator/src/manager/tests/manager_tests.rs
@@ -34,10 +34,11 @@ use crate::internal_queue::types::message::{EnqueuedMessage, InternalMessageValu
 use crate::internal_queue::types::router::PartitionRouter;
 use crate::internal_queue::types::stats::DiffStatistics;
 use crate::manager::blocks_cache::BlocksCache;
-use crate::manager::types::{BlockCacheStoreResult, CollationSyncState, NextCollationStep};
-use crate::manager::{
-    CollatedBlockInfo, CollationStatus, GlobalCapabilitiesExt, McBlockSubgraphExtract,
+use crate::manager::state_update_handler::GlobalCapabilitiesExt;
+use crate::manager::types::{
+    BlockCacheStoreResult, CollationSyncState, McBlockSubgraphExtract, NextCollationStep,
 };
+use crate::manager::{CollatedBlockInfo, CollationStatus};
 use crate::queue_adapter::MessageQueueAdapter;
 use crate::state_node::{CollatorSyncContext, InitiatedStoreState, StateNodeAdapter};
 use crate::test_utils::{create_test_queue_adapter, try_init_test_tracing};

--- a/collator/src/manager/types.rs
+++ b/collator/src/manager/types.rs
@@ -158,7 +158,7 @@ impl Debug for BlockCacheStoreResult {
             .field("block_mismatch", &self.block_mismatch)
             .field(
                 "last_collated_mc_block_id",
-                &DebugDisplayOpt(self.last_collated_mc_block_id),
+                &DebugDisplayOpt(&self.last_collated_mc_block_id),
             )
             .field("applied_mc_queue_range", &self.applied_mc_queue_range)
             .finish()

--- a/collator/src/manager/types.rs
+++ b/collator/src/manager/types.rs
@@ -210,11 +210,6 @@ pub(super) enum CandidateStatus {
     Synced,
 }
 
-pub(super) enum BlockCacheStoreSource {
-    Collated,
-    Received,
-}
-
 #[expect(clippy::large_enum_variant)]
 pub(super) enum BlockCacheEntryData {
     Collated {

--- a/collator/src/queue_adapter.rs
+++ b/collator/src/queue_adapter.rs
@@ -330,7 +330,7 @@ impl<V: InternalMessageValue> MessageQueueAdapter<V> for MessageQueueAdapterStdI
         let elapsed = start_time.elapsed();
         tracing::info!(target: tracing_targets::MQ_ADAPTER,
             elapsed = %humantime::format_duration(elapsed),
-            block_id = ?DebugDisplayOpt(block_id),
+            block_id = ?DebugDisplayOpt(&block_id),
             "get_last_committed_mc_block_id completed"
         );
         Ok(block_id)

--- a/collator/src/types.rs
+++ b/collator/src/types.rs
@@ -529,8 +529,8 @@ impl<T: std::fmt::Display> std::fmt::Debug for DebugDisplay<T> {
     }
 }
 
-pub struct DebugDisplayOpt<T>(pub Option<T>);
-impl<T: std::fmt::Display> std::fmt::Debug for DebugDisplayOpt<T> {
+pub struct DebugDisplayOpt<'a, T>(pub &'a Option<T>);
+impl<'a, T: std::fmt::Display> std::fmt::Debug for DebugDisplayOpt<'a, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Debug::fmt(&self.0.as_ref().map(DebugDisplay), f)
     }

--- a/util/src/futures/await_blocking.rs
+++ b/util/src/futures/await_blocking.rs
@@ -1,3 +1,5 @@
+use tracing::Instrument;
+
 pub trait AwaitBlocking: IntoFuture {
     /// Blocks the current thread polling the future to completion.
     ///
@@ -7,6 +9,6 @@ pub trait AwaitBlocking: IntoFuture {
 
 impl<T: IntoFuture> AwaitBlocking for T {
     fn await_blocking(self) -> <Self as IntoFuture>::Output {
-        futures_executor::block_on(self.into_future())
+        futures_executor::block_on(self.into_future().instrument(tracing::Span::current()))
     }
 }


### PR DESCRIPTION
Use explicit flow to cancel active collations on the block mismatch or when received a block from bc far ahead of last collated. Now we drain active collation tasks in a separate cancel task and do not relay on collator result cancellation using flags. Removed races when shard collator trying to collate next block even if cancellation requested before sync.

Collation manager code was splitted on several modules.

## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

None

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

None
---

### COMPATIBILITY

Fully compatible

### SPECIAL DEPLOYMENT ACTIONS

Not Required

---

### PERFORMANCE IMPACT

No impact expected

---

### TESTS

#### Unit Tests

No special coverage

#### Network Tests

No special coverage

#### Manual Tests

Manual tests used on devnet5
- transfers 30k
- externals 100k
- deploy 30kk
- transfers 30k
- transfers 50k
- dex 2000

---

**Notes/Additional Comments:**  

Better to review all commits except the last one separately because the last commit only moves working code from a single file to a several modules. 