### PR TITLE
perf(consensus): reduce mempool points RocksDB stalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4185,6 +4185,7 @@ dependencies = [
  "blake3",
  "bumpalo",
  "bytes",
+ "bytesize",
  "clap",
  "dashmap",
  "futures-util",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -22,6 +22,7 @@ bitflags = { workspace = true }
 blake3 = { workspace = true }
 bumpalo = { workspace = true }
 bytes = { workspace = true }
+bytesize = { workspace = true }
 dashmap = { workspace = true }
 futures-util = { workspace = true }
 humantime = { workspace = true }

--- a/consensus/src/storage/tables.rs
+++ b/consensus/src/storage/tables.rs
@@ -1,3 +1,4 @@
+use bytesize::ByteSize;
 use tycho_storage::kv::{
     DEFAULT_MIN_BLOB_SIZE, NamedTables, TableContext, optimize_for_point_lookup,
 };
@@ -32,6 +33,17 @@ impl ColumnFamily for Points {
 impl ColumnFamilyOptions<TableContext> for Points {
     fn options(opts: &mut Options, ctx: &mut TableContext) {
         optimize_for_point_lookup(opts, ctx);
+
+        let write_buffer_size = ByteSize::mib(64);
+        let write_buffer_count = 6u64;
+        opts.set_write_buffer_size(write_buffer_size.as_u64() as _);
+        opts.set_min_write_buffer_number_to_merge(1);
+        opts.set_max_write_buffer_number(write_buffer_count as _);
+        ctx.track_buffer_usage(
+            write_buffer_size,
+            ByteSize(write_buffer_size.as_u64() * write_buffer_count),
+        );
+
         opts.set_disable_auto_compactions(true);
 
         opts.set_enable_blob_files(true);


### PR DESCRIPTION
<img width="2400" height="1440" alt="points-rocksdb-flush-stalls" src="https://github.com/user-attachments/assets/7be27149-0336-4249-b775-b6759f9bbeee" />

 We waited for 2 memtables before flushing, while live cleanup forced manual flushes and produced smaller-than-needed SSTs. This wasted flush work and still left only 2 immutable memtables before  rocksdb stopped writes.