### PR TITLE
Feature/consensus/rayon

### DIFF
--- a/cli/src/cmd/debug/mempool.rs
+++ b/cli/src/cmd/debug/mempool.rs
@@ -10,7 +10,7 @@ use tokio::sync::{mpsc, oneshot};
 use tycho_block_util::state::ShardStateStuff;
 use tycho_consensus::prelude::{
     EngineBinding, EngineNetworkArgs, EngineSession, InitPeers, InputBuffer, MempoolConfigBuilder,
-    MempoolDb, MempoolMergedConfig, Moderator,
+    MempoolDb, MempoolMergedConfig, MempoolRayon, Moderator,
 };
 use tycho_consensus::test_utils::{AnchorConsumer, LastAnchorFile, test_logger};
 use tycho_control::{ControlEndpoint, ControlServer, ControlServerConfig, ControlServerVersion};
@@ -179,6 +179,7 @@ struct Mempool {
 
     mempool_db: Arc<MempoolDb>,
     input_buffer: InputBuffer,
+    rayon: MempoolRayon,
     merged_conf: MempoolMergedConfig,
 
     // a guard to abort the server future on drop
@@ -186,7 +187,7 @@ struct Mempool {
 }
 
 impl Mempool {
-    async fn new(cmd: CmdRun, node_config: NodeConfig) -> Result<Mempool> {
+    async fn new(cmd: CmdRun, node_config: NodeConfig) -> Result<Self> {
         let global_config =
             GlobalConfig::from_file(&cmd.global_config).context("failed to load global config")?;
 
@@ -303,12 +304,15 @@ impl Mempool {
             &merged_conf.conf.consensus,
         );
 
-        Ok(Mempool {
+        let rayon = MempoolRayon::new(merged_conf.node_config().rayon_threads)?;
+
+        Ok(Self {
             net_args,
             init_peers,
 
             mempool_db,
             input_buffer,
+            rayon,
             merged_conf,
 
             _control_endpoint,
@@ -328,6 +332,7 @@ impl Mempool {
         let bind = EngineBinding {
             mempool_db: self.mempool_db.clone(),
             input_buffer: self.input_buffer.clone(),
+            rayon: self.rayon.clone(),
             top_known_anchor: anchor_consumer.top_known_anchor.clone(),
             commit_finished: anchor_consumer.commit_finished.clone(),
             anchors_tx,

--- a/collator/src/mempool/impls/std_impl/mod.rs
+++ b/collator/src/mempool/impls/std_impl/mod.rs
@@ -98,6 +98,7 @@ impl MempoolAdapterStdImpl {
         let bind = EngineBinding {
             mempool_db: self.mempool_db.clone(),
             input_buffer: self.input_buffer.clone(),
+            rayon: MempoolRayon::new(merged_conf.node_config().rayon_threads)?,
             top_known_anchor: self.top_known_anchor.clone(),
             commit_finished: commit_finished.clone(),
             anchors_tx,

--- a/consensus/examples/engine.rs
+++ b/consensus/examples/engine.rs
@@ -10,8 +10,8 @@ use futures_util::FutureExt;
 use parking_lot::deadlock;
 use tokio::sync::{Notify, mpsc, oneshot};
 use tycho_consensus::prelude::{
-    EngineBinding, EngineNetworkArgs, EngineSession, InitPeers, InputBuffer, MempoolDb, Moderator,
-    ModeratorConfig,
+    EngineBinding, EngineNetworkArgs, EngineSession, InitPeers, InputBuffer, MempoolDb,
+    MempoolRayon, Moderator, ModeratorConfig,
 };
 use tycho_consensus::test_utils::*;
 use tycho_crypto::ed25519::{KeyPair, SecretKey};
@@ -195,6 +195,9 @@ fn make_network(
                             }
                         };
 
+                        let rayon = MempoolRayon::new(merged_conf.node_config().rayon_threads)
+                            .expect("failed to create mempool rayon thread pool");
+
                         let bind = EngineBinding {
                             mempool_db,
                             input_buffer: InputBuffer::new_stub(
@@ -202,6 +205,7 @@ fn make_network(
                                 cli.steps_until_full,
                                 &merged_conf.conf.consensus,
                             ),
+                            rayon,
                             top_known_anchor,
                             commit_finished,
                             anchors_tx,

--- a/consensus/src/effects/context.rs
+++ b/consensus/src/effects/context.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use tracing::Span;
 
 use crate::effects::task::TaskTracker;
-use crate::effects::{AltFormat, TaskCtx};
+use crate::effects::{AltFormat, MempoolRayon, TaskCtx};
 use crate::engine::MempoolConfig;
 use crate::models::{Point, PointId, PointInfo, Round};
 
@@ -12,14 +12,16 @@ use crate::models::{Point, PointId, PointInfo, Round};
 pub trait Ctx {
     fn span(&self) -> &Span;
     fn conf(&self) -> &MempoolConfig;
+    fn rayon(&self) -> &MempoolRayon;
     fn task(&self) -> TaskCtx<'_>;
 }
 
 /// Root context for uninterrupted sequence of engine rounds
-pub struct EngineCtx(Arc<EngineCtxInner>);
+pub struct EngineCtx(Box<EngineCtxInner>);
 struct EngineCtxInner {
     span: Span,
     conf: MempoolConfig,
+    rayon: MempoolRayon,
     task_tracker: TaskTracker,
 }
 impl Ctx for EngineCtx {
@@ -29,24 +31,29 @@ impl Ctx for EngineCtx {
     fn conf(&self) -> &MempoolConfig {
         &self.0.conf
     }
+    fn rayon(&self) -> &MempoolRayon {
+        &self.0.rayon
+    }
     fn task(&self) -> TaskCtx<'_> {
         self.0.task_tracker.ctx()
     }
 }
 impl EngineCtx {
-    pub fn new(since: Round, conf: &MempoolConfig, task_tracker: &TaskTracker) -> Self {
-        Self(Arc::new(EngineCtxInner {
+    pub fn new(
+        since: Round,
+        conf: &MempoolConfig,
+        task_tracker: &TaskTracker,
+        rayon: &MempoolRayon,
+    ) -> Self {
+        Self(Box::new(EngineCtxInner {
             span: tracing::error_span!("rounds", "since" = since.0),
             conf: conf.clone(),
+            rayon: rayon.clone(),
             task_tracker: task_tracker.clone(),
         }))
     }
     pub fn update(&mut self, since: Round) {
-        self.0 = Arc::new(EngineCtxInner {
-            span: tracing::error_span!("rounds", "since" = since.0),
-            conf: self.0.conf.clone(),
-            task_tracker: self.0.task_tracker.clone(),
-        });
+        self.0.span = tracing::error_span!("rounds", "since" = since.0);
     }
     pub fn meter_dag_len(len: usize) {
         metrics::gauge!("tycho_mempool_rounds_dag_length").set(len as u32);
@@ -58,6 +65,7 @@ pub struct RoundCtx(Arc<RoundCtxInner>);
 struct RoundCtxInner {
     span: Span,
     conf: MempoolConfig,
+    rayon: MempoolRayon,
     task_tracker: TaskTracker,
     current_round: Round,
     download_max_depth: AtomicU32,
@@ -68,6 +76,9 @@ impl Ctx for RoundCtx {
     }
     fn conf(&self) -> &MempoolConfig {
         &self.0.conf
+    }
+    fn rayon(&self) -> &MempoolRayon {
+        &self.0.rayon
     }
     fn task(&self) -> TaskCtx<'_> {
         self.0.task_tracker.ctx()
@@ -80,6 +91,7 @@ impl RoundCtx {
                 .span()
                 .in_scope(|| tracing::error_span!("round", "current" = current_round.0)),
             conf: parent.conf().clone(),
+            rayon: parent.rayon().clone(),
             task_tracker: parent.0.task_tracker.clone(),
             current_round,
             download_max_depth: Default::default(),
@@ -100,6 +112,9 @@ impl Ctx for CollectCtx {
     }
     fn conf(&self) -> &MempoolConfig {
         self.parent.conf()
+    }
+    fn rayon(&self) -> &MempoolRayon {
+        self.parent.rayon()
     }
     fn task(&self) -> TaskCtx<'_> {
         self.parent.task()
@@ -124,6 +139,9 @@ impl Ctx for BroadcastCtx {
     }
     fn conf(&self) -> &MempoolConfig {
         self.parent.conf()
+    }
+    fn rayon(&self) -> &MempoolRayon {
+        self.parent.rayon()
     }
     fn task(&self) -> TaskCtx<'_> {
         self.parent.task()
@@ -154,6 +172,9 @@ impl Ctx for DownloadCtx {
     }
     fn conf(&self) -> &MempoolConfig {
         self.parent.conf()
+    }
+    fn rayon(&self) -> &MempoolRayon {
+        self.parent.rayon()
     }
     fn task(&self) -> TaskCtx<'_> {
         self.parent.task()
@@ -211,6 +232,9 @@ impl Ctx for ValidateCtx {
     }
     fn conf(&self) -> &MempoolConfig {
         self.0.parent.conf()
+    }
+    fn rayon(&self) -> &MempoolRayon {
+        self.0.parent.rayon()
     }
     fn task(&self) -> TaskCtx<'_> {
         self.0.parent.task()

--- a/consensus/src/effects/mod.rs
+++ b/consensus/src/effects/mod.rs
@@ -1,5 +1,6 @@
 pub use alt_format::*;
 pub use context::*;
+pub use rayon::*;
 pub use task::*;
 
 #[macro_use]
@@ -7,4 +8,5 @@ mod macros;
 
 mod alt_format;
 mod context;
+mod rayon;
 mod task;

--- a/consensus/src/effects/rayon.rs
+++ b/consensus/src/effects/rayon.rs
@@ -1,0 +1,49 @@
+use std::num::NonZeroU8;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use tycho_util::metrics::HistogramGuard;
+
+/// Separate twin of [`tycho_util::sync::rayon_run_fifo`]
+#[derive(Clone)]
+pub struct MempoolRayon(Arc<rayon::ThreadPool>);
+
+impl MempoolRayon {
+    pub fn new(num_threads: NonZeroU8) -> Result<Self, rayon::ThreadPoolBuildError> {
+        let thread_pool = rayon::ThreadPoolBuilder::new()
+            .stack_size(8 * 1024 * 1024)
+            .thread_name(|_| "mempool-rayon".to_string())
+            .num_threads(num_threads.get() as usize)
+            .build()?;
+        Ok(Self(Arc::new(thread_pool)))
+    }
+
+    pub(crate) async fn run_fifo<T: 'static + Send>(
+        &self,
+        f: impl FnOnce() -> T + Send + 'static,
+    ) -> T {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+        let (send, recv) = tokio::sync::oneshot::channel();
+        let wait_time_histogram = HistogramGuard::begin("tycho_rayon_mempool_queue_time");
+
+        self.0.spawn_fifo(move || {
+            drop(wait_time_histogram);
+
+            let _task_time = HistogramGuard::begin("tycho_rayon_mempool_task_time");
+
+            COUNTER.fetch_add(1, Ordering::Relaxed);
+            let res = f();
+            let in_flight = COUNTER.fetch_sub(1, Ordering::Relaxed);
+
+            metrics::histogram!("tycho_rayon_mempool_threads").record(in_flight as f64);
+
+            send.send(res).ok();
+        });
+
+        // mempool parse point task may be not interested in result (finishes earlier)
+
+        recv.await
+            .expect("mempool rayon thread pool completes all work before terminated")
+    }
+}

--- a/consensus/src/engine/impl_.rs
+++ b/consensus/src/engine/impl_.rs
@@ -61,7 +61,7 @@ impl Engine {
         consensus_round.set_max(conf.genesis_round);
         bind.top_known_anchor.set_max(conf.genesis_round);
 
-        let engine_ctx = EngineCtx::new(consensus_round.get(), conf, task_tracker);
+        let engine_ctx = EngineCtx::new(consensus_round.get(), conf, task_tracker, &bind.rayon);
         let round_ctx = RoundCtx::new(&engine_ctx, Round::BOTTOM);
 
         let store = MempoolStore::new(bind.mempool_db.clone());

--- a/consensus/src/engine/lifecycle/args.rs
+++ b/consensus/src/engine/lifecycle/args.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc;
 use tycho_crypto::ed25519::KeyPair;
 use tycho_network::{Network, OverlayService, PeerResolver, PrivateOverlay};
 
-use crate::effects::AltFormat;
+use crate::effects::{AltFormat, MempoolRayon};
 use crate::engine::round_watch::{Commit, RoundWatch, TopKnownAnchor};
 use crate::engine::{InputBuffer, MempoolMergedConfig};
 use crate::intercom::{Dispatcher, InitPeers, PeerSchedule, Responder};
@@ -16,6 +16,7 @@ use crate::storage::MempoolDb;
 pub struct EngineBinding {
     pub mempool_db: Arc<MempoolDb>,
     pub input_buffer: InputBuffer,
+    pub rayon: MempoolRayon,
     pub top_known_anchor: RoundWatch<TopKnownAnchor>,
     pub commit_finished: RoundWatch<Commit>,
     pub anchors_tx: mpsc::UnboundedSender<MempoolOutput>,

--- a/consensus/src/engine/mempool_config.rs
+++ b/consensus/src/engine/mempool_config.rs
@@ -188,6 +188,9 @@ pub struct MempoolNodeConfig {
     /// Each dag round has at least one weak reference to previous dag round;
     /// more links reduce [`std::sync::Weak::upgrade`] calls which results are immediately dropped
     pub weak_dag_round_links: NonZeroU8,
+
+    /// Threads to use in a separate thread pool
+    pub rayon_threads: NonZeroU8,
 }
 
 impl Default for MempoolNodeConfig {
@@ -201,6 +204,7 @@ impl Default for MempoolNodeConfig {
             max_upload_tasks: 50.try_into().unwrap(),
             max_download_tasks: 250.try_into().unwrap(),
             weak_dag_round_links: 7.try_into().unwrap(),
+            rayon_threads: 4.try_into().unwrap(),
         }
     }
 }

--- a/consensus/src/intercom/core/responder.rs
+++ b/consensus/src/intercom/core/responder.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
-use std::time::Instant;
 
 use arc_swap::ArcSwapOption;
 use futures_util::future::BoxFuture;
 use futures_util::{FutureExt, future};
 use tycho_network::{PeerId, Response, Service, ServiceRequest};
-use tycho_util::sync::rayon_run_fifo;
+use tycho_util::metrics::HistogramGuard;
 
 use crate::dag::DagHead;
 use crate::effects::{AltFormat, Ctx, RoundCtx};
@@ -216,10 +215,11 @@ impl ResponderInner {
 
         let query = match medium_query {
             QueryRequestMedium::Broadcast(bytes) => {
-                let start = Instant::now();
-                let parse_result = rayon_run_fifo(|| Point::parse(bytes.into())).await;
-                metrics::histogram!("tycho_mempool_engine_parse_point_time")
-                    .record(start.elapsed());
+                let parse_duration = HistogramGuard::begin("tycho_mempool_engine_parse_point_time");
+                let parse_result = (round_ctx.rayon())
+                    .run_fifo(|| Point::parse(bytes.into()))
+                    .await;
+                drop(parse_duration);
                 match parse_result {
                     Ok(Ok(Ok(point))) if point.info().author() == peer_id => {
                         QueryRequest::Broadcast(point, None)

--- a/consensus/src/intercom/dependency/downloader.rs
+++ b/consensus/src/intercom/dependency/downloader.rs
@@ -15,10 +15,9 @@ use tycho_network::PeerId;
 use tycho_util::FastHashSet;
 use tycho_util::mem::Reclaimer;
 use tycho_util::metrics::HistogramGuard;
-use tycho_util::sync::rayon_run_fifo;
 
 use crate::dag::{IllFormedReason, Verifier, VerifyError};
-use crate::effects::{AltFormat, Cancelled, Ctx, DownloadCtx, TaskResult};
+use crate::effects::{AltFormat, Cancelled, Ctx, DownloadCtx, MempoolRayon, TaskResult};
 use crate::engine::{MempoolConfig, NodeConfig};
 use crate::intercom::core::query::response::DownloadResponse;
 use crate::intercom::core::query::{DownloadQuery, QueryError};
@@ -99,9 +98,9 @@ impl Downloader {
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         let mut task = DownloadTask {
-            peer_schedule: self.inner.peer_schedule.clone(),
-            ctx,
             query: DownloadQuery::new(self.inner.dispatcher.clone(), point_id),
+            dependers_rx,
+            broadcast_result,
             peer_count,
             // this node is +1 to 2F; count every peer uniquely, as they may be removed and resolved
             not_found: FastHashSet::with_capacity(peer_count.majority_of_others()),
@@ -113,19 +112,18 @@ impl Downloader {
                 (undone_peers.iter()).chain(iter::once((&point_id.author, &author_state))),
             ),
             parse_queue: Vec::with_capacity(peer_count.reliable_minority()),
-            parse_slot: futures_util::future::pending().boxed(),
             downloading: FuturesUnordered::new(),
             interval,
             attempt: 0,
         };
         let downloaded = task
-            .run(dependers_rx, broadcast_result)
+            .run(&self.inner.peer_schedule, &ctx)
             .instrument(entered_span.exit())
             .await?;
 
         if matches!(downloaded, DownloadResult::NotFound) {
             tracing::warn!(
-                parent: task.ctx.span(),
+                parent: ctx.span(),
                 "not downloaded",
             );
         }
@@ -137,10 +135,9 @@ impl Downloader {
 }
 
 struct DownloadTask {
-    peer_schedule: PeerSchedule,
-    ctx: DownloadCtx,
-
     query: DownloadQuery,
+    dependers_rx: mpsc::UnboundedReceiver<PeerId>,
+    broadcast_result: oneshot::Receiver<DownloadResult>,
 
     peer_count: PeerCount,
     not_found: FastHashSet<PeerId>, // count peers towards `2F` to decide the point is unavailable
@@ -152,7 +149,6 @@ struct DownloadTask {
     downloading: FuturesUnordered<BoxFuture<'static, QueryFutureOutput<Bytes>>>,
 
     parse_queue: Vec<(PeerId, Bytes)>,
-    parse_slot: BoxFuture<'static, QueryFutureOutput<ParseResult>>,
 
     interval: Interval,
     attempt: u32,
@@ -168,22 +164,24 @@ impl DownloadTask {
     // recursively: every dependency is expected to be signed by 2/3+1
     pub async fn run(
         &mut self,
-        mut dependers_rx: mpsc::UnboundedReceiver<PeerId>,
-        mut broadcast_result: oneshot::Receiver<DownloadResult>,
+        peer_schedule: &PeerSchedule,
+        ctx: &DownloadCtx,
     ) -> TaskResult<DownloadResult> {
         // if parse slot is taken - neither create new queries nor increase task limit
         // but continue to poll created queries in order not to cancel them
         let mut parse_slot_taken = false;
+        let mut parse_slot: BoxFuture<'_, QueryFutureOutput<ParseResult>> =
+            futures_util::future::pending().boxed();
 
         loop {
             tokio::select! {
                 biased; // mandatory priority: signals lifecycle, updates, data lifecycle
-                bcast_result = &mut broadcast_result, if !broadcast_result.is_terminated() => {
+                bcast_result = &mut self.broadcast_result, if !self.broadcast_result.is_terminated() => {
                     if let Ok(bcast_result) = bcast_result {
                         break Ok(bcast_result);
                     }
                 },
-                Some(depender) = dependers_rx.recv() => self.add_depender(&depender),
+                Some(depender) = self.dependers_rx.recv() => self.add_depender(&depender),
                 update = self.updates.recv() => self.match_peer_updates(update)?,
                 Some(out) = self.downloading.next() => {
                     let new_result = match out.result {
@@ -191,7 +189,7 @@ impl DownloadTask {
                             if parse_slot_taken {
                                 self.parse_queue.push((out.peer_id, bytes));
                             } else {
-                                self.parse_slot = Self::parse(out.peer_id, bytes).boxed();
+                                parse_slot = parse(ctx.rayon(), out.peer_id, bytes);
                                 parse_slot_taken = true;
                             }
                             continue;
@@ -204,33 +202,33 @@ impl DownloadTask {
                         peer_id: out.peer_id,
                         result: new_result,
                     };
-                    if let Some(result) = self.inspect(new_out) {
+                    if let Some(result) = self.inspect(new_out, peer_schedule, ctx) {
                         break Ok(result);
                     } else if self.not_found.len() >= self.peer_count.majority_of_others() {
                         break Ok(DownloadResult::NotFound);
                     } else if !parse_slot_taken {
-                        self.download_random(); // keep the current request amount
+                        self.download_random(ctx); // keep the current request amount
                     }
                 },
-                parsed_out = &mut self.parse_slot, if parse_slot_taken => {
-                    if let Some(result) = self.inspect(parsed_out) {
+                parsed_out = &mut parse_slot, if parse_slot_taken => {
+                    if let Some(result) = self.inspect(parsed_out, peer_schedule, ctx) {
                         break Ok(result);
                     } else if self.not_found.len() >= self.peer_count.majority_of_others() {
                         break Ok(DownloadResult::NotFound);
                     }
                     if let Some((peer_id, bytes)) = self.parse_queue.pop() {
-                        self.parse_slot = Self::parse(peer_id, bytes).boxed();
+                        parse_slot = parse(ctx.rayon(), peer_id, bytes);
                     } else {
                         parse_slot_taken = false;
                     }
                     if !parse_slot_taken {
-                        self.download_random(); // keep the current request amount
+                        self.download_random(ctx); // keep the current request amount
                     }
                 }
                 // most rare arm to make progress despite slow responding peers
                 _ = self.interval.tick(), if !parse_slot_taken => {
                     // first tick fires immediately
-                    self.download_random();
+                    self.download_random(ctx);
                     self.attempt = self.attempt.wrapping_add(1);
                 },
             }
@@ -246,12 +244,12 @@ impl DownloadTask {
         });
     }
 
-    fn download_random(&mut self) {
+    fn download_random(&mut self, ctx: &DownloadCtx) {
         let amount = current_peers(
             self.attempt,
             self.downloading.len(),
             &self.peer_count,
-            self.ctx.conf(),
+            ctx.conf(),
         );
 
         for _ in 0..amount {
@@ -266,17 +264,12 @@ impl DownloadTask {
         }
     }
 
-    async fn parse(peer_id: PeerId, bytes: Bytes) -> QueryFutureOutput<ParseResult> {
-        let start = std::time::Instant::now();
-        let parse_result = rayon_run_fifo(|| Point::parse(bytes.into())).await;
-        metrics::histogram!("tycho_mempool_engine_parse_point_time").record(start.elapsed());
-        QueryFutureOutput {
-            peer_id,
-            result: Ok(DownloadResponse::Defined(parse_result)),
-        }
-    }
-
-    fn inspect(&mut self, out: QueryFutureOutput<ParseResult>) -> Option<DownloadResult> {
+    fn inspect(
+        &mut self,
+        out: QueryFutureOutput<ParseResult>,
+        peer_schedule: &PeerSchedule,
+        ctx: &DownloadCtx,
+    ) -> Option<DownloadResult> {
         // remove peer status: will not repeat request to the peer in this download task
         enum LastResponse {
             Point(Point),
@@ -285,6 +278,15 @@ impl DownloadTask {
             BadPoint(PointIntegrityError),
             TlError(tl_proto::TlError),
         }
+
+        let mut on_try_later = || {
+            if !self.undone_peers.update(&out.peer_id, |status| {
+                status.is_in_flight = false;
+                status.failed_queries = status.failed_queries.saturating_add(1);
+            }) {
+                panic!("Coding error: peer not in map {}", out.peer_id.alt());
+            };
+        };
 
         let last_response = match out.result {
             Ok(DownloadResponse::Defined(parse_result)) => match parse_result {
@@ -296,23 +298,12 @@ impl DownloadTask {
             Ok(DownloadResponse::DefinedNone) => LastResponse::DefinedNone,
             Err(QueryError::TlError(tl_error)) => LastResponse::TlError(tl_error),
             Ok(DownloadResponse::TryLater) => {
-                // apply the same retry strategy as for network errors
-                if !self.undone_peers.update(&out.peer_id, |status| {
-                    status.is_in_flight = false;
-                    status.failed_queries = status.failed_queries.saturating_add(1);
-                }) {
-                    panic!("Coding error: peer not in map {}", out.peer_id.alt());
-                };
+                on_try_later();
                 tracing::trace!(peer = display(out.peer_id.alt()), "try later");
                 return None;
             }
             Err(QueryError::Network(network_err)) => {
-                if !self.undone_peers.update(&out.peer_id, |status| {
-                    status.is_in_flight = false;
-                    status.failed_queries = status.failed_queries.saturating_add(1);
-                }) {
-                    panic!("Coding error: peer not in map {}", out.peer_id.alt());
-                };
+                on_try_later();
                 metrics::counter!("tycho_mempool_download_query_failed_count").increment(1);
                 tracing::debug!(
                     peer = display(out.peer_id.alt()),
@@ -410,7 +401,7 @@ impl DownloadTask {
                 None
             }
             LastResponse::Point(point) => {
-                match Verifier::verify(point.info(), &self.peer_schedule, self.ctx.conf()) {
+                match Verifier::verify(point.info(), peer_schedule, ctx.conf()) {
                     Ok(()) => Some(DownloadResult::Verified(point)), // `Some` breaks outer loop
                     Err(error) => {
                         tracing::error!(
@@ -445,6 +436,24 @@ impl DownloadTask {
             }
         }
     }
+}
+
+fn parse(
+    rayon: &MempoolRayon,
+    peer_id: PeerId,
+    bytes: Bytes,
+) -> BoxFuture<'_, QueryFutureOutput<ParseResult>> {
+    let parse_duration = HistogramGuard::begin("tycho_mempool_engine_parse_point_time");
+    rayon
+        .run_fifo(|| Point::parse(bytes.into()))
+        .map(move |parse_result| {
+            drop(parse_duration);
+            QueryFutureOutput {
+                peer_id,
+                result: Ok(DownloadResponse::Defined(parse_result)),
+            }
+        })
+        .boxed()
 }
 
 impl DownloadCtx {

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -12,6 +12,7 @@ pub mod test_utils;
 
 pub mod prelude {
     pub use crate::dag::WAVE_ROUNDS;
+    pub use crate::effects::MempoolRayon;
     pub use crate::engine::lifecycle::{EngineBinding, EngineNetworkArgs, EngineSession};
     pub use crate::engine::round_watch::{Commit, RoundWatch, TopKnownAnchor};
     pub use crate::engine::{

--- a/consensus/src/models/point/impl_.rs
+++ b/consensus/src/models/point/impl_.rs
@@ -328,7 +328,6 @@ mod tests {
     use anyhow::{Context, Result, ensure};
     use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
     use test_point::{PEERS, new_key_pair, payload, point, prev_point_data};
-    use tycho_util::sync::rayon_run;
 
     use super::*;
     use crate::test_utils::default_test_config;
@@ -388,12 +387,12 @@ mod tests {
         let (digest, data) = prev_point_data();
 
         let timer = Instant::now();
-        rayon_run(|| ()).await;
+        tycho_util::sync::rayon_run(|| ()).await;
         let elapsed = timer.elapsed();
         println!("init rayon took {}", humantime::format_duration(elapsed));
 
         let timer = Instant::now();
-        rayon_run(move || {
+        tycho_util::sync::rayon_run(move || {
             assert!(
                 data.iter()
                     .all(|(peer_id, sig)| sig.verifies(peer_id, &digest)),

--- a/consensus/src/test_utils/dag.rs
+++ b/consensus/src/test_utils/dag.rs
@@ -11,7 +11,7 @@ use tycho_network::{Network, OverlayId, PeerId, PrivateOverlay, Router};
 use tycho_util::FastHashMap;
 
 use crate::dag::{AnchorStage, DagRound, ValidateResult, Verifier};
-use crate::effects::{Ctx, EngineCtx, RoundCtx, TaskTracker, ValidateCtx};
+use crate::effects::{Ctx, EngineCtx, MempoolRayon, RoundCtx, TaskTracker, ValidateCtx};
 use crate::engine::MempoolConfig;
 use crate::intercom::{Dispatcher, Downloader, InitPeers, PeerSchedule, Responder};
 use crate::models::{
@@ -41,7 +41,10 @@ pub fn make_engine_parts<const PEER_COUNT: usize>(
 
     let dispatcher = Dispatcher::new(&network, &private_overlay, &Moderator::new_stub(), conf);
 
-    let engine_ctx = EngineCtx::new(conf.genesis_round, conf, &task_tracker);
+    let rayon = MempoolRayon::new(merged_conf.node_config().rayon_threads)
+        .expect("failed to create mempool rayon thread pool");
+
+    let engine_ctx = EngineCtx::new(conf.genesis_round, conf, &task_tracker, &rayon);
 
     // any peer id will be ok, network is not used
     let peer_schedule = PeerSchedule::new(local_keys, private_overlay);

--- a/scripts/gen-dashboard.py
+++ b/scripts/gen-dashboard.py
@@ -3095,10 +3095,6 @@ def mempool_misc() -> RowPanel:
             "Responder: query execution aborted (total at moment)",
             legend_format="{{instance}} - {{kind}}",
         ),
-        create_heatmap_panel(
-            "tycho_mempool_point_parse_verify_time",
-            "Responder and Downloader: point parse time (incl check sig and verify)",
-        ),
         create_counter_panel(
             expr_sum_increase(
                 "tycho_mempool_stats_merge_errors",
@@ -3109,15 +3105,40 @@ def mempool_misc() -> RowPanel:
             legend_format="{{instance}} - {{kind}}",
         ),
         create_heatmap_panel(
-            "tycho_mempool_engine_parse_point_time",
-            "Responder and Downloader: point parse task duration (async result)",
-        ),
-        create_heatmap_panel(
             "tycho_mempool_verifier_validate_time",
             "Verifier: validate() point dependencies in DAG and all-1 sigs",
         ),
     ]
     return create_row("Mempool misc", metrics)
+
+
+def mempool_rayon() -> RowPanel:
+    metrics = [
+        create_heatmap_panel(
+            "tycho_mempool_point_parse_verify_time",
+            "Responder and Downloader: point parse time (incl check sig and verify)",
+        ),
+        create_heatmap_panel(
+            "tycho_mempool_engine_parse_point_time",
+            "Responder and Downloader: point parse task duration (async result)",
+        ),
+        create_heatmap_panel(
+            "tycho_rayon_mempool_task_time",
+            "Mempool fifo Task Time",
+            yaxis(UNITS.SECONDS),
+        ),
+        create_heatmap_panel(
+            "tycho_rayon_mempool_queue_time",
+            "Mempool fifo Queue Time",
+            yaxis(UNITS.SECONDS),
+        ),
+        create_heatmap_panel(
+            "tycho_rayon_mempool_threads",
+            "Mempool fifo Threads",
+            yaxis(UNITS.NUMBER_FORMAT),
+        ),
+    ]
+    return create_row("Mempool rayon", metrics)
 
 
 def mempool_broadcasts() -> RowPanel:
@@ -3652,6 +3673,7 @@ dashboard = Dashboard(
         mempool_engine(),
         mempool_stats(),
         mempool_misc(),
+        mempool_rayon(),
         mempool_broadcasts(),
         mempool_downloads(),
         mempool_peers(),


### PR DESCRIPTION
## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

Added `.mempool.rayon_threads` default `4`

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

None

---

### COMPATIBILITY

Full

### SPECIAL DEPLOYMENT ACTIONS

Not Required

---

### PERFORMANCE IMPACT

a bit more stable broadcast rate

---

### TESTS

#### Unit Tests

No coverage

#### Network Tests

No coverage

#### Manual Tests

transfers-30k

---

**Notes/Additional Comments:**  

Rayon queue time reduced significantly.
Observed behavior: under load, when other CPU threads are busy, rayon gives 1 thread to mempool and that's enough on our devnets for better results.

<img width="1280" height="514" alt="image" src="https://github.com/user-attachments/assets/5054b9d8-01bc-4f56-b1e0-0605284642ff" />
<img width="1280" height="508" alt="image" src="https://github.com/user-attachments/assets/b064b1a0-23d8-479e-9737-4a06a150048c" />