### PR TITLE
fix: clear manager cache on sync skip

### DIFF
--- a/collator/src/collator/do_collate/mod.rs
+++ b/collator/src/collator/do_collate/mod.rs
@@ -100,6 +100,15 @@ impl CollatorStdImpl {
         let total_collation_histogram =
             HistogramGuard::begin_with_labels("tycho_do_collate_total_time_high", &labels);
 
+        // HACK: slowdown collation when special flag is activated
+        if let Some(slowdown_ms) = self.config.slowdown_do_collate_ms {
+            tracing::debug!(target: tracing_targets::COLLATOR,
+                "HACK: slowdown collation on {} ms",
+                slowdown_ms,
+            );
+            tokio::time::sleep(Duration::from_millis(slowdown_ms)).await;
+        }
+
         let WorkingState {
             next_block_id_short,
             mc_data,

--- a/collator/src/collator/mod.rs
+++ b/collator/src/collator/mod.rs
@@ -644,6 +644,15 @@ impl CollatorStdImpl {
         let histogram =
             HistogramGuard::begin_with_labels("tycho_collator_resume_collation_time_high", &labels);
 
+        // HACK: slowdown collation resume when special flag is activated
+        if let Some(slowdown_ms) = self.config.slowdown_resume_collation_ms {
+            tracing::debug!(target: tracing_targets::COLLATOR,
+                "HACK: slowdown collation resume on {} ms",
+                slowdown_ms,
+            );
+            tokio::time::sleep(Duration::from_millis(slowdown_ms)).await;
+        }
+
         // update collation session info to refer to a correct subset in collated block
         self.collation_session = collation_session;
 

--- a/collator/src/manager/blocks_cache.rs
+++ b/collator/src/manager/blocks_cache.rs
@@ -531,6 +531,99 @@ impl BlocksCache {
         }
     }
 
+    pub(super) fn peek_front_applied_mc_block_subgraph(
+        &self,
+        from_seqno: u32,
+    ) -> Result<Option<CachedMcBlockSubgraphView>> {
+        // get master blocks keys from cache
+        let keys: Vec<_> = self.inner.masters.lock().blocks.keys().copied().collect();
+
+        for key in keys {
+            // skip blocks before the from boundary
+            if key < from_seqno {
+                continue;
+            }
+
+            // build master block view
+            let (mut subgraph_view, top_shard_blocks_info) = {
+                let guard = self.inner.masters.lock();
+                let Some(mc_block_entry) = guard.blocks.get(&key) else {
+                    bail!("Block cache entry should exist ({})", key)
+                };
+
+                // get only received blocks
+                if !matches!(
+                    mc_block_entry.data,
+                    BlockCacheEntryData::Received { .. }
+                        | BlockCacheEntryData::Collated {
+                            received_after_collation: true,
+                            ..
+                        }
+                ) {
+                    continue;
+                }
+
+                let subgraph_view = CachedMcBlockSubgraphView {
+                    block_id: mc_block_entry.block_id,
+                    ref_by_mc_seqno: mc_block_entry.ref_by_mc_seqno,
+                    queue_diff: match &mc_block_entry.data {
+                        BlockCacheEntryData::Received { queue_diff, .. } => queue_diff.clone(),
+                        BlockCacheEntryData::Collated {
+                            candidate_stuff, ..
+                        } => candidate_stuff.candidate.queue_diff_aug.data.clone(),
+                    },
+                    top_shard_blocks: vec![],
+                    missing_top_shard_block: None,
+                };
+
+                let top_shard_blocks_info = mc_block_entry.top_shard_blocks_info.clone();
+
+                (subgraph_view, top_shard_blocks_info)
+            };
+
+            // try to read top shard blocks data
+            for top_shard_block in top_shard_blocks_info {
+                // skip shard blocks that included in previous master blocks
+                if !top_shard_block.updated
+                    || top_shard_block.block.ref_by_mc_seqno <= self.inner.zerostate_mc_seqno
+                {
+                    continue;
+                }
+
+                // try get shard block from cache
+                if let Some(shard_cache) =
+                    self.inner.shards.get(&top_shard_block.block.block_id.shard)
+                    && let Some(sc_block_entry) = shard_cache
+                        .blocks
+                        .get(&top_shard_block.block.block_id.seqno)
+                    && sc_block_entry.ref_by_mc_seqno == subgraph_view.block_id.seqno
+                {
+                    // get diff
+                    let queue_diff = match &sc_block_entry.data {
+                        BlockCacheEntryData::Received { queue_diff, .. } => queue_diff.clone(),
+                        BlockCacheEntryData::Collated {
+                            candidate_stuff, ..
+                        } => candidate_stuff.candidate.queue_diff_aug.data.clone(),
+                    };
+
+                    subgraph_view.top_shard_blocks.push(CachedShardBlockView {
+                        block_id: top_shard_block.block.block_id,
+                        ref_by_mc_seqno: top_shard_block.block.ref_by_mc_seqno,
+                        queue_diff,
+                    });
+                } else {
+                    subgraph_view.missing_top_shard_block =
+                        Some(top_shard_block.block.block_id.as_short_id());
+                    break;
+                }
+            }
+
+            return Ok(Some(subgraph_view));
+        }
+
+        Ok(None)
+    }
+
     pub fn pop_front_applied_mc_block_subgraph(
         &self,
         from_seqno: u32,
@@ -1114,6 +1207,20 @@ impl BlocksCacheData for ShardBlocksCacheData {
     fn on_insert_received(&mut self, _: &BlockCacheEntry) -> Result<Self::NewReceived> {
         Ok(())
     }
+}
+
+pub(super) struct CachedMcBlockSubgraphView {
+    pub block_id: BlockId,
+    pub ref_by_mc_seqno: u32,
+    pub queue_diff: QueueDiffStuff,
+    pub top_shard_blocks: Vec<CachedShardBlockView>,
+    pub missing_top_shard_block: Option<BlockCacheKey>,
+}
+
+pub(super) struct CachedShardBlockView {
+    pub block_id: BlockId,
+    pub ref_by_mc_seqno: u32,
+    pub queue_diff: QueueDiffStuff,
 }
 
 struct ReceivedBlockContext {

--- a/collator/src/manager/blocks_cache.rs
+++ b/collator/src/manager/blocks_cache.rs
@@ -535,138 +535,131 @@ impl BlocksCache {
         &self,
         from_seqno: u32,
     ) -> Result<Option<CachedMcBlockSubgraphView>> {
-        // get master blocks keys from cache
-        let keys: Vec<_> = self.inner.masters.lock().blocks.keys().copied().collect();
+        // build master block view
+        let (mut subgraph_view, top_shard_blocks_info) = {
+            let guard = self.inner.masters.lock();
+            let Some(mc_block_entry) = guard
+                .blocks
+                .range(from_seqno..)
+                .find(|(_, entry)| {
+                    matches!(
+                        entry.data,
+                        BlockCacheEntryData::Received { .. }
+                            | BlockCacheEntryData::Collated {
+                                received_after_collation: true,
+                                ..
+                            }
+                    )
+                })
+                .map(|(_, entry)| entry)
+            else {
+                return Ok(None);
+            };
 
-        for key in keys {
-            // skip blocks before the from boundary
-            if key < from_seqno {
+            let subgraph_view = CachedMcBlockSubgraphView {
+                block_id: mc_block_entry.block_id,
+                ref_by_mc_seqno: mc_block_entry.ref_by_mc_seqno,
+                queue_diff: match &mc_block_entry.data {
+                    BlockCacheEntryData::Received { queue_diff, .. } => queue_diff.clone(),
+                    BlockCacheEntryData::Collated {
+                        candidate_stuff, ..
+                    } => candidate_stuff.candidate.queue_diff_aug.data.clone(),
+                },
+                top_shard_blocks: vec![],
+                missing_top_shard_block: None,
+            };
+
+            let top_shard_blocks_info = mc_block_entry.top_shard_blocks_info.clone();
+
+            (subgraph_view, top_shard_blocks_info)
+        };
+
+        // try to read top shard blocks data
+        for top_shard_block in top_shard_blocks_info {
+            // skip shard blocks that included in previous master blocks
+            if !top_shard_block.updated
+                || top_shard_block.block.ref_by_mc_seqno <= self.inner.zerostate_mc_seqno
+            {
                 continue;
             }
 
-            // build master block view
-            let (mut subgraph_view, top_shard_blocks_info) = {
-                let guard = self.inner.masters.lock();
-                let Some(mc_block_entry) = guard.blocks.get(&key) else {
-                    bail!("Block cache entry should exist ({})", key)
+            // try get shard block from cache
+            if let Some(shard_cache) = self.inner.shards.get(&top_shard_block.block.block_id.shard)
+                && let Some(sc_block_entry) = shard_cache
+                    .blocks
+                    .get(&top_shard_block.block.block_id.seqno)
+                && sc_block_entry.ref_by_mc_seqno == subgraph_view.block_id.seqno
+            {
+                // get diff
+                let queue_diff = match &sc_block_entry.data {
+                    BlockCacheEntryData::Received { queue_diff, .. } => queue_diff.clone(),
+                    BlockCacheEntryData::Collated {
+                        candidate_stuff, ..
+                    } => candidate_stuff.candidate.queue_diff_aug.data.clone(),
                 };
 
-                // get only received blocks
-                if !matches!(
-                    mc_block_entry.data,
-                    BlockCacheEntryData::Received { .. }
-                        | BlockCacheEntryData::Collated {
-                            received_after_collation: true,
-                            ..
-                        }
-                ) {
-                    continue;
-                }
-
-                let subgraph_view = CachedMcBlockSubgraphView {
-                    block_id: mc_block_entry.block_id,
-                    ref_by_mc_seqno: mc_block_entry.ref_by_mc_seqno,
-                    queue_diff: match &mc_block_entry.data {
-                        BlockCacheEntryData::Received { queue_diff, .. } => queue_diff.clone(),
-                        BlockCacheEntryData::Collated {
-                            candidate_stuff, ..
-                        } => candidate_stuff.candidate.queue_diff_aug.data.clone(),
-                    },
-                    top_shard_blocks: vec![],
-                    missing_top_shard_block: None,
-                };
-
-                let top_shard_blocks_info = mc_block_entry.top_shard_blocks_info.clone();
-
-                (subgraph_view, top_shard_blocks_info)
-            };
-
-            // try to read top shard blocks data
-            for top_shard_block in top_shard_blocks_info {
-                // skip shard blocks that included in previous master blocks
-                if !top_shard_block.updated
-                    || top_shard_block.block.ref_by_mc_seqno <= self.inner.zerostate_mc_seqno
-                {
-                    continue;
-                }
-
-                // try get shard block from cache
-                if let Some(shard_cache) =
-                    self.inner.shards.get(&top_shard_block.block.block_id.shard)
-                    && let Some(sc_block_entry) = shard_cache
-                        .blocks
-                        .get(&top_shard_block.block.block_id.seqno)
-                    && sc_block_entry.ref_by_mc_seqno == subgraph_view.block_id.seqno
-                {
-                    // get diff
-                    let queue_diff = match &sc_block_entry.data {
-                        BlockCacheEntryData::Received { queue_diff, .. } => queue_diff.clone(),
-                        BlockCacheEntryData::Collated {
-                            candidate_stuff, ..
-                        } => candidate_stuff.candidate.queue_diff_aug.data.clone(),
-                    };
-
-                    subgraph_view.top_shard_blocks.push(CachedShardBlockView {
-                        block_id: top_shard_block.block.block_id,
-                        ref_by_mc_seqno: top_shard_block.block.ref_by_mc_seqno,
-                        queue_diff,
-                    });
-                } else {
-                    subgraph_view.missing_top_shard_block =
-                        Some(top_shard_block.block.block_id.as_short_id());
-                    break;
-                }
+                subgraph_view.top_shard_blocks.push(CachedShardBlockView {
+                    block_id: top_shard_block.block.block_id,
+                    ref_by_mc_seqno: top_shard_block.block.ref_by_mc_seqno,
+                    queue_diff,
+                });
+            } else {
+                subgraph_view.missing_top_shard_block =
+                    Some(top_shard_block.block.block_id.as_short_id());
+                break;
             }
-
-            return Ok(Some(subgraph_view));
         }
 
-        Ok(None)
+        Ok(Some(subgraph_view))
     }
 
     pub fn pop_front_applied_mc_block_subgraph(
         &self,
         from_seqno: u32,
     ) -> Result<(McBlockSubgraphExtract, bool)> {
-        let mut extracted_mc_block_entry = None;
-        let mut is_last = true;
-        {
+        let is_last;
+        let mc_block_entry = {
             let mut guard = self.inner.masters.lock();
-            let keys = guard.blocks.keys().copied().collect::<Vec<_>>();
-            for key in keys {
-                if key < from_seqno {
-                    continue;
-                }
-
-                let btree_map::Entry::Occupied(occupied_entry) = guard.blocks.entry(key) else {
-                    bail!("Block cache entry should exist ({})", key)
-                };
-
-                if matches!(
-                    occupied_entry.get().data,
+            let Some(key) = guard.blocks.range(from_seqno..).find_map(|(key, entry)| {
+                matches!(
+                    entry.data,
                     BlockCacheEntryData::Received { .. }
                         | BlockCacheEntryData::Collated {
                             received_after_collation: true,
                             ..
                         }
-                ) {
-                    if extracted_mc_block_entry.is_some() {
-                        is_last = false;
-                        break;
-                    } else {
-                        let mc_block_entry = occupied_entry.remove();
-                        // clean previous last collated blocks ids
-                        guard
-                            .data
-                            .remove_last_collated_block_ids_before(&mc_block_entry.block_id.seqno);
-                        // update range of received blocks
-                        guard.data.move_range_start(mc_block_entry.block_id.seqno);
-                        extracted_mc_block_entry = Some(mc_block_entry);
-                    }
-                }
-            }
-        }
-        let mc_block_entry = extracted_mc_block_entry.unwrap();
+                )
+                .then_some(*key)
+            }) else {
+                bail!(
+                    "Applied master block not found in cache from seqno {}",
+                    from_seqno
+                )
+            };
+
+            is_last = !guard
+                .blocks
+                .range((std::ops::Bound::Excluded(key), std::ops::Bound::Unbounded))
+                .any(|(_, entry)| {
+                    matches!(
+                        entry.data,
+                        BlockCacheEntryData::Received { .. }
+                            | BlockCacheEntryData::Collated {
+                                received_after_collation: true,
+                                ..
+                            }
+                    )
+                });
+
+            let mc_block_entry = guard.blocks.remove(&key).expect("block entry should exist");
+            // clean previous last collated blocks ids
+            guard
+                .data
+                .remove_last_collated_block_ids_before(&mc_block_entry.block_id.seqno);
+            // update range of received blocks
+            guard.data.move_range_start(mc_block_entry.block_id.seqno);
+            mc_block_entry
+        };
         let subgraph_extract = self.extract_mc_block_subgraph(mc_block_entry);
         Ok((subgraph_extract, is_last))
     }

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -500,6 +500,7 @@ where
                             .gc_applied_blocks_with_not_required_diffs(
                                 last_collated_mc_block_id,
                                 applied_range,
+                                None,
                             )
                             .await?;
                         tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
@@ -708,6 +709,7 @@ where
                 .gc_applied_blocks_with_not_required_diffs(
                     store_res.last_collated_mc_block_id,
                     store_res.applied_mc_queue_range,
+                    block_id.is_masterchain().then_some(block_id.seqno),
                 )
                 .await?;
             tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
@@ -1028,6 +1030,7 @@ where
                 .gc_applied_blocks_with_not_required_diffs(
                     store_res.last_collated_mc_block_id,
                     store_res.applied_mc_queue_range,
+                    Some(block_id.seqno),
                 )
                 .await?;
             tracing::debug!(target: tracing_targets::COLLATION_MANAGER,

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -17,6 +17,7 @@ use self::cancel_validation_runner::CancelValidationRunnerState;
 use self::collation_cancel::{ActionAfterCancel, CollationCancelHandle, update_action_after};
 use self::state_event_listener::{ChannelStateEventListener, StateEvent};
 use self::state_update_handler::ProcessMcStateUpdateMode;
+use self::sync::ShouldSyncToAppliedMcBlock;
 use self::types::{
     ActiveCollator, CollatedBlockInfo, CollationState, CollationStatus, CollationSyncState,
     CollatorJoinTask, CollatorState, HandledBlockFromBcCtx, ImportedAnchorEvent, NextCollationStep,
@@ -491,8 +492,23 @@ where
                         .blocks_cache
                         .get_last_collated_block_and_applied_mc_queue_range();
 
-                    // run sync if has applied mc blocks and has not newer received
-                    if !self.has_newer_received_mc_block(applied_range) {
+                    // run sync only if has applied mc blocks and has not newer received
+                    // master block was already received
+                    if self.has_newer_received_mc_block(applied_range) {
+                        // cleanup front applied blocks from cache if their diffs not required to restore queue
+                        let cleanup_res = self
+                            .gc_applied_blocks_with_not_required_diffs(
+                                last_collated_mc_block_id,
+                                applied_range,
+                            )
+                            .await?;
+                        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                            ?cleanup_res,
+                            last_collated_mc_block_id = ?last_collated_mc_block_id,
+                            applied_range = ?applied_range,
+                            "cache cleanup after skipped sync finished",
+                        );
+                    } else {
                         return self
                             .sync_to_applied_mc_block_if_exist(
                                 next_block_id_short,
@@ -683,8 +699,30 @@ where
                 .map(|mc_data| mc_data.prev_key_block_seqno == mc_data.block_id.seqno),
         );
 
+        // cleanup front applied blocks from cache if their diffs not required to restore queue
+        if matches!(
+            should_sync_to_last_applied_mc_block,
+            ShouldSyncToAppliedMcBlock::NoBecauseNewerReceived
+        ) {
+            let cleanup_res = self
+                .gc_applied_blocks_with_not_required_diffs(
+                    store_res.last_collated_mc_block_id,
+                    store_res.applied_mc_queue_range,
+                )
+                .await?;
+            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                ?cleanup_res,
+                last_collated_mc_block_id = ?store_res.last_collated_mc_block_id,
+                applied_range = ?store_res.applied_mc_queue_range,
+                "cache cleanup after skipped sync finished",
+            );
+        }
+
         // run sync or process just collated block
-        if should_sync_to_last_applied_mc_block {
+        if matches!(
+            should_sync_to_last_applied_mc_block,
+            ShouldSyncToAppliedMcBlock::Yes
+        ) {
             // before sync will cancel any active collations
             Ok(HandleTaskResult::with_cancel(
                 ActionAfterCancel::SyncToAppliedMcBlock {
@@ -969,16 +1007,42 @@ where
             } else {
                 self.config.min_mc_block_delta_from_bc_to_sync
             };
-        let should_sync_to_last_applied_mc_block = (is_last_mc_block_in_batch || is_key_block)
-            && self.check_should_sync_to_last_applied_mc_block(
+
+        let should_sync_to_last_applied_mc_block = if is_last_mc_block_in_batch || is_key_block {
+            self.check_should_sync_to_last_applied_mc_block(
                 &store_res,
                 top_mc_block_id_for_next_collation,
                 required_min_mc_block_delta,
                 Some(is_key_block),
+            )
+        } else {
+            ShouldSyncToAppliedMcBlock::No
+        };
+
+        // cleanup front applied blocks from cache if their diffs not required to restore queue
+        if matches!(
+            should_sync_to_last_applied_mc_block,
+            ShouldSyncToAppliedMcBlock::NoBecauseNewerReceived
+        ) {
+            let cleanup_res = self
+                .gc_applied_blocks_with_not_required_diffs(
+                    store_res.last_collated_mc_block_id,
+                    store_res.applied_mc_queue_range,
+                )
+                .await?;
+            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                ?cleanup_res,
+                last_collated_mc_block_id = ?store_res.last_collated_mc_block_id,
+                applied_range = ?store_res.applied_mc_queue_range,
+                "cache cleanup after skipped sync finished",
             );
+        }
 
         // run sync or commit block
-        if should_sync_to_last_applied_mc_block {
+        if matches!(
+            should_sync_to_last_applied_mc_block,
+            ShouldSyncToAppliedMcBlock::Yes
+        ) {
             // should only refresh collation sessions when sync on key block
             let process_state_update_mode = if is_last_mc_block_in_batch {
                 ProcessMcStateUpdateMode::StartCollation {

--- a/collator/src/manager/msgs_queue.rs
+++ b/collator/src/manager/msgs_queue.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
+use std::time::Duration;
 
 use ahash::HashMapExt;
 use anyhow::{Context, Result, bail};
@@ -470,17 +471,29 @@ where
         Ok(QueueDiffRequired::Required)
     }
 
-    #[tracing::instrument(skip_all, fields(from_mc_block_seqno))]
-    pub(super) async fn restore_queue(
-        blocks_cache: &BlocksCache,
-        state_node_adapter: Arc<dyn StateNodeAdapter>,
-        mq_adapter: Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
-        from_mc_block_seqno: u32,
-        min_processed_to_by_shards: BTreeMap<ShardIdent, QueueKey>,
-        before_tail_block_ids: BTreeMap<ShardIdent, (Option<BlockId>, Vec<BlockId>)>,
-        queue_diffs_applied_to_top_blocks: FastHashMap<ShardIdent, u32>,
-    ) -> Result<RestoreQueueResult> {
+    #[tracing::instrument(skip_all, fields(from_mc_block_seqno = ctx.from_mc_block_seqno))]
+    pub(super) async fn restore_queue(ctx: RestoreQueueContext<'_>) -> Result<RestoreQueueResult> {
+        let RestoreQueueContext {
+            blocks_cache,
+            state_node_adapter,
+            mq_adapter,
+            from_mc_block_seqno,
+            min_processed_to_by_shards,
+            before_tail_block_ids,
+            queue_diffs_applied_to_top_blocks,
+            slowdown_restore_queue_ms,
+        } = ctx;
+
         let mut res = RestoreQueueResult::default();
+
+        // HACK: slowdown queue restore when special flag is activated
+        if let Some(slowdown_ms) = slowdown_restore_queue_ms {
+            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                "HACK: slowdown queue restore on {} ms",
+                slowdown_ms,
+            );
+            tokio::time::sleep(Duration::from_millis(slowdown_ms)).await;
+        }
 
         // NOTE: Queue restore is split into two adjacent ranges:
         // - First, find the first applied MC subgraph stored in cache, e.g. MB2 with top shard SB3.
@@ -807,6 +820,17 @@ where
 
         Ok(())
     }
+}
+
+pub(super) struct RestoreQueueContext<'a> {
+    pub blocks_cache: &'a BlocksCache,
+    pub state_node_adapter: Arc<dyn StateNodeAdapter>,
+    pub mq_adapter: Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
+    pub from_mc_block_seqno: u32,
+    pub min_processed_to_by_shards: BTreeMap<ShardIdent, QueueKey>,
+    pub before_tail_block_ids: BTreeMap<ShardIdent, (Option<BlockId>, Vec<BlockId>)>,
+    pub queue_diffs_applied_to_top_blocks: FastHashMap<ShardIdent, u32>,
+    pub slowdown_restore_queue_ms: Option<u64>,
 }
 
 #[derive(Default)]

--- a/collator/src/manager/msgs_queue.rs
+++ b/collator/src/manager/msgs_queue.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result, bail};
 use tycho_block_util::queue::{QueueDiffStuff, QueueKey, QueuePartitionIdx};
 use tycho_block_util::state::ShardStateStuff;
 use tycho_core::storage::LoadStateHint;
-use tycho_types::models::{BlockId, ShardIdent};
+use tycho_types::models::{BlockId, BlockIdShort, ShardIdent};
 use tycho_util::metrics::HistogramGuard;
 use tycho_util::{FastHashMap, FastHashSet};
 
@@ -20,7 +20,9 @@ use crate::internal_queue::types::stats::DiffStatistics;
 use crate::queue_adapter::MessageQueueAdapter;
 use crate::state_node::StateNodeAdapter;
 use crate::tracing_targets;
-use crate::types::processed_upto::{BlockSeqno, ProcessedUptoInfoStuff};
+use crate::types::processed_upto::{
+    BlockSeqno, ProcessedUptoInfoStuff, find_min_processed_to_by_shards,
+};
 use crate::types::{ProcessedTo, ProcessedToByPartitions, TopBlockId, TopBlockIdUpdated};
 use crate::validator::Validator;
 
@@ -86,6 +88,29 @@ where
         Ok(result)
     }
 
+    pub(super) async fn get_queue_restore_processed_to_by_shards(
+        &self,
+        last_applied_mc_block_key: &BlockIdShort,
+    ) -> Result<QueueRestoreProcessedTo> {
+        // get internals processed_to from master and all shards for last applied master block
+        let all_shards_processed_to_by_partitions =
+            Self::get_all_shards_processed_to_by_partitions_for_mc_block(
+                last_applied_mc_block_key,
+                &self.blocks_cache,
+                self.state_node_adapter.clone(),
+            )
+            .await?;
+
+        // find internals min processed_to
+        let min_processed_to_by_shards =
+            find_min_processed_to_by_shards(&all_shards_processed_to_by_partitions);
+
+        Ok(QueueRestoreProcessedTo {
+            all_shards_processed_to_by_partitions,
+            min_processed_to_by_shards,
+        })
+    }
+
     // Returns top master block id upto which all queue diffs applied
     pub(super) fn get_queue_diffs_applied_to_mc_block_id(
         &self,
@@ -110,6 +135,37 @@ where
         };
 
         Ok(mc_block_id)
+    }
+
+    pub(super) async fn get_queue_diffs_applied_to_top_blocks(
+        &self,
+        last_collated_mc_block_id: Option<BlockId>,
+    ) -> Result<Option<FastHashMap<ShardIdent, BlockSeqno>>> {
+        if !self.config.fast_sync {
+            return Ok(None);
+        }
+
+        let Some(applied_to_mc_block_id) =
+            self.get_queue_diffs_applied_to_mc_block_id(last_collated_mc_block_id)?
+        else {
+            // BACKWARD COMPATIBILITY: `last_committed_mc_block_id` will not exist in queue storage
+            // in previous version. We will receive None and will use all required diffs to restore the queue
+            return Ok(None);
+        };
+
+        // NOTE: when the node started to sync from a persistent state with a bunch of archives after it,
+        //      the `last_collated_mc_block_id` will be None, and `applied_to_mc_block_id` will be equal
+        //      to the top block of the persistent state - init block. But the persistent state can be already
+        //      removed because of the long history after it when collator starts to sync by recent blocks.
+        //      So we will not able to read top blocks ids and will fallback the full sync.
+
+        // collect top blocks queue diffs already applied to
+        Self::get_top_blocks_seqno(
+            &applied_to_mc_block_id,
+            &self.blocks_cache,
+            self.state_node_adapter.clone(),
+        )
+        .await
     }
 
     /// Returns false when any of top block diffs is required or unable to check
@@ -660,6 +716,12 @@ pub(crate) struct RestoreQueueResult {
     pub prev_mc_block_id: Option<BlockId>,
     pub synced_to_blocks_keys: Vec<BlockCacheKey>,
     pub applied_diffs_ids: FastHashSet<BlockId>,
+}
+
+pub(super) struct QueueRestoreProcessedTo {
+    pub all_shards_processed_to_by_partitions:
+        FastHashMap<ShardIdent, (bool, ProcessedToByPartitions)>,
+    pub min_processed_to_by_shards: ProcessedTo,
 }
 
 enum QueueDiffRequired {

--- a/collator/src/manager/msgs_queue.rs
+++ b/collator/src/manager/msgs_queue.rs
@@ -238,34 +238,29 @@ where
     ) -> Result<QueueDiffRequired> {
         let block_id = queue_diff.block_id();
 
-        if ref_by_mc_seqno <= zerostate_mc_seqno {
-            return Ok(QueueDiffRequired::NotRequired);
+        let check_res = Self::check_queue_diff_boundaries(
+            *block_id,
+            ref_by_mc_seqno,
+            queue_diffs_applied_to_top_blocks,
+            init_mc_block_id,
+            zerostate_mc_seqno,
+            true,
+            false,
+        );
+        if check_res.is_not_required() {
+            return Ok(check_res);
         }
 
-        if let Some(init_mc_block_id) = init_mc_block_id {
-            assert!(
-                ref_by_mc_seqno >= init_mc_block_id.seqno,
-                "cached block {} ref_by_mc_seqno {} is below init master block {}",
-                block_id,
-                ref_by_mc_seqno,
-                init_mc_block_id,
-            );
-            if ref_by_mc_seqno == init_mc_block_id.seqno {
-                return Ok(QueueDiffRequired::NotRequired);
-            }
-        }
+        Self::check_loaded_queue_diff_required(mq_adapter, queue_diff, min_processed_to, true)
+    }
 
-        if let Some(queue_diff_applied_to_top_block_seqno) =
-            queue_diffs_applied_to_top_blocks.get(&block_id.shard)
-            && block_id.seqno <= *queue_diff_applied_to_top_block_seqno
-        {
-            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                queue_diff_block_id = %block_id.as_short_id(),
-                top_applied_seqno = queue_diff_applied_to_top_block_seqno,
-                "queue diff is not required because it is below top applied",
-            );
-            return Ok(QueueDiffRequired::NotRequired);
-        }
+    fn check_loaded_queue_diff_required(
+        mq_adapter: &Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
+        queue_diff: &QueueDiffStuff,
+        min_processed_to: Option<&QueueKey>,
+        check_diff_exists: bool,
+    ) -> Result<QueueDiffRequired> {
+        let block_id = queue_diff.block_id();
 
         let Some(min_processed_to) = min_processed_to else {
             tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
@@ -287,7 +282,7 @@ where
             return Ok(QueueDiffRequired::NotRequired);
         }
 
-        if mq_adapter.is_diff_exists(&block_id.as_short_id())? {
+        if check_diff_exists && mq_adapter.is_diff_exists(&block_id.as_short_id())? {
             tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
                 queue_diff_block_id = %block_id.as_short_id(),
                 "queue diff will be skipped because it is already applied",
@@ -297,11 +292,180 @@ where
 
         tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
             block_id = %block_id.as_short_id(),
-            ref_by_mc_seqno,
             max_message = %queue_diff.as_ref().max_message,
             min_processed_to = %min_processed_to,
             "block diff is required to restore queue",
         );
+
+        Ok(QueueDiffRequired::Required)
+    }
+
+    fn check_queue_diff_boundaries(
+        block_id: BlockId,
+        ref_by_mc_seqno: BlockSeqno,
+        queue_diffs_applied_to_top_blocks: &FastHashMap<ShardIdent, BlockSeqno>,
+        init_mc_block_id: Option<BlockId>,
+        zerostate_mc_seqno: BlockSeqno,
+        assert_not_below_init: bool,
+        check_sequence_after_init: bool,
+    ) -> QueueDiffRequired {
+        let check_res = Self::check_queue_diff_boundaries_with_ref_by_mc(
+            block_id,
+            ref_by_mc_seqno,
+            init_mc_block_id,
+            zerostate_mc_seqno,
+            assert_not_below_init,
+            check_sequence_after_init,
+        );
+        if check_res.is_not_required() {
+            return check_res;
+        }
+
+        if let Some(check_res) =
+            Self::check_queue_diff_by_applied_boundary(block_id, queue_diffs_applied_to_top_blocks)
+        {
+            return check_res;
+        }
+
+        QueueDiffRequired::Required
+    }
+
+    fn check_queue_diff_boundaries_with_ref_by_mc(
+        block_id: BlockId,
+        ref_by_mc_seqno: BlockSeqno,
+        init_mc_block_id: Option<BlockId>,
+        zerostate_mc_seqno: BlockSeqno,
+        assert_not_below_init: bool,
+        check_sequence_after_init: bool,
+    ) -> QueueDiffRequired {
+        if check_sequence_after_init
+            && let Some(init_mc_block_id) = init_mc_block_id
+            && ref_by_mc_seqno <= init_mc_block_id.seqno
+        {
+            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                queue_diff_block_id = %block_id.as_short_id(),
+                init_mc_block_id = %init_mc_block_id.as_short_id(),
+                "queue diff is not required because it is below init block from persistent state",
+            );
+            return QueueDiffRequired::NotRequiredCheckSequence;
+        }
+
+        if ref_by_mc_seqno <= zerostate_mc_seqno {
+            return QueueDiffRequired::NotRequired;
+        }
+
+        if let Some(init_mc_block_id) = init_mc_block_id {
+            if assert_not_below_init {
+                assert!(
+                    ref_by_mc_seqno >= init_mc_block_id.seqno,
+                    "cached block {} ref_by_mc_seqno {} is below init master block {}",
+                    block_id,
+                    ref_by_mc_seqno,
+                    init_mc_block_id,
+                );
+            }
+            if ref_by_mc_seqno <= init_mc_block_id.seqno {
+                tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                    queue_diff_block_id = %block_id.as_short_id(),
+                    init_mc_block_id = %init_mc_block_id.as_short_id(),
+                    "queue diff is not required because it is below init block from persistent state",
+                );
+                if check_sequence_after_init {
+                    return QueueDiffRequired::NotRequiredCheckSequence;
+                }
+                return QueueDiffRequired::NotRequired;
+            }
+        }
+
+        QueueDiffRequired::Required
+    }
+
+    fn check_queue_diff_by_applied_boundary(
+        block_id: BlockId,
+        queue_diffs_applied_to_top_blocks: &FastHashMap<ShardIdent, BlockSeqno>,
+    ) -> Option<QueueDiffRequired> {
+        if let Some(queue_diff_applied_to_top_block_seqno) =
+            queue_diffs_applied_to_top_blocks.get(&block_id.shard)
+            && block_id.seqno <= *queue_diff_applied_to_top_block_seqno
+        {
+            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                queue_diff_block_id = %block_id.as_short_id(),
+                top_applied_seqno = queue_diff_applied_to_top_block_seqno,
+                "queue diff is not required because it is below top applied",
+            );
+            return Some(QueueDiffRequired::NotRequired);
+        }
+
+        None
+    }
+
+    async fn check_stored_queue_diff_preload_required(
+        state_node_adapter: &dyn StateNodeAdapter,
+        mq_adapter: &Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
+        block_id: &BlockId,
+        queue_diffs_applied_to_top_blocks: &FastHashMap<ShardIdent, BlockSeqno>,
+        init_mc_block_id: Option<BlockId>,
+        init_mc_block_reached_on: &mut FastHashMap<ShardIdent, BlockSeqno>,
+    ) -> Result<QueueDiffRequired> {
+        // NOTE: We don't skip prev block ids for shard zerostates because
+        // it is quite hard to propagate `ref_by_mc_seqno` here (we construct
+        // prev ids based just on `BlockId` here). There seems to be no problems
+        // with that because we are checking `init_mc_block_reached` using
+        // the handle data so zerostate ids will be skipped in any case.
+        // This check is just to not change the old behavior just in case.
+        if block_id.seqno == 0
+            || block_id.is_masterchain()
+                && block_id.seqno <= state_node_adapter.zerostate_id().seqno
+        {
+            return Ok(QueueDiffRequired::NotRequired);
+        }
+
+        if let Some(check_res) =
+            Self::check_queue_diff_by_applied_boundary(*block_id, queue_diffs_applied_to_top_blocks)
+        {
+            return Ok(check_res);
+        }
+
+        if let Some(init_mc_block_id) = init_mc_block_id {
+            let ref_by_mc_seqno = if block_id.is_masterchain() {
+                block_id.seqno
+            } else if matches!(
+                init_mc_block_reached_on.get(&block_id.shard),
+                Some(reached_seqno) if block_id.seqno <= *reached_seqno,
+            ) {
+                init_mc_block_id.seqno
+            } else {
+                // for shard block we should check it's `ref_by_mc_seqno`
+                let ref_by_mc_seqno = state_node_adapter
+                    .get_ref_by_mc_seqno(block_id)
+                    .await?
+                    .unwrap();
+                if ref_by_mc_seqno <= init_mc_block_id.seqno {
+                    init_mc_block_reached_on.insert(block_id.shard, block_id.seqno);
+                }
+                ref_by_mc_seqno
+            };
+
+            let check_res = Self::check_queue_diff_boundaries_with_ref_by_mc(
+                *block_id,
+                ref_by_mc_seqno,
+                Some(init_mc_block_id),
+                state_node_adapter.zerostate_id().seqno,
+                false,
+                true,
+            );
+            if check_res.is_not_required() {
+                return Ok(check_res);
+            }
+        }
+
+        if mq_adapter.is_diff_exists(&block_id.as_short_id())? {
+            tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
+                queue_diff_block_id = %block_id.as_short_id(),
+                "previous queue diff apply skipped because it is already applied",
+            );
+            return Ok(QueueDiffRequired::AlreadyApplied);
+        }
 
         Ok(QueueDiffRequired::Required)
     }
@@ -340,87 +504,23 @@ where
             let mut prev_block_ids: VecDeque<_> = prev_block_ids.iter().cloned().collect();
 
             while let Some(prev_block_id) = prev_block_ids.pop_front() {
-                // NOTE: We don't skip prev block ids for shard zerostates because
-                // it is quite hard to propagate `ref_by_mc_seqno` here (we construct
-                // prev ids based just on `BlockId` here). There seems to be no problems
-                // with that because we are checking `init_mc_block_reached` using
-                // the handle data so zerostate ids will be skipped in any case.
-                // This check is just to not change the old behavior just in case.
-                if prev_block_id.seqno == 0
-                    || prev_block_id.is_masterchain()
-                        && prev_block_id.seqno <= state_node_adapter.zerostate_id().seqno
+                match Self::check_stored_queue_diff_preload_required(
+                    state_node_adapter.as_ref(),
+                    &mq_adapter,
+                    &prev_block_id,
+                    &queue_diffs_applied_to_top_blocks,
+                    init_mc_block_id,
+                    &mut init_mc_block_reached_on,
+                )
+                .await?
                 {
-                    continue;
-                }
-
-                // if diff is below top applied then skip
-                if let Some(border) = queue_diffs_applied_to_top_blocks.get(shard_id)
-                    && prev_block_id.seqno <= *border
-                {
-                    tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                        prev_block_id = %prev_block_id.as_short_id(),
-                        top_applied_seqno = border,
-                        "previous queue diff skipped because it below top applied",
-                    );
-                    continue;
-                }
-
-                // if diff is before init block (from persistent state)
-                // we do not need to apply it because queue was already restored from persistent
-                if let Some(init_mc_block_id) = init_mc_block_id {
-                    let mut skip_diff = false;
-                    if prev_block_id.is_masterchain() {
-                        if prev_block_id.seqno <= init_mc_block_id.seqno {
-                            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                                prev_block_id = %prev_block_id.as_short_id(),
-                                init_mc_block_id = %init_mc_block_id.as_short_id(),
-                                "master block queue diff apply skipped because it is below init block from persistent state",
-                            );
-                            skip_diff = true;
-                        }
-                    } else {
-                        // check if we already reached init mc block before
-                        let mut init_mc_block_reached = matches!(
-                            init_mc_block_reached_on.get(&prev_block_id.shard),
-                            Some(reached_seqno) if prev_block_id.seqno <= *reached_seqno,
-                        );
-                        if !init_mc_block_reached {
-                            // for shard block we should check it's `ref_by_mc_seqno`
-                            let prev_ref_by_mc_seqno = state_node_adapter
-                                .get_ref_by_mc_seqno(&prev_block_id)
-                                .await?
-                                .unwrap();
-                            init_mc_block_reached = prev_ref_by_mc_seqno <= init_mc_block_id.seqno;
-                            if init_mc_block_reached {
-                                init_mc_block_reached_on
-                                    .insert(prev_block_id.shard, prev_block_id.seqno);
-                            }
-                        }
-                        if init_mc_block_reached {
-                            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                                prev_block_id = %prev_block_id.as_short_id(),
-                                init_mc_block_id = %init_mc_block_id.as_short_id(),
-                                "shard block queue diff apply skipped because it is below init block from persistent state",
-                            );
-                            skip_diff = true;
-                        }
-                    }
-                    if skip_diff {
-                        // if current diff is below init block
-                        // then we should check sequense for each next diff
+                    QueueDiffRequired::NotRequired => continue,
+                    QueueDiffRequired::AlreadyApplied
+                    | QueueDiffRequired::NotRequiredCheckSequence => {
                         first_required_diffs.insert(prev_block_id.shard, BlockId::default());
                         continue;
                     }
-                }
-
-                // skip already applied diff
-                if mq_adapter.is_diff_exists(&prev_block_id.as_short_id())? {
-                    tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
-                        queue_diff_block_id = %prev_block_id.as_short_id(),
-                        "previous queue diff apply skipped because it is already applied",
-                    );
-                    first_required_diffs.insert(prev_block_id.shard, BlockId::default());
-                    continue;
+                    QueueDiffRequired::Required | QueueDiffRequired::Unknown => {}
                 }
 
                 // load diff to check if it is required
@@ -439,15 +539,13 @@ where
 
                     return Ok(res);
                 };
-                let diff_required = &queue_diff_stuff.as_ref().max_message > min_processed_to;
-                tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                    diff_block_id = %prev_block_id.as_short_id(),
-                    diff_required,
-                    max_message = %queue_diff_stuff.as_ref().max_message,
-                    min_processed_to = %min_processed_to,
-                    "check if diff required to restore queue working state on sync:",
-                );
-                if diff_required {
+                let check_res = Self::check_loaded_queue_diff_required(
+                    &mq_adapter,
+                    &queue_diff_stuff,
+                    Some(min_processed_to),
+                    false,
+                )?;
+                if !check_res.is_not_required() {
                     // if next diff is not required
                     // then current will be the first required
                     first_required_diffs.insert(prev_block_id.shard, prev_block_id);
@@ -614,7 +712,9 @@ where
             init_mc_block_id,
             zerostate_mc_seqno,
         )? {
-            QueueDiffRequired::NotRequired => return Ok(None),
+            QueueDiffRequired::NotRequired | QueueDiffRequired::NotRequiredCheckSequence => {
+                return Ok(None);
+            }
             QueueDiffRequired::AlreadyApplied => {
                 // if diff for block from bc already applied
                 // then we should check sequense for each next diff
@@ -727,6 +827,8 @@ pub(super) struct QueueRestoreProcessedTo {
 enum QueueDiffRequired {
     Required,
     NotRequired,
+    // also means not required, but restore must check the sequence for the next diff
+    NotRequiredCheckSequence,
     // also means not required, but restore must update `first_required_diffs` for already applied diffs
     AlreadyApplied,
     Unknown,
@@ -734,6 +836,9 @@ enum QueueDiffRequired {
 
 impl QueueDiffRequired {
     fn is_not_required(&self) -> bool {
-        matches!(self, Self::NotRequired | Self::AlreadyApplied)
+        matches!(
+            self,
+            Self::NotRequired | Self::NotRequiredCheckSequence | Self::AlreadyApplied
+        )
     }
 }

--- a/collator/src/manager/msgs_queue.rs
+++ b/collator/src/manager/msgs_queue.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use ahash::HashMapExt;
 use anyhow::{Context, Result, bail};
-use tycho_block_util::queue::{QueueKey, QueuePartitionIdx};
+use tycho_block_util::queue::{QueueDiffStuff, QueueKey, QueuePartitionIdx};
 use tycho_block_util::state::ShardStateStuff;
 use tycho_core::storage::LoadStateHint;
 use tycho_types::models::{BlockId, ShardIdent};
@@ -11,7 +11,7 @@ use tycho_util::metrics::HistogramGuard;
 use tycho_util::{FastHashMap, FastHashSet};
 
 use super::CollationManager;
-use super::blocks_cache::BlocksCache;
+use super::blocks_cache::{BlocksCache, CachedMcBlockSubgraphView};
 use super::types::{BlockCacheEntry, BlockCacheEntryData, BlockCacheKey, McBlockSubgraphExtract};
 use crate::collator::CollatorFactory;
 use crate::internal_queue::types::diff::{DiffZone, QueueDiffWithMessages};
@@ -20,8 +20,8 @@ use crate::internal_queue::types::stats::DiffStatistics;
 use crate::queue_adapter::MessageQueueAdapter;
 use crate::state_node::StateNodeAdapter;
 use crate::tracing_targets;
-use crate::types::processed_upto::ProcessedUptoInfoStuff;
-use crate::types::{ProcessedToByPartitions, TopBlockId, TopBlockIdUpdated};
+use crate::types::processed_upto::{BlockSeqno, ProcessedUptoInfoStuff};
+use crate::types::{ProcessedTo, ProcessedToByPartitions, TopBlockId, TopBlockIdUpdated};
 use crate::validator::Validator;
 
 impl<CF, V> CollationManager<CF, V>
@@ -112,6 +112,109 @@ where
         Ok(mc_block_id)
     }
 
+    /// Returns false when any of top block diffs is required or unable to check
+    pub(super) async fn check_top_blocks_diffs_not_required(
+        mq_adapter: &Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
+        mc_block_subgraph_view: &CachedMcBlockSubgraphView,
+        min_processed_to_by_shards: &ProcessedTo,
+        queue_diffs_applied_to_top_blocks: &FastHashMap<ShardIdent, BlockSeqno>,
+        init_mc_block_id: Option<BlockId>,
+        zerostate_mc_seqno: BlockSeqno,
+    ) -> Result<bool> {
+        // if top shard block is missing for any reason
+        // we unable to check if his diff required,
+        // so will not cleanup cache in this case
+        if let Some(missing_top_shard_block) = mc_block_subgraph_view.missing_top_shard_block {
+            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                mc_block_id = %mc_block_subgraph_view.block_id.as_short_id(),
+                %missing_top_shard_block,
+                "skip cache cleanup because top shard block is missing in cache",
+            );
+            return Ok(false);
+        }
+
+        let check_block = |block_id: BlockId,
+                           ref_by_mc_seqno: u32,
+                           queue_diff: &QueueDiffStuff|
+         -> Result<Option<bool>> {
+            if ref_by_mc_seqno <= zerostate_mc_seqno {
+                return Ok(Some(false));
+            }
+
+            if let Some(init_mc_block_id) = init_mc_block_id
+                && ref_by_mc_seqno <= init_mc_block_id.seqno
+            {
+                return Ok(Some(false));
+            }
+
+            if let Some(queue_diff_applied_to_top_block_seqno) =
+                queue_diffs_applied_to_top_blocks.get(&block_id.shard)
+                && block_id.seqno <= *queue_diff_applied_to_top_block_seqno
+            {
+                return Ok(Some(false));
+            }
+
+            let Some(min_processed_to) = min_processed_to_by_shards.get(&block_id.shard) else {
+                tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                    block_id = %block_id.as_short_id(),
+                    shard = %block_id.shard,
+                    "unable to check if diff required for queue restore \
+                    because processed_to data for the shard is incomplete",
+                );
+                return Ok(None);
+            };
+
+            if queue_diff.as_ref().max_message <= *min_processed_to {
+                return Ok(Some(false));
+            }
+
+            if mq_adapter.is_diff_exists(&block_id.as_short_id())? {
+                return Ok(Some(false));
+            }
+
+            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                block_id = %block_id.as_short_id(),
+                ref_by_mc_seqno,
+                max_message = %queue_diff.as_ref().max_message,
+                min_processed_to = %min_processed_to,
+                "top block diff is required to restore queue",
+            );
+
+            Ok(Some(true))
+        };
+
+        // check master block diff
+        if matches!(
+            check_block(
+                mc_block_subgraph_view.block_id,
+                mc_block_subgraph_view.ref_by_mc_seqno,
+                &mc_block_subgraph_view.queue_diff,
+            )?,
+            None | Some(true)
+        ) {
+            // return earlier and do not check shard blocks
+            // if master block diff is required or unable to check
+            return Ok(false);
+        }
+
+        // check if shard blocks diffs are required
+        for top_shard_block in &mc_block_subgraph_view.top_shard_blocks {
+            if matches!(
+                check_block(
+                    top_shard_block.block_id,
+                    top_shard_block.ref_by_mc_seqno,
+                    &top_shard_block.queue_diff,
+                )?,
+                None | Some(true)
+            ) {
+                // return earlier if any of shard block diff is required or unable to check
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
     #[tracing::instrument(skip_all, fields(from_mc_block_seqno))]
     pub(super) async fn restore_queue(
         blocks_cache: &BlocksCache,
@@ -123,6 +226,14 @@ where
         queue_diffs_applied_to_top_blocks: FastHashMap<ShardIdent, u32>,
     ) -> Result<RestoreQueueResult> {
         let mut res = RestoreQueueResult::default();
+
+        // NOTE: Queue restore is split into two adjacent ranges:
+        // - First, find the first applied MC subgraph stored in cache, e.g. MB2 with top shard SB3.
+        // - Then collect block ids immediately before that subgraph, e.g. MB1 and SB2.
+        // - Walk backwards from those before-tail blocks through storage and apply required historical diffs.
+        // - After that, pop applied MC subgraphs from cache starting from MB2 and apply required cached diffs forward.
+        // These ranges should not overlap: storage diffs restore the queue before the cached applied range,
+        // and cached diffs advance it through the applied range.
 
         // load init block (from persistent state) to check if required diff was already applied from persistent
         let init_mc_block_id = state_node_adapter.load_init_block_id();
@@ -209,6 +320,16 @@ where
                         first_required_diffs.insert(prev_block_id.shard, BlockId::default());
                         continue;
                     }
+                }
+
+                // skip already applied diff
+                if mq_adapter.is_diff_exists(&prev_block_id.as_short_id())? {
+                    tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
+                        queue_diff_block_id = %prev_block_id.as_short_id(),
+                        "previous queue diff apply skipped because it is already applied",
+                    );
+                    first_required_diffs.insert(prev_block_id.shard, BlockId::default());
+                    continue;
                 }
 
                 // load diff to check if it is required

--- a/collator/src/manager/msgs_queue.rs
+++ b/collator/src/manager/msgs_queue.rs
@@ -133,65 +133,18 @@ where
             return Ok(false);
         }
 
-        let check_block = |block_id: BlockId,
-                           ref_by_mc_seqno: u32,
-                           queue_diff: &QueueDiffStuff|
-         -> Result<Option<bool>> {
-            if ref_by_mc_seqno <= zerostate_mc_seqno {
-                return Ok(Some(false));
-            }
-
-            if let Some(init_mc_block_id) = init_mc_block_id
-                && ref_by_mc_seqno <= init_mc_block_id.seqno
-            {
-                return Ok(Some(false));
-            }
-
-            if let Some(queue_diff_applied_to_top_block_seqno) =
-                queue_diffs_applied_to_top_blocks.get(&block_id.shard)
-                && block_id.seqno <= *queue_diff_applied_to_top_block_seqno
-            {
-                return Ok(Some(false));
-            }
-
-            let Some(min_processed_to) = min_processed_to_by_shards.get(&block_id.shard) else {
-                tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                    block_id = %block_id.as_short_id(),
-                    shard = %block_id.shard,
-                    "unable to check if diff required for queue restore \
-                    because processed_to data for the shard is incomplete",
-                );
-                return Ok(None);
-            };
-
-            if queue_diff.as_ref().max_message <= *min_processed_to {
-                return Ok(Some(false));
-            }
-
-            if mq_adapter.is_diff_exists(&block_id.as_short_id())? {
-                return Ok(Some(false));
-            }
-
-            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                block_id = %block_id.as_short_id(),
-                ref_by_mc_seqno,
-                max_message = %queue_diff.as_ref().max_message,
-                min_processed_to = %min_processed_to,
-                "top block diff is required to restore queue",
-            );
-
-            Ok(Some(true))
-        };
-
         // check master block diff
-        if matches!(
-            check_block(
-                mc_block_subgraph_view.block_id,
-                mc_block_subgraph_view.ref_by_mc_seqno,
-                &mc_block_subgraph_view.queue_diff,
-            )?,
-            None | Some(true)
-        ) {
+        if !Self::check_queue_diff_required(
+            mq_adapter,
+            &mc_block_subgraph_view.queue_diff,
+            mc_block_subgraph_view.ref_by_mc_seqno,
+            min_processed_to_by_shards.get(&mc_block_subgraph_view.block_id.shard),
+            queue_diffs_applied_to_top_blocks,
+            init_mc_block_id,
+            zerostate_mc_seqno,
+        )?
+        .is_not_required()
+        {
             // return earlier and do not check shard blocks
             // if master block diff is required or unable to check
             return Ok(false);
@@ -199,20 +152,102 @@ where
 
         // check if shard blocks diffs are required
         for top_shard_block in &mc_block_subgraph_view.top_shard_blocks {
-            if matches!(
-                check_block(
-                    top_shard_block.block_id,
-                    top_shard_block.ref_by_mc_seqno,
-                    &top_shard_block.queue_diff,
-                )?,
-                None | Some(true)
-            ) {
+            if !Self::check_queue_diff_required(
+                mq_adapter,
+                &top_shard_block.queue_diff,
+                top_shard_block.ref_by_mc_seqno,
+                min_processed_to_by_shards.get(&top_shard_block.block_id.shard),
+                queue_diffs_applied_to_top_blocks,
+                init_mc_block_id,
+                zerostate_mc_seqno,
+            )?
+            .is_not_required()
+            {
                 // return earlier if any of shard block diff is required or unable to check
                 return Ok(false);
             }
         }
 
         Ok(true)
+    }
+
+    fn check_queue_diff_required(
+        mq_adapter: &Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
+        queue_diff: &QueueDiffStuff,
+        ref_by_mc_seqno: BlockSeqno,
+        min_processed_to: Option<&QueueKey>,
+        queue_diffs_applied_to_top_blocks: &FastHashMap<ShardIdent, BlockSeqno>,
+        init_mc_block_id: Option<BlockId>,
+        zerostate_mc_seqno: BlockSeqno,
+    ) -> Result<QueueDiffRequired> {
+        let block_id = queue_diff.block_id();
+
+        if ref_by_mc_seqno <= zerostate_mc_seqno {
+            return Ok(QueueDiffRequired::NotRequired);
+        }
+
+        if let Some(init_mc_block_id) = init_mc_block_id {
+            assert!(
+                ref_by_mc_seqno >= init_mc_block_id.seqno,
+                "cached block {} ref_by_mc_seqno {} is below init master block {}",
+                block_id,
+                ref_by_mc_seqno,
+                init_mc_block_id,
+            );
+            if ref_by_mc_seqno == init_mc_block_id.seqno {
+                return Ok(QueueDiffRequired::NotRequired);
+            }
+        }
+
+        if let Some(queue_diff_applied_to_top_block_seqno) =
+            queue_diffs_applied_to_top_blocks.get(&block_id.shard)
+            && block_id.seqno <= *queue_diff_applied_to_top_block_seqno
+        {
+            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                queue_diff_block_id = %block_id.as_short_id(),
+                top_applied_seqno = queue_diff_applied_to_top_block_seqno,
+                "queue diff is not required because it is below top applied",
+            );
+            return Ok(QueueDiffRequired::NotRequired);
+        }
+
+        let Some(min_processed_to) = min_processed_to else {
+            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                block_id = %block_id.as_short_id(),
+                shard = %block_id.shard,
+                "unable to check if diff required for queue restore \
+                because processed_to data for the shard is incomplete",
+            );
+            return Ok(QueueDiffRequired::Unknown);
+        };
+
+        if queue_diff.as_ref().max_message <= *min_processed_to {
+            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+                queue_diff_block_id = %block_id.as_short_id(),
+                "queue diff is not required: max_message {} <= min_processed_to {}",
+                queue_diff.as_ref().max_message,
+                min_processed_to,
+            );
+            return Ok(QueueDiffRequired::NotRequired);
+        }
+
+        if mq_adapter.is_diff_exists(&block_id.as_short_id())? {
+            tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
+                queue_diff_block_id = %block_id.as_short_id(),
+                "queue diff will be skipped because it is already applied",
+            );
+            return Ok(QueueDiffRequired::AlreadyApplied);
+        }
+
+        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
+            block_id = %block_id.as_short_id(),
+            ref_by_mc_seqno,
+            max_message = %queue_diff.as_ref().max_message,
+            min_processed_to = %min_processed_to,
+            "block diff is required to restore queue",
+        );
+
+        Ok(QueueDiffRequired::Required)
     }
 
     #[tracing::instrument(skip_all, fields(from_mc_block_seqno))]
@@ -442,28 +477,17 @@ where
                     .into_iter()
                     .chain(subgraph.shard_blocks.iter())
                 {
-                    // if diff is below top applied then skip
-                    if let Some(border) =
-                        queue_diffs_applied_to_top_blocks.get(&block_entry.block_id.shard)
-                        && block_entry.block_id.seqno <= *border
-                    {
-                        tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                            received_block_id = %block_entry.block_id.as_short_id(),
-                            top_applied_seqno = border,
-                            "queue diff apply skipped because it is below top applied",
-                        );
-                        continue;
-                    }
-
                     let min_processed_to =
                         min_processed_to_by_shards.get(&block_entry.block_id.shard);
 
                     if let Some(applied_diff_block_id) =
                         Self::apply_block_queue_diff_from_entry_stuff(
-                            state_node_adapter.as_ref(),
                             mq_adapter.clone(),
                             block_entry,
                             min_processed_to,
+                            &queue_diffs_applied_to_top_blocks,
+                            init_mc_block_id,
+                            state_node_adapter.zerostate_id().seqno,
                             &mut first_required_diffs,
                         )?
                     {
@@ -508,18 +532,15 @@ where
     /// Returns `BlockId` if diff was applied.
     /// * `first_required_diffs` - contains ids of known first required diffs for queue for each shard
     fn apply_block_queue_diff_from_entry_stuff(
-        state_node_adapter: &dyn StateNodeAdapter,
         mq_adapter: Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
         block_entry: &BlockCacheEntry,
         min_processed_to: Option<&QueueKey>,
+        queue_diffs_applied_to_top_blocks: &FastHashMap<ShardIdent, BlockSeqno>,
+        init_mc_block_id: Option<BlockId>,
+        zerostate_mc_seqno: BlockSeqno,
         first_required_diffs: &mut FastHashMap<ShardIdent, BlockId>,
     ) -> Result<Option<BlockId>> {
         let block_id = block_entry.block_id;
-
-        // TODO: error if <
-        if block_entry.ref_by_mc_seqno <= state_node_adapter.zerostate_id().seqno {
-            return Ok(None);
-        }
 
         let queue_diff = match &block_entry.data {
             BlockCacheEntryData::Collated {
@@ -528,29 +549,23 @@ where
             BlockCacheEntryData::Received { queue_diff, .. } => queue_diff,
         };
 
-        // skip diff below min processed to
-        if let Some(min_pt) = min_processed_to
-            && queue_diff.as_ref().max_message <= *min_pt
-        {
-            tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-                "Skipping diff for block {}: max_message {} <= min_processed_to {}",
-                block_id.as_short_id(),
-                queue_diff.as_ref().max_message,
-                min_pt,
-            );
-            return Ok(None);
-        }
-
-        // skip already applied diff
-        if mq_adapter.is_diff_exists(&block_id.as_short_id())? {
-            tracing::trace!(target: tracing_targets::COLLATION_MANAGER,
-                queue_diff_block_id = %block_id.as_short_id(),
-                "queue diff apply skipped because it is already applied",
-            );
-            // if diff for block from bc already applied
-            // then we should check sequense for each next diff
-            first_required_diffs.insert(block_id.shard, BlockId::default());
-            return Ok(None);
+        match Self::check_queue_diff_required(
+            &mq_adapter,
+            queue_diff,
+            block_entry.ref_by_mc_seqno,
+            min_processed_to,
+            queue_diffs_applied_to_top_blocks,
+            init_mc_block_id,
+            zerostate_mc_seqno,
+        )? {
+            QueueDiffRequired::NotRequired => return Ok(None),
+            QueueDiffRequired::AlreadyApplied => {
+                // if diff for block from bc already applied
+                // then we should check sequense for each next diff
+                first_required_diffs.insert(block_id.shard, BlockId::default());
+                return Ok(None);
+            }
+            QueueDiffRequired::Required | QueueDiffRequired::Unknown => {}
         }
 
         // load out_msg
@@ -645,4 +660,18 @@ pub(crate) struct RestoreQueueResult {
     pub prev_mc_block_id: Option<BlockId>,
     pub synced_to_blocks_keys: Vec<BlockCacheKey>,
     pub applied_diffs_ids: FastHashSet<BlockId>,
+}
+
+enum QueueDiffRequired {
+    Required,
+    NotRequired,
+    // also means not required, but restore must update `first_required_diffs` for already applied diffs
+    AlreadyApplied,
+    Unknown,
+}
+
+impl QueueDiffRequired {
+    fn is_not_required(&self) -> bool {
+        matches!(self, Self::NotRequired | Self::AlreadyApplied)
+    }
 }

--- a/collator/src/manager/sync.rs
+++ b/collator/src/manager/sync.rs
@@ -240,15 +240,15 @@ where
         top_mc_block_id_for_next_collation: Option<BlockId>,
         required_min_mc_block_delta: BlockSeqno,
         is_key_block: Option<bool>,
-    ) -> bool {
+    ) -> ShouldSyncToAppliedMcBlock {
         // do not sync to last applied mc block if newer already received
         if self.has_newer_received_mc_block(store_res.applied_mc_queue_range) {
-            return false;
+            return ShouldSyncToAppliedMcBlock::NoBecauseNewerReceived;
         }
 
         // should sync if collated block mismatched
         if store_res.block_mismatch {
-            return true;
+            return ShouldSyncToAppliedMcBlock::Yes;
         }
 
         let has_active_collations = self.has_active_collations();
@@ -282,7 +282,7 @@ where
                         applied_range_end, top_mc_block_id_for_next_collation.seqno,
                         applied_range_end_delta, required_min_mc_block_delta,
                     );
-                    false
+                    ShouldSyncToAppliedMcBlock::No
                 } else {
                     tracing::info!(target: tracing_targets::COLLATION_MANAGER,
                         last_synced_to_mc_block_id = ?last_synced_to_mc_block_id,
@@ -295,7 +295,7 @@ where
                         applied_range_end, top_mc_block_id_for_next_collation.seqno,
                         applied_range_end_delta, required_min_mc_block_delta,
                     );
-                    true
+                    ShouldSyncToAppliedMcBlock::Yes
                 }
             } else {
                 // should collate next own mc block because no applied ahead
@@ -307,7 +307,7 @@ where
                     is_key_block = ?is_key_block,
                     "check_should_sync: should collate next own mc block after because nothing applied ahead",
                 );
-                false
+                ShouldSyncToAppliedMcBlock::No
             }
         } else if store_res.applied_mc_queue_range.is_some() {
             tracing::info!(target: tracing_targets::COLLATION_MANAGER,
@@ -318,7 +318,7 @@ where
                 is_key_block = ?is_key_block,
                 "check_should_sync: should sync to last applied mc block when no last collated or prev sync to",
             );
-            true
+            ShouldSyncToAppliedMcBlock::Yes
         } else {
             tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
                 last_synced_to_mc_block_id = ?last_synced_to_mc_block_id,
@@ -329,7 +329,7 @@ where
                 "check_should_sync: should continue local collation when no last collated or prev sync to \
                 and nothing applied ahead",
             );
-            false
+            ShouldSyncToAppliedMcBlock::No
         }
     }
 
@@ -641,4 +641,127 @@ where
             all_shards_processed_to_by_partitions,
         )
     }
+
+    /// Returns top removed master block id during cleanup
+    pub(super) async fn gc_applied_blocks_with_not_required_diffs(
+        &self,
+        last_collated_mc_block_id: Option<BlockId>,
+        applied_range: Option<(BlockSeqno, BlockSeqno)>,
+    ) -> Result<Option<BlockId>> {
+        let Some(applied_range) = applied_range else {
+            return Ok(None);
+        };
+
+        tracing::info!(target: tracing_targets::COLLATION_MANAGER,
+            ?applied_range,
+            "start cache cleanup after sync was skipped when newer master block received",
+        );
+
+        let last_applied_mc_block_key = BlockIdShort {
+            shard: ShardIdent::MASTERCHAIN,
+            seqno: applied_range.1,
+        };
+
+        // get internals processed_to from master and all shards
+        // for last applied master block
+        let all_shards_processed_to_by_partitions =
+            Self::get_all_shards_processed_to_by_partitions_for_mc_block(
+                &last_applied_mc_block_key,
+                &self.blocks_cache,
+                self.state_node_adapter.clone(),
+            )
+            .await?;
+
+        // find internals min processed_to
+        let min_processed_to_by_shards =
+            find_min_processed_to_by_shards(&all_shards_processed_to_by_partitions);
+
+        // if `fast_sync` is enabled then take applied to boundary from queue
+        let queue_diffs_applied_to_top_blocks = if self.config.fast_sync
+            && let Some(applied_to_mc_block_id) =
+                self.get_queue_diffs_applied_to_mc_block_id(last_collated_mc_block_id)?
+        {
+            Self::get_top_blocks_seqno(
+                &applied_to_mc_block_id,
+                &self.blocks_cache,
+                self.state_node_adapter.clone(),
+            )
+            .await?
+        } else {
+            None
+        }
+        .unwrap_or_default();
+
+        // check master blocks and their top shard blocks one by one
+        let mut top_removed_mc_block_id = None;
+
+        let init_mc_block_id = self.state_node_adapter.load_init_block_id();
+        let zerostate_mc_seqno = self.state_node_adapter.zerostate_id().seqno;
+
+        let mut from_seqno = applied_range.0;
+        loop {
+            // read front master block subgraph info from cache
+            let Some(mc_block_subgraph_view) = self
+                .blocks_cache
+                .peek_front_applied_mc_block_subgraph(from_seqno)?
+            else {
+                break;
+            };
+
+            // check if top blocks diffs required for queue restore
+            if !Self::check_top_blocks_diffs_not_required(
+                &self.mq_adapter,
+                &mc_block_subgraph_view,
+                &min_processed_to_by_shards,
+                &queue_diffs_applied_to_top_blocks,
+                init_mc_block_id,
+                zerostate_mc_seqno,
+            )
+            .await?
+            {
+                break;
+            }
+
+            // if top blocks diffs are not required for queue restore then we can remove subgraph
+            // we do not need it for sync anymore
+            let (mc_block_subgraph_extract, _) = self
+                .blocks_cache
+                .pop_front_applied_mc_block_subgraph(from_seqno)?;
+            let subgraph = match mc_block_subgraph_extract {
+                super::types::McBlockSubgraphExtract::Extracted(subgraph) => subgraph,
+                super::types::McBlockSubgraphExtract::AlreadyExtracted => {
+                    bail!("mc block subgraph extract result cannot be AlreadyExtracted")
+                }
+            };
+
+            top_removed_mc_block_id = Some(subgraph.master_block.block_id);
+
+            // update gc boundary
+            let to_blocks_keys = subgraph.master_block.get_top_blocks_keys()?;
+            self.blocks_cache.set_gc_to_boundary(&to_blocks_keys);
+
+            // update front seqno for futher checks
+            let (_, Some((new_from_seqno, _))) = self
+                .blocks_cache
+                .get_last_collated_block_and_applied_mc_queue_range()
+            else {
+                break;
+            };
+            from_seqno = new_from_seqno;
+        }
+
+        // run gc only when any block was really removed
+        if top_removed_mc_block_id.is_some() {
+            self.blocks_cache.gc_prev_blocks();
+        }
+
+        Ok(top_removed_mc_block_id)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum ShouldSyncToAppliedMcBlock {
+    Yes,
+    No,
+    NoBecauseNewerReceived,
 }

--- a/collator/src/manager/sync.rs
+++ b/collator/src/manager/sync.rs
@@ -625,6 +625,7 @@ where
         &self,
         last_collated_mc_block_id: Option<BlockId>,
         applied_range: Option<(BlockSeqno, BlockSeqno)>,
+        before_mc_seqno: Option<BlockSeqno>,
     ) -> Result<Option<BlockId>> {
         let Some(applied_range) = applied_range else {
             return Ok(None);
@@ -632,6 +633,7 @@ where
 
         tracing::info!(target: tracing_targets::COLLATION_MANAGER,
             ?applied_range,
+            ?before_mc_seqno,
             "start cache cleanup after sync was skipped when newer master block received",
         );
 
@@ -670,6 +672,10 @@ where
             else {
                 break;
             };
+
+            if before_mc_seqno.is_some_and(|seqno| mc_block_subgraph_view.block_id.seqno >= seqno) {
+                break;
+            }
 
             // check if top blocks diffs required for queue restore
             if !Self::check_top_blocks_diffs_not_required(

--- a/collator/src/manager/sync.rs
+++ b/collator/src/manager/sync.rs
@@ -12,6 +12,7 @@ use tycho_util::metrics::HistogramGuard;
 
 use super::CollationManager;
 use super::blocks_cache::BlocksCache;
+use super::msgs_queue::QueueRestoreProcessedTo;
 use super::state_update_handler::ProcessMcStateUpdateMode;
 use super::types::{
     ActiveSync, BlockCacheStoreResult, CollationStatus, CollationSyncState, CollatorJoinTask,
@@ -19,7 +20,7 @@ use super::types::{
 use crate::collator::CollatorFactory;
 use crate::state_node::StateNodeAdapter;
 use crate::tracing_targets;
-use crate::types::processed_upto::{BlockSeqno, find_min_processed_to_by_shards};
+use crate::types::processed_upto::BlockSeqno;
 use crate::types::{DisplayAsShortId, DisplayBlockIdsIntoIter, McData, ProcessedToByPartitions};
 use crate::validator::Validator;
 
@@ -441,20 +442,15 @@ where
 
         // get internals processed_to from master and all shards
         // for last applied master block
-        let all_shards_processed_to_by_partitions =
-            Self::get_all_shards_processed_to_by_partitions_for_mc_block(
-                &last_applied_mc_block_key,
-                &self.blocks_cache,
-                self.state_node_adapter.clone(),
-            )
+        let QueueRestoreProcessedTo {
+            all_shards_processed_to_by_partitions,
+            min_processed_to_by_shards,
+        } = self
+            .get_queue_restore_processed_to_by_shards(&last_applied_mc_block_key)
             .await_blocking()?;
 
-        // find internals min processed_to
-        let min_processed_to_by_shards =
-            find_min_processed_to_by_shards(&all_shards_processed_to_by_partitions);
-
         tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
-            ?min_processed_to_by_shards,
+            min_processed_to_by_shards = ?min_processed_to_by_shards,
         );
 
         // find first applied mc block and tail shard blocks and get previous
@@ -482,29 +478,9 @@ where
         }
 
         // if `fast_sync` is enabled then we will skip already applied queue diffs
-        let queue_diffs_applied_to_top_blocks = if self.config.fast_sync
-            && let Some(applied_to_mc_block_id) =
-                self.get_queue_diffs_applied_to_mc_block_id(last_collated_mc_block_id)?
-        {
-            // BACKWARD COMPATIBILITY: `last_committed_mc_block_id` will not exist in queue storage
-            // in previous version. We will receive None and will use all required diffs to restore the queue
-
-            // NOTE: when the node started to sync from a persistent state with a bunch of archives after it,
-            //      the `last_collated_mc_block_id` will be None, and `applied_to_mc_block_id` will be equal
-            //      to the top block of the persistent state - init block. But the persistent state can be already
-            //      removed because of the long history after it when collator starts to sync by recent blocks.
-            //      So we will not able to read top blocks ids and will fallback the full sync.
-
-            // collect top blocks queue diffs already applied to
-            Self::get_top_blocks_seqno(
-                &applied_to_mc_block_id,
-                &self.blocks_cache,
-                self.state_node_adapter.clone(),
-            )
-            .await_blocking()?
-        } else {
-            None
-        };
+        let queue_diffs_applied_to_top_blocks = self
+            .get_queue_diffs_applied_to_top_blocks(last_collated_mc_block_id)
+            .await_blocking()?;
         if queue_diffs_applied_to_top_blocks.is_some() {
             tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
                 ?queue_diffs_applied_to_top_blocks,
@@ -664,33 +640,18 @@ where
 
         // get internals processed_to from master and all shards
         // for last applied master block
-        let all_shards_processed_to_by_partitions =
-            Self::get_all_shards_processed_to_by_partitions_for_mc_block(
-                &last_applied_mc_block_key,
-                &self.blocks_cache,
-                self.state_node_adapter.clone(),
-            )
+        let QueueRestoreProcessedTo {
+            min_processed_to_by_shards,
+            ..
+        } = self
+            .get_queue_restore_processed_to_by_shards(&last_applied_mc_block_key)
             .await?;
 
-        // find internals min processed_to
-        let min_processed_to_by_shards =
-            find_min_processed_to_by_shards(&all_shards_processed_to_by_partitions);
-
         // if `fast_sync` is enabled then take applied to boundary from queue
-        let queue_diffs_applied_to_top_blocks = if self.config.fast_sync
-            && let Some(applied_to_mc_block_id) =
-                self.get_queue_diffs_applied_to_mc_block_id(last_collated_mc_block_id)?
-        {
-            Self::get_top_blocks_seqno(
-                &applied_to_mc_block_id,
-                &self.blocks_cache,
-                self.state_node_adapter.clone(),
-            )
+        let queue_diffs_applied_to_top_blocks = self
+            .get_queue_diffs_applied_to_top_blocks(last_collated_mc_block_id)
             .await?
-        } else {
-            None
-        }
-        .unwrap_or_default();
+            .unwrap_or_default();
 
         // check master blocks and their top shard blocks one by one
         let mut top_removed_mc_block_id = None;

--- a/collator/src/manager/sync.rs
+++ b/collator/src/manager/sync.rs
@@ -12,7 +12,7 @@ use tycho_util::metrics::HistogramGuard;
 
 use super::CollationManager;
 use super::blocks_cache::BlocksCache;
-use super::msgs_queue::QueueRestoreProcessedTo;
+use super::msgs_queue::{QueueRestoreProcessedTo, RestoreQueueContext};
 use super::state_update_handler::ProcessMcStateUpdateMode;
 use super::types::{
     ActiveSync, BlockCacheStoreResult, CollationStatus, CollationSyncState, CollatorJoinTask,
@@ -489,15 +489,17 @@ where
         }
 
         // restore queue state and return latest applied master state
-        let queue_restore_res = Self::restore_queue(
-            &self.blocks_cache,
-            self.state_node_adapter.clone(),
-            self.mq_adapter.clone(),
-            applied_range.0,
+        let queue_restore_res = Self::restore_queue(RestoreQueueContext {
+            blocks_cache: &self.blocks_cache,
+            state_node_adapter: self.state_node_adapter.clone(),
+            mq_adapter: self.mq_adapter.clone(),
+            from_mc_block_seqno: applied_range.0,
             min_processed_to_by_shards,
             before_tail_block_ids,
-            queue_diffs_applied_to_top_blocks.unwrap_or_default(),
-        )
+            queue_diffs_applied_to_top_blocks: queue_diffs_applied_to_top_blocks
+                .unwrap_or_default(),
+            slowdown_restore_queue_ms: self.config.slowdown_restore_queue_ms,
+        })
         .await_blocking()?;
 
         let Some(last_mc_state) = queue_restore_res.last_mc_state else {

--- a/collator/src/manager/tests/manager_tests.rs
+++ b/collator/src/manager/tests/manager_tests.rs
@@ -35,6 +35,7 @@ use crate::internal_queue::types::message::{EnqueuedMessage, InternalMessageValu
 use crate::internal_queue::types::router::PartitionRouter;
 use crate::internal_queue::types::stats::DiffStatistics;
 use crate::manager::blocks_cache::BlocksCache;
+use crate::manager::msgs_queue::RestoreQueueContext;
 use crate::manager::state_update_handler::GlobalCapabilitiesExt;
 use crate::manager::sync::ShouldSyncToAppliedMcBlock;
 use crate::manager::types::{
@@ -2481,15 +2482,16 @@ async fn test_queue_restore_on_sync() {
         "queue_diffs_applied_to_top_blocks: {:?}",
         queue_diffs_applied_to_top_blocks,
     );
-    let queue_restore_res = TestCollationManager::restore_queue(
-        &test_adapter.blocks_cache,
-        test_adapter.state_adapter.clone(),
-        test_adapter.mq_adapter.clone(),
-        first_applied_mc_block_key.seqno,
+    let queue_restore_res = TestCollationManager::restore_queue(RestoreQueueContext {
+        blocks_cache: &test_adapter.blocks_cache,
+        state_node_adapter: test_adapter.state_adapter.clone(),
+        mq_adapter: test_adapter.mq_adapter.clone(),
+        from_mc_block_seqno: first_applied_mc_block_key.seqno,
         min_processed_to_by_shards,
         before_tail_block_ids,
-        queue_diffs_applied_to_top_blocks.unwrap_or_default(),
-    )
+        queue_diffs_applied_to_top_blocks: queue_diffs_applied_to_top_blocks.unwrap_or_default(),
+        slowdown_restore_queue_ms: None,
+    })
     .await
     .unwrap();
 
@@ -2893,15 +2895,16 @@ async fn test_queue_restore_on_sync() {
         "queue_diffs_applied_to_top_blocks: {:?}",
         queue_diffs_applied_to_top_blocks,
     );
-    let queue_restore_res = TestCollationManager::restore_queue(
-        &test_adapter.blocks_cache,
-        test_adapter.state_adapter.clone(),
-        test_adapter.mq_adapter.clone(),
-        first_applied_mc_block_key.seqno,
+    let queue_restore_res = TestCollationManager::restore_queue(RestoreQueueContext {
+        blocks_cache: &test_adapter.blocks_cache,
+        state_node_adapter: test_adapter.state_adapter.clone(),
+        mq_adapter: test_adapter.mq_adapter.clone(),
+        from_mc_block_seqno: first_applied_mc_block_key.seqno,
         min_processed_to_by_shards,
         before_tail_block_ids,
-        queue_diffs_applied_to_top_blocks.unwrap_or_default(),
-    )
+        queue_diffs_applied_to_top_blocks: queue_diffs_applied_to_top_blocks.unwrap_or_default(),
+        slowdown_restore_queue_ms: None,
+    })
     .await
     .unwrap();
 
@@ -3221,15 +3224,16 @@ async fn test_queue_restore_on_sync() {
         "queue_diffs_applied_to_top_blocks: {:?}",
         queue_diffs_applied_to_top_blocks,
     );
-    let queue_restore_res = TestCollationManager::restore_queue(
-        &test_adapter.blocks_cache,
-        test_adapter.state_adapter.clone(),
-        test_adapter.mq_adapter.clone(),
-        first_applied_mc_block_key.seqno,
+    let queue_restore_res = TestCollationManager::restore_queue(RestoreQueueContext {
+        blocks_cache: &test_adapter.blocks_cache,
+        state_node_adapter: test_adapter.state_adapter.clone(),
+        mq_adapter: test_adapter.mq_adapter.clone(),
+        from_mc_block_seqno: first_applied_mc_block_key.seqno,
         min_processed_to_by_shards,
         before_tail_block_ids,
-        queue_diffs_applied_to_top_blocks.unwrap_or_default(),
-    )
+        queue_diffs_applied_to_top_blocks: queue_diffs_applied_to_top_blocks.unwrap_or_default(),
+        slowdown_restore_queue_ms: None,
+    })
     .await
     .unwrap();
 
@@ -3561,15 +3565,16 @@ async fn test_queue_restore_on_sync() {
         "queue_diffs_applied_to_top_blocks: {:?}",
         queue_diffs_applied_to_top_blocks,
     );
-    let queue_restore_res = TestCollationManager::restore_queue(
-        &test_adapter.blocks_cache,
-        test_adapter.state_adapter.clone(),
-        test_adapter.mq_adapter.clone(),
-        first_applied_mc_block_key.seqno,
+    let queue_restore_res = TestCollationManager::restore_queue(RestoreQueueContext {
+        blocks_cache: &test_adapter.blocks_cache,
+        state_node_adapter: test_adapter.state_adapter.clone(),
+        mq_adapter: test_adapter.mq_adapter.clone(),
+        from_mc_block_seqno: first_applied_mc_block_key.seqno,
         min_processed_to_by_shards,
         before_tail_block_ids,
-        queue_diffs_applied_to_top_blocks.unwrap_or_default(),
-    )
+        queue_diffs_applied_to_top_blocks: queue_diffs_applied_to_top_blocks.unwrap_or_default(),
+        slowdown_restore_queue_ms: None,
+    })
     .await
     .unwrap();
 

--- a/collator/src/manager/tests/manager_tests.rs
+++ b/collator/src/manager/tests/manager_tests.rs
@@ -3880,6 +3880,23 @@ async fn test_cache_gc_on_skipped_sync() {
         .gc_applied_blocks_with_not_required_diffs(
             store_res.last_collated_mc_block_id,
             store_res.applied_mc_queue_range,
+            Some(1),
+        )
+        .await
+        .unwrap();
+    assert_eq!(cleanup_res, None);
+    assert_eq!(
+        manager
+            .blocks_cache
+            .get_last_collated_block_and_applied_mc_queue_range()
+            .1,
+        Some((1, 2))
+    );
+    let cleanup_res = manager
+        .gc_applied_blocks_with_not_required_diffs(
+            store_res.last_collated_mc_block_id,
+            store_res.applied_mc_queue_range,
+            None,
         )
         .await
         .unwrap();

--- a/collator/src/manager/tests/manager_tests.rs
+++ b/collator/src/manager/tests/manager_tests.rs
@@ -36,6 +36,7 @@ use crate::internal_queue::types::router::PartitionRouter;
 use crate::internal_queue::types::stats::DiffStatistics;
 use crate::manager::blocks_cache::BlocksCache;
 use crate::manager::state_update_handler::GlobalCapabilitiesExt;
+use crate::manager::sync::ShouldSyncToAppliedMcBlock;
 use crate::manager::types::{
     BlockCacheStoreResult, CollationSyncState, McBlockSubgraphExtract, NextCollationStep,
 };
@@ -1929,12 +1930,14 @@ async fn test_should_not_sync_without_applied_range_after_known_sync() {
         manager.get_top_mc_block_id_for_next_collation(store_res.last_collated_mc_block_id);
 
     assert_eq!(top_mc_block_id_for_next_collation, Some(mc_block_id));
-    assert!(!manager.check_should_sync_to_last_applied_mc_block(
-        &store_res,
-        top_mc_block_id_for_next_collation,
-        1,
-        None,
-    ));
+    assert!(
+        manager.check_should_sync_to_last_applied_mc_block(
+            &store_res,
+            top_mc_block_id_for_next_collation,
+            1,
+            None,
+        ) != ShouldSyncToAppliedMcBlock::Yes
+    );
 }
 
 #[tokio::test]
@@ -3655,6 +3658,237 @@ impl Validator for NoopValidator {
     }
 }
 
+type CleanupTestCollationManager = CollationManager<CollatorStdImplFactory, NoopValidator>;
+
+#[tokio::test]
+async fn test_cache_gc_on_skipped_sync() {
+    try_init_test_tracing(tracing_subscriber::filter::LevelFilter::TRACE);
+
+    let (mq_adapter, _tmp_dir) = create_test_queue_adapter::<EnqueuedMessage>()
+        .await
+        .unwrap();
+    let msgs_factory =
+        TestMessageFactory::new(BTreeMap::new(), |info, cell| EnqueuedMessage { info, cell });
+    let state_adapter = Arc::new(TestStateNodeAdapter::default());
+    let blocks_cache = BlocksCache::new(&Default::default());
+
+    let shard = ShardIdent::new_full(0);
+    let mut transfers_wallets = BTreeMap::<u8, IntAddr>::new();
+    for i in 100..110 {
+        transfers_wallets.insert(i, IntAddr::Std(StdAddr::new(0, HashBytes([i; 32]))));
+    }
+    for i in 110..120 {
+        transfers_wallets.insert(i, IntAddr::Std(StdAddr::new(-1, HashBytes([i; 32]))));
+    }
+
+    let mut test_adapter = TestAdapter {
+        state_adapter,
+        mq_adapter,
+        msgs_factory,
+        blocks_cache,
+        account_lt: 0,
+        transfers_wallets,
+        processed_to_stuff: TestProcessedToStuff::new(shard),
+        last_sc_block_id: BlockId {
+            shard,
+            seqno: 0,
+            root_hash: HashBytes::default(),
+            file_hash: HashBytes::default(),
+        },
+        last_mc_block_id: BlockId {
+            shard: ShardIdent::MASTERCHAIN,
+            seqno: 0,
+            root_hash: HashBytes::default(),
+            file_hash: HashBytes::default(),
+        },
+        last_sc_blocks: BTreeMap::new(),
+        last_mc_blocks: BTreeMap::new(),
+    };
+
+    let generated_block_info = test_adapter.gen_shard_block(
+        shard,
+        1,
+        (test_adapter.last_sc_block_id, 0),
+        (test_adapter.last_mc_block_id, 0),
+        10,
+    );
+    let StoreBlockResult {
+        block_stuff: last_sc_block_stuff,
+        ..
+    } = test_adapter.store_as_candidate(generated_block_info);
+
+    test_adapter
+        .processed_to_stuff
+        .set_processed_to(shard, test_adapter.last_sc_blocks.get(&1).unwrap());
+
+    let generated_block_info = test_adapter.gen_shard_block(
+        shard,
+        2,
+        last_sc_block_stuff.prev_block_info(),
+        (test_adapter.last_mc_block_id, 0),
+        10,
+    );
+    let StoreBlockResult {
+        block_stuff: last_sc_block_stuff,
+        ..
+    } = test_adapter.store_as_candidate(generated_block_info);
+
+    let generated_block_info = test_adapter.gen_shard_block(
+        shard,
+        3,
+        last_sc_block_stuff.prev_block_info(),
+        (test_adapter.last_mc_block_id, 0),
+        10,
+    );
+    let StoreBlockResult {
+        block_stuff: last_sc_block_stuff,
+        ..
+    } = test_adapter.store_as_candidate(generated_block_info);
+
+    test_adapter.processed_to_stuff.set_processed_to(
+        ShardIdent::MASTERCHAIN,
+        test_adapter.last_sc_blocks.get(&3).unwrap(),
+    );
+
+    let generated_block_info = test_adapter.gen_master_block(
+        1,
+        (test_adapter.last_mc_block_id, 0),
+        &last_sc_block_stuff.data,
+        true,
+        false,
+        5,
+    );
+    let mc_block_id_1 = *generated_block_info.block_stuff.id();
+    let master1_queue_diff = generated_block_info.queue_diff_stuff.clone();
+    let master1_queue_diff_with_msgs = generated_block_info.queue_diff_with_msgs.clone();
+    let master1_statistics = DiffStatistics::from_diff(
+        &master1_queue_diff_with_msgs,
+        mc_block_id_1.shard,
+        master1_queue_diff.diff().min_message,
+        master1_queue_diff.diff().max_message,
+    );
+    test_adapter
+        .mq_adapter
+        .apply_diff(
+            master1_queue_diff_with_msgs,
+            mc_block_id_1.as_short_id(),
+            master1_queue_diff.diff_hash(),
+            master1_statistics,
+            Some(DiffZone::Both),
+        )
+        .unwrap();
+    let StoreBlockResult {
+        block_stuff: last_mc_block_stuff,
+        ..
+    } = test_adapter
+        .store_as_received(&mc_block_id_1, generated_block_info)
+        .await;
+
+    let generated_block_info = test_adapter.gen_shard_block(
+        shard,
+        4,
+        last_sc_block_stuff.prev_block_info(),
+        last_mc_block_stuff.prev_block_info(),
+        10,
+    );
+    let StoreBlockResult {
+        block_stuff: last_sc_block_stuff,
+        ..
+    } = test_adapter.store_as_candidate(generated_block_info);
+
+    let generated_block_info = test_adapter.gen_master_block(
+        2,
+        last_mc_block_stuff.prev_block_info(),
+        &last_sc_block_stuff.data,
+        true,
+        false,
+        5,
+    );
+    let mc_block_id_2 = *generated_block_info.block_stuff.id();
+    let StoreBlockResult {
+        block_stuff: _last_mc_block_stuff,
+        ..
+    } = test_adapter
+        .store_as_received(&mc_block_id_2, generated_block_info)
+        .await;
+
+    let TestAdapter {
+        state_adapter,
+        mq_adapter,
+        msgs_factory: _,
+        blocks_cache,
+        account_lt: _,
+        transfers_wallets: _,
+        processed_to_stuff: _,
+        last_sc_block_id: _,
+        last_mc_block_id: _,
+        last_sc_blocks: _last_sc_blocks,
+        last_mc_blocks,
+    } = test_adapter;
+    let mempool_adapter = MempoolAdapterStubImpl::with_stub_externals(Some(0));
+    let keypair = Arc::new(KeyPair::from(&SecretKey::from_bytes([7; 32])));
+    let config = crate::types::CollatorConfig {
+        fast_sync: false,
+        ..Default::default()
+    };
+
+    let mut manager = CleanupTestCollationManager::create(
+        keypair,
+        config,
+        mq_adapter,
+        TestStateNodeAdapterFactory::new(state_adapter),
+        mempool_adapter,
+        NoopValidator,
+        CollatorStdImplFactory {
+            wu_tuner_event_sender: None,
+        },
+        None,
+    );
+    Arc::get_mut(&mut manager)
+        .expect("manager should be uniquely owned")
+        .blocks_cache = blocks_cache;
+
+    let last_received_mc_block_id = BlockId {
+        shard: ShardIdent::MASTERCHAIN,
+        seqno: 4,
+        root_hash: HashBytes::default(),
+        file_hash: HashBytes::default(),
+    };
+    manager.update_last_received_mc_block_seqno(&last_received_mc_block_id);
+
+    let (last_collated_mc_block_id, applied_mc_queue_range) = manager
+        .blocks_cache
+        .get_last_collated_block_and_applied_mc_queue_range();
+    let store_res = BlockCacheStoreResult {
+        received_and_collated: false,
+        block_mismatch: false,
+        last_collated_mc_block_id,
+        applied_mc_queue_range,
+    };
+
+    assert!(matches!(
+        manager.check_should_sync_to_last_applied_mc_block(&store_res, None, 3, None,),
+        ShouldSyncToAppliedMcBlock::NoBecauseNewerReceived
+    ));
+
+    let cleanup_res = manager
+        .gc_applied_blocks_with_not_required_diffs(
+            store_res.last_collated_mc_block_id,
+            store_res.applied_mc_queue_range,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(cleanup_res, Some(*last_mc_blocks.get(&1).unwrap().id()));
+    assert_eq!(
+        manager
+            .blocks_cache
+            .get_last_collated_block_and_applied_mc_queue_range()
+            .1,
+        Some((2, 2))
+    );
+}
+
 trait BlockStuffExt {
     fn end_lt(&self) -> Lt;
     fn prev_block_info(&self) -> (BlockId, Lt);
@@ -4081,6 +4315,32 @@ fn create_queue_diff_with_msgs<V: InternalMessageValue>(
             .collect(),
         processed_to,
         partition_router: PartitionRouter::default(),
+    }
+}
+
+struct TestStateNodeAdapterFactory(Mutex<Option<TestStateNodeAdapter>>);
+
+impl TestStateNodeAdapterFactory {
+    fn new(state_adapter: Arc<TestStateNodeAdapter>) -> Self {
+        let state_adapter = match Arc::try_unwrap(state_adapter) {
+            Ok(state_adapter) => state_adapter,
+            _ => panic!("state adapter should be unique"),
+        };
+        Self(Mutex::new(Some(state_adapter)))
+    }
+}
+
+impl crate::state_node::StateNodeAdapterFactory for TestStateNodeAdapterFactory {
+    type Adapter = TestStateNodeAdapter;
+
+    fn create(
+        &self,
+        _listener: Arc<dyn crate::state_node::StateNodeEventListener>,
+    ) -> Self::Adapter {
+        self.0
+            .lock()
+            .take()
+            .expect("state adapter should be available")
     }
 }
 

--- a/collator/src/types.rs
+++ b/collator/src/types.rs
@@ -67,6 +67,13 @@ pub struct CollatorConfig {
     ///
     /// Default: `5` (means 32 shards).
     pub merkle_split_depth: u8,
+
+    /// Optional queue restore slowdown in milliseconds.
+    pub slowdown_restore_queue_ms: Option<u64>,
+    /// Optional collation resume slowdown in milliseconds.
+    pub slowdown_resume_collation_ms: Option<u64>,
+    /// Optional collation slowdown in milliseconds.
+    pub slowdown_do_collate_ms: Option<u64>,
 }
 
 impl Default for CollatorConfig {
@@ -80,6 +87,9 @@ impl Default for CollatorConfig {
             fast_sync: true,
             accounts_split_depth: 4,
             merkle_split_depth: 5,
+            slowdown_restore_queue_ms: None,
+            slowdown_resume_collation_ms: None,
+            slowdown_do_collate_ms: None,
         }
     }
 }

--- a/collator/tests/collation_tests.rs
+++ b/collator/tests/collation_tests.rs
@@ -163,6 +163,9 @@ fn default_collator_config() -> CollatorConfig {
         fast_sync: false,
         accounts_split_depth: 4,
         merkle_split_depth: 5,
+        slowdown_restore_queue_ms: None,
+        slowdown_resume_collation_ms: None,
+        slowdown_do_collate_ms: None,
     }
 }
 


### PR DESCRIPTION
On collator state sync node checks if a newer mc state is already received. If so it does not process current mc state update after sync and continue syncing. But collation manager's cache was cleared only after the sync finish. So the cache may grow infinite that may cause OOM.

This update adds the guard that clears blocks from the cache which are not required for queue restore. So even if node syncs slow and receives new blocks faster then perform sync, the cache is invalidated correctly.

Additionally added some hacks to slowdown collator operations for debug purposes:
- restore queue
- resume collation
- do collate

## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

[Yes]

Added optional params that allow to slowdown collator operations.

node.config
```
{
  "collator": {
    "slowdown_restore_queue_ms":  60000,
    "slowdown_resume_collation_ms": 60000,
    "slowdown_do_collate_ms": 60000
  }
}
```

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

[None]

---

### COMPATIBILITY

Fully compatible

### SPECIAL DEPLOYMENT ACTIONS

[Not Required]

---

### PERFORMANCE IMPACT

[No impact expected]

---

### TESTS

#### Unit Tests

Covered by:
 - test_cache_gc_on_skipped_sync

#### Network Tests

[No coverage]

#### Manual Tests

Manual tests used:
- deploy 10kk
- set `"slowdown_restore_queue_ms":  100000` on some node and restart it
- run transfers 5k
- check that collation manager's cache metrics does not grow > 100

<img width="1487" height="265" alt="Screenshot 2026-05-26 at 18 03 23" src="https://github.com/user-attachments/assets/8d739693-0d9f-4fc9-94b5-a4f1adf4021d" />

[metrics](https://grafana.broxus.com/dashboard/snapshot/wC2YdFmbwtHzxKqPDs5DomTVUHz5Zq2Y)