### PR TITLE
queue commit rollback when queue ahead of mc state on restart

### DIFF
--- a/cli/src/node/mod.rs
+++ b/cli/src/node/mod.rs
@@ -7,16 +7,20 @@ use bytes::Bytes;
 use futures_util::future;
 use futures_util::future::BoxFuture;
 use tycho_block_util::block::BlockIdRelation;
+use tycho_block_util::state::ShardStateStuff;
 use tycho_collator::collator::CollatorStdImplFactory;
 use tycho_collator::internal_queue::queue::{QueueConfig, QueueFactory, QueueFactoryStdImpl};
 use tycho_collator::internal_queue::state::storage::QueueStateImplFactory;
+use tycho_collator::internal_queue::types::message::EnqueuedMessage;
 use tycho_collator::manager::CollationManager;
 use tycho_collator::mempool::{
     MempoolAdapter, MempoolAdapterSingleNodeImpl, MempoolAdapterStdImpl,
 };
 use tycho_collator::queue_adapter::{MessageQueueAdapter, MessageQueueAdapterStdImpl};
 use tycho_collator::state_node::{CollatorSyncContext, StateNodeAdapter, StateNodeAdapterStdImpl};
-use tycho_collator::types::CollatorConfig;
+use tycho_collator::types::{
+    CollatorConfig, ShardDescriptionShortExt, TopBlockId, TopBlockIdUpdated,
+};
 use tycho_collator::validator::{
     ValidatorNetworkContext, ValidatorStdImpl, ValidatorStdImplConfig,
 };
@@ -164,6 +168,55 @@ impl Node {
             .await
     }
 
+    fn recover_messages_queue_commit_state_after_restart(
+        message_queue_adapter: &impl MessageQueueAdapter<EnqueuedMessage>,
+        last_mc_block_id: &BlockId,
+        mc_state: &ShardStateStuff,
+    ) -> Result<()> {
+        let mut top_shards_for_queue_clean = mc_state.get_top_shards()?;
+
+        // rollback commit pointers if committed queue is ahead of last applied mc state
+        if let Some(last_committed_mc_block_id) =
+            message_queue_adapter.get_last_committed_mc_block_id()?
+        {
+            if last_committed_mc_block_id.seqno > last_mc_block_id.seqno {
+                let top_shard_blocks_info = mc_state
+                    .shards()?
+                    .iter()
+                    .map(|item| {
+                        let (shard_id, shard_descr) = item?;
+                        Ok(TopBlockIdUpdated {
+                            block: TopBlockId {
+                                ref_by_mc_seqno: shard_descr.reg_mc_seqno,
+                                block_id: shard_descr.get_block_id(shard_id),
+                            },
+                            updated: shard_descr.top_sc_block_updated,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                let removed_commit_pointer_shards = message_queue_adapter
+                    .rollback_commit_pointers(last_mc_block_id, top_shard_blocks_info)?;
+                for shard in removed_commit_pointer_shards {
+                    if !top_shards_for_queue_clean.contains(&shard) {
+                        top_shards_for_queue_clean.push(shard);
+                    }
+                }
+            } else {
+                anyhow::ensure!(
+                    last_committed_mc_block_id.seqno != last_mc_block_id.seqno
+                        || last_committed_mc_block_id == *last_mc_block_id,
+                    "internal messages queue is committed on different masterchain block: queue={}, applied={}",
+                    last_committed_mc_block_id,
+                    last_mc_block_id,
+                );
+            }
+        }
+
+        // We should clear uncommitted queue state because it may contain incorrect diffs
+        // that were created before node restart. We will restore queue strictly above last committed state
+        message_queue_adapter.clear_uncommitted_state(&top_shards_for_queue_clean)
+    }
+
     pub async fn run(self, last_block_id: &BlockId, is_single_node: bool) -> Result<()> {
         let base = &self.base;
 
@@ -217,10 +270,11 @@ impl Node {
         let queue = queue_factory.create()?;
         let message_queue_adapter = MessageQueueAdapterStdImpl::new(queue);
 
-        // We should clear uncommitted queue state because it may contain incorrect diffs
-        // that were created before node restart. We will restore queue strictly above last committed state
-        let top_shards = mc_state.get_top_shards()?;
-        message_queue_adapter.clear_uncommitted_state(&top_shards)?;
+        Self::recover_messages_queue_commit_state_after_restart(
+            &message_queue_adapter,
+            last_block_id,
+            &mc_state,
+        )?;
 
         let validator = ValidatorStdImpl::new(
             ValidatorNetworkContext {

--- a/cli/src/node/mod.rs
+++ b/cli/src/node/mod.rs
@@ -7,20 +7,16 @@ use bytes::Bytes;
 use futures_util::future;
 use futures_util::future::BoxFuture;
 use tycho_block_util::block::BlockIdRelation;
-use tycho_block_util::state::ShardStateStuff;
 use tycho_collator::collator::CollatorStdImplFactory;
 use tycho_collator::internal_queue::queue::{QueueConfig, QueueFactory, QueueFactoryStdImpl};
 use tycho_collator::internal_queue::state::storage::QueueStateImplFactory;
-use tycho_collator::internal_queue::types::message::EnqueuedMessage;
 use tycho_collator::manager::CollationManager;
 use tycho_collator::mempool::{
     MempoolAdapter, MempoolAdapterSingleNodeImpl, MempoolAdapterStdImpl,
 };
 use tycho_collator::queue_adapter::{MessageQueueAdapter, MessageQueueAdapterStdImpl};
 use tycho_collator::state_node::{CollatorSyncContext, StateNodeAdapter, StateNodeAdapterStdImpl};
-use tycho_collator::types::{
-    CollatorConfig, ShardDescriptionShortExt, TopBlockId, TopBlockIdUpdated,
-};
+use tycho_collator::types::CollatorConfig;
 use tycho_collator::validator::{
     ValidatorNetworkContext, ValidatorStdImpl, ValidatorStdImplConfig,
 };
@@ -168,55 +164,6 @@ impl Node {
             .await
     }
 
-    fn recover_messages_queue_commit_state_after_restart(
-        message_queue_adapter: &impl MessageQueueAdapter<EnqueuedMessage>,
-        last_mc_block_id: &BlockId,
-        mc_state: &ShardStateStuff,
-    ) -> Result<()> {
-        let mut top_shards_for_queue_clean = mc_state.get_top_shards()?;
-
-        // rollback commit pointers if committed queue is ahead of last applied mc state
-        if let Some(last_committed_mc_block_id) =
-            message_queue_adapter.get_last_committed_mc_block_id()?
-        {
-            if last_committed_mc_block_id.seqno > last_mc_block_id.seqno {
-                let top_shard_blocks_info = mc_state
-                    .shards()?
-                    .iter()
-                    .map(|item| {
-                        let (shard_id, shard_descr) = item?;
-                        Ok(TopBlockIdUpdated {
-                            block: TopBlockId {
-                                ref_by_mc_seqno: shard_descr.reg_mc_seqno,
-                                block_id: shard_descr.get_block_id(shard_id),
-                            },
-                            updated: shard_descr.top_sc_block_updated,
-                        })
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-                let removed_commit_pointer_shards = message_queue_adapter
-                    .rollback_commit_pointers(last_mc_block_id, top_shard_blocks_info)?;
-                for shard in removed_commit_pointer_shards {
-                    if !top_shards_for_queue_clean.contains(&shard) {
-                        top_shards_for_queue_clean.push(shard);
-                    }
-                }
-            } else {
-                anyhow::ensure!(
-                    last_committed_mc_block_id.seqno != last_mc_block_id.seqno
-                        || last_committed_mc_block_id == *last_mc_block_id,
-                    "internal messages queue is committed on different masterchain block: queue={}, applied={}",
-                    last_committed_mc_block_id,
-                    last_mc_block_id,
-                );
-            }
-        }
-
-        // We should clear uncommitted queue state because it may contain incorrect diffs
-        // that were created before node restart. We will restore queue strictly above last committed state
-        message_queue_adapter.clear_uncommitted_state(&top_shards_for_queue_clean)
-    }
-
     pub async fn run(self, last_block_id: &BlockId, is_single_node: bool) -> Result<()> {
         let base = &self.base;
 
@@ -269,12 +216,7 @@ impl Node {
         };
         let queue = queue_factory.create()?;
         let message_queue_adapter = MessageQueueAdapterStdImpl::new(queue);
-
-        Self::recover_messages_queue_commit_state_after_restart(
-            &message_queue_adapter,
-            last_block_id,
-            &mc_state,
-        )?;
+        message_queue_adapter.recover_after_restart(&mc_state)?;
 
         let validator = ValidatorStdImpl::new(
             ValidatorNetworkContext {

--- a/collator/src/internal_queue/queue.rs
+++ b/collator/src/internal_queue/queue.rs
@@ -124,6 +124,13 @@ where
         partitions: &FastHashSet<QueuePartitionIdx>,
     ) -> Result<()>;
 
+    /// Roll back commit pointers to the specified top blocks.
+    fn rollback_commit_pointers(
+        &self,
+        to_mc_block_id: &BlockId,
+        to_top_blocks: &[TopBlockIdUpdated],
+    ) -> Result<Vec<ShardIdent>>;
+
     /// Remove all data in uncommitted zone
     fn clear_uncommitted_state(
         &self,
@@ -432,6 +439,65 @@ where
         }
 
         Ok(())
+    }
+
+    fn rollback_commit_pointers(
+        &self,
+        to_mc_block_id: &BlockId,
+        to_top_blocks: &[TopBlockIdUpdated],
+    ) -> Result<Vec<ShardIdent>> {
+        let _global_write_guard = self.global_lock.write();
+
+        let mut new_commit_pointers = FastHashMap::default();
+
+        for item in to_top_blocks {
+            let block_id = &item.block.block_id;
+
+            let diff = self
+                .state
+                .get_diff_info(&block_id.shard, block_id.seqno, DiffZone::Both)?;
+
+            let diff = match diff {
+                None if item.updated && item.block.ref_by_mc_seqno > self.zerostate_id.seqno => {
+                    bail!(
+                        "Diff not found for block_id: {} ref {} zerostate {} during commit pointers rollback",
+                        block_id,
+                        item.block.ref_by_mc_seqno,
+                        self.zerostate_id.seqno
+                    )
+                }
+                None => continue,
+                Some(diff) => diff,
+            };
+
+            if new_commit_pointers
+                .insert(block_id.shard, (diff.max_message, diff.seqno))
+                .is_some()
+            {
+                bail!(
+                    "Duplicate shard in rollback_commit_pointers: {}",
+                    block_id.shard
+                );
+            }
+        }
+
+        let old_commit_pointers = self.state.get_commit_pointers()?;
+        let removed_commit_pointer_shards: Vec<_> = old_commit_pointers
+            .keys()
+            .filter(|shard_id| !new_commit_pointers.contains_key(shard_id))
+            .copied()
+            .collect();
+
+        tracing::debug!(target: tracing_targets::MQ,
+            ?new_commit_pointers,
+            ?removed_commit_pointer_shards,
+            "rollback_commit_pointers",
+        );
+
+        self.state
+            .replace_commit_pointers(new_commit_pointers, to_mc_block_id)?;
+
+        Ok(removed_commit_pointer_shards)
     }
 
     fn clear_uncommitted_state(

--- a/collator/src/internal_queue/queue.rs
+++ b/collator/src/internal_queue/queue.rs
@@ -448,6 +448,7 @@ where
     ) -> Result<Vec<ShardIdent>> {
         let _global_write_guard = self.global_lock.write();
 
+        let old_commit_pointers = self.state.get_commit_pointers()?;
         let mut new_commit_pointers = FastHashMap::default();
 
         for item in to_top_blocks {
@@ -466,6 +467,29 @@ where
                         self.zerostate_id.seqno
                     )
                 }
+                None if !item.updated => {
+                    if let Some(old_pointer) = old_commit_pointers.get(&block_id.shard) {
+                        if old_pointer.seqno != block_id.seqno {
+                            bail!(
+                                "Cannot roll back commit pointer for unchanged shard {} to seqno {}: \
+                                target diff is missing and old pointer seqno is {}",
+                                block_id.shard,
+                                block_id.seqno,
+                                old_pointer.seqno,
+                            );
+                        }
+                        if new_commit_pointers
+                            .insert(block_id.shard, (old_pointer.queue_key, old_pointer.seqno))
+                            .is_some()
+                        {
+                            bail!(
+                                "Duplicate shard in rollback_commit_pointers: {}",
+                                block_id.shard
+                            );
+                        }
+                    }
+                    continue;
+                }
                 None => continue,
                 Some(diff) => diff,
             };
@@ -481,7 +505,6 @@ where
             }
         }
 
-        let old_commit_pointers = self.state.get_commit_pointers()?;
         let removed_commit_pointer_shards: Vec<_> = old_commit_pointers
             .keys()
             .filter(|shard_id| !new_commit_pointers.contains_key(shard_id))

--- a/collator/src/internal_queue/state/storage.rs
+++ b/collator/src/internal_queue/state/storage.rs
@@ -93,6 +93,14 @@ pub trait QueueState<V: InternalMessageValue>: Send + Sync {
         mc_block_id: &BlockId,
     ) -> Result<()>;
 
+    /// Replace commit pointers and last committed mc block id.
+    /// ATTENTION! Overrides old value without checks. Should validate the new value in the calling code.
+    fn replace_commit_pointers(
+        &self,
+        commit_pointers: FastHashMap<ShardIdent, (QueueKey, u32)>,
+        mc_block_id: &BlockId,
+    ) -> Result<()>;
+
     /// Load statistics for given partition and ranges
     fn load_diff_statistics(
         &self,
@@ -211,13 +219,18 @@ impl<V: InternalMessageValue> QueueState<V> for QueueStateStdImpl {
     ) -> Result<()> {
         let mut tx = self.storage.begin_transaction();
         tx.commit_messages(commit_pointers)?;
-        tx.set_last_committed_mc_block_id(mc_block_id)?;
-        tx.write()?;
-        let db = self.storage.db();
-        db.rocksdb()
-            .flush_cf(&db.internal_message_commit_pointer.cf())?;
-        db.rocksdb().flush_cf(&db.internal_message_var.cf())?;
-        Ok(())
+        self.write_commit_transaction(tx, mc_block_id)
+    }
+
+    fn replace_commit_pointers(
+        &self,
+        commit_pointers: FastHashMap<ShardIdent, (QueueKey, u32)>,
+        mc_block_id: &BlockId,
+    ) -> Result<()> {
+        let old_commit_pointers = self.storage.make_snapshot().read_commit_pointers()?;
+        let mut tx = self.storage.begin_transaction();
+        tx.replace_commit_pointers(&old_commit_pointers, commit_pointers)?;
+        self.write_commit_transaction(tx, mc_block_id)
     }
 
     fn load_diff_statistics(
@@ -383,6 +396,20 @@ impl<V: InternalMessageValue> QueueState<V> for QueueStateStdImpl {
 }
 
 impl QueueStateStdImpl {
+    fn write_commit_transaction(
+        &self,
+        mut tx: InternalQueueTransaction,
+        mc_block_id: &BlockId,
+    ) -> Result<()> {
+        tx.set_last_committed_mc_block_id(mc_block_id)?;
+        tx.write()?;
+        let db = self.storage.db();
+        db.rocksdb()
+            .flush_cf(&db.internal_message_commit_pointer.cf())?;
+        db.rocksdb().flush_cf(&db.internal_message_var.cf())?;
+        Ok(())
+    }
+
     /// write new messages to storage
     fn add_messages<V: InternalMessageValue>(
         internal_queue_tx: &mut InternalQueueTransaction,

--- a/collator/src/queue_adapter.rs
+++ b/collator/src/queue_adapter.rs
@@ -74,6 +74,13 @@ where
         partitions: &FastHashSet<QueuePartitionIdx>,
     ) -> Result<()>;
 
+    /// Roll back commit pointers to the specified top blocks.
+    fn rollback_commit_pointers(
+        &self,
+        to_mc_block_id: &BlockId,
+        to_top_shard_blocks: Vec<TopBlockIdUpdated>,
+    ) -> Result<Vec<ShardIdent>>;
+
     fn clear_uncommitted_state(&self, top_shards: &[ShardIdent]) -> Result<()>;
 
     /// Get diff for the given block from committed and/or uncommitted zone
@@ -266,6 +273,38 @@ impl<V: InternalMessageValue> MessageQueueAdapter<V> for MessageQueueAdapterStdI
         );
 
         Ok(())
+    }
+
+    #[instrument(skip_all, fields(%to_mc_block_id))]
+    fn rollback_commit_pointers(
+        &self,
+        to_mc_block_id: &BlockId,
+        to_top_shard_blocks: Vec<TopBlockIdUpdated>,
+    ) -> Result<Vec<ShardIdent>> {
+        let start_time = std::time::Instant::now();
+
+        let mut to_top_blocks = to_top_shard_blocks;
+        to_top_blocks.push(TopBlockIdUpdated {
+            block: crate::types::TopBlockId {
+                ref_by_mc_seqno: to_mc_block_id.seqno,
+                block_id: *to_mc_block_id,
+            },
+            updated: true,
+        });
+
+        let removed_commit_pointer_shards = self
+            .queue
+            .rollback_commit_pointers(to_mc_block_id, &to_top_blocks)?;
+
+        let elapsed = start_time.elapsed();
+        tracing::info!(target: tracing_targets::MQ_ADAPTER,
+            top_blocks = ?to_top_blocks,
+            ?removed_commit_pointer_shards,
+            elapsed = %humantime::format_duration(elapsed),
+            "rollback_commit_pointers completed"
+        );
+
+        Ok(removed_commit_pointer_shards)
     }
 
     #[instrument(skip_all)]

--- a/collator/src/queue_adapter.rs
+++ b/collator/src/queue_adapter.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use tracing::instrument;
 use tycho_block_util::queue::{QueueKey, QueuePartitionIdx};
+use tycho_block_util::state::ShardStateStuff;
 use tycho_types::cell::HashBytes;
 use tycho_types::models::{BlockId, BlockIdShort, ShardIdent};
 use tycho_util::metrics::HistogramGuard;
@@ -20,7 +21,9 @@ use crate::internal_queue::types::stats::{
 use crate::storage::models::DiffInfo;
 use crate::storage::snapshot::AccountStatistics;
 use crate::tracing_targets;
-use crate::types::{DebugDisplayOpt, DebugIter, TopBlockIdUpdated};
+use crate::types::{
+    DebugDisplayOpt, DebugIter, ShardDescriptionShortExt, TopBlockId, TopBlockIdUpdated,
+};
 
 pub struct MessageQueueAdapterStdImpl<V: InternalMessageValue> {
     queue: QueueImpl<QueueStateStdImpl, V>,
@@ -118,6 +121,55 @@ where
         diff_info: DiffInfo,
         partition: QueuePartitionIdx,
     ) -> Result<(PartitionRouter, DiffStatistics)>;
+
+    /// Recovers message queue state after restart.
+    fn recover_after_restart(&self, mc_state: &ShardStateStuff) -> Result<()> {
+        let mc_block_id = mc_state.block_id();
+        assert!(
+            mc_block_id.is_masterchain(),
+            "latest masterchain block id and state must be provided"
+        );
+
+        let mut top_shards_for_queue_clean = mc_state.get_top_shards()?;
+
+        // rollback commit pointers if committed queue is ahead of last applied mc state
+        if let Some(last_committed_mc_block_id) = self.get_last_committed_mc_block_id()? {
+            if last_committed_mc_block_id.seqno > mc_block_id.seqno {
+                let top_shard_blocks_info = mc_state
+                    .shards()?
+                    .iter()
+                    .map(|item| {
+                        let (shard_id, shard_descr) = item?;
+                        Ok(TopBlockIdUpdated {
+                            block: TopBlockId {
+                                ref_by_mc_seqno: shard_descr.reg_mc_seqno,
+                                block_id: shard_descr.get_block_id(shard_id),
+                            },
+                            updated: shard_descr.top_sc_block_updated,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                let removed_commit_pointer_shards =
+                    self.rollback_commit_pointers(mc_block_id, top_shard_blocks_info)?;
+                for shard in removed_commit_pointer_shards {
+                    if !top_shards_for_queue_clean.contains(&shard) {
+                        top_shards_for_queue_clean.push(shard);
+                    }
+                }
+            } else {
+                anyhow::ensure!(
+                    last_committed_mc_block_id.seqno != mc_block_id.seqno
+                        || last_committed_mc_block_id == *mc_block_id,
+                    "internal messages queue is committed on different masterchain block: \
+                    queue={last_committed_mc_block_id}, applied={mc_block_id}",
+                );
+            }
+        }
+
+        // We should clear uncommitted queue state because it may contain incorrect diffs
+        // that were created before node restart. We will restore queue strictly above last committed state
+        self.clear_uncommitted_state(&top_shards_for_queue_clean)
+    }
 }
 
 impl<V: InternalMessageValue> MessageQueueAdapterStdImpl<V> {

--- a/collator/src/storage/transaction.rs
+++ b/collator/src/storage/transaction.rs
@@ -85,6 +85,27 @@ impl InternalQueueTransaction {
         Ok(())
     }
 
+    /// Replaces all commit pointers with the provided set.
+    pub fn replace_commit_pointers(
+        &mut self,
+        old_commit_pointers: &FastHashMap<ShardIdent, CommitPointerValue>,
+        commit_pointers: FastHashMap<ShardIdent, (QueueKey, u32)>,
+    ) -> Result<()> {
+        let commit_pointers_cf = self.db.internal_message_commit_pointer.cf();
+
+        for shard_ident in old_commit_pointers.keys() {
+            if !commit_pointers.contains_key(shard_ident) {
+                let key = CommitPointerKey {
+                    shard_ident: *shard_ident,
+                }
+                .to_vec();
+                self.batch.delete_cf(&commit_pointers_cf, key);
+            }
+        }
+
+        self.commit_messages(commit_pointers)
+    }
+
     /// Removes all keys that are strictly above the committed pointers in each partition.
     /// (Anything above `pointer + 1` is considered "uncommitted" and will be deleted.)
     ///
@@ -115,10 +136,9 @@ impl InternalQueueTransaction {
             }
         }
 
-        // backoff: if no commit pointers (no any committed diff)
-        //          create full ranges for delete for each shard
-        if ranges.is_empty() {
-            for &shard_ident in top_shards {
+        // backoff: if no commit pointer for a shard, delete the full shard range
+        for &shard_ident in top_shards {
+            if !commit_pointers.contains_key(&shard_ident) {
                 for &partition in partitions {
                     ranges.push(QueueRange {
                         shard_ident,

--- a/collator/tests/internal_queue.rs
+++ b/collator/tests/internal_queue.rs
@@ -15,6 +15,7 @@ use tycho_collator::internal_queue::types::ranges::QueueShardRange;
 use tycho_collator::internal_queue::types::router::PartitionRouter;
 use tycho_collator::internal_queue::types::stats::DiffStatistics;
 use tycho_collator::storage::InternalQueueStorage;
+use tycho_collator::storage::models::QueueRange;
 use tycho_collator::storage::snapshot::{AccountStatistics, InternalQueueSnapshot};
 use tycho_collator::types::{TopBlockId, TopBlockIdUpdated};
 use tycho_core::global_config::ZerostateId;
@@ -1615,10 +1616,56 @@ async fn test_version() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_rollback_commit_pointers() -> anyhow::Result<()> {
-    let (ctx, _tmp_dir) = StorageContext::new_temp().await?;
+struct RollbackCommitPointersTestData {
+    _tmp_dir: tempfile::TempDir,
+    storage: InternalQueueStorage,
+    partitions: FastHashSet<QueuePartitionIdx>,
+    queue: QueueImpl<QueueStateStdImpl, StoredObject>,
+    shard: ShardIdent,
+    block_mc1: BlockId,
+    block_sc1: BlockId,
+    block_mc2: BlockId,
+    block_mc3: BlockId,
+    block_sc2: BlockId,
+    block_mc4: BlockId,
+    top_mc1: Vec<TopBlockIdUpdated>,
+    top_mc2: Vec<TopBlockIdUpdated>,
+    top_mc3: Vec<TopBlockIdUpdated>,
+    top_mc4: Vec<TopBlockIdUpdated>,
+    diff_sc2: QueueDiffWithMessages<StoredObject>,
+    diff_mc4: QueueDiffWithMessages<StoredObject>,
+    hash_sc2: HashBytes,
+    hash_mc4: HashBytes,
+}
 
+fn create_rollback_commit_pointers_diff(
+    key: u64,
+    account: u8,
+) -> anyhow::Result<QueueDiffWithMessages<StoredObject>> {
+    let mut diff = QueueDiffWithMessages::new();
+    let stored_object = create_stored_object(key, RouterAddr {
+        workchain: -1,
+        account: HashBytes::from([account; 32]),
+    })?;
+    diff.messages.insert(stored_object.key(), stored_object);
+    Ok(diff)
+}
+
+fn create_rollback_commit_pointers_statistics(
+    diff: &QueueDiffWithMessages<StoredObject>,
+    block_id: &BlockId,
+) -> DiffStatistics {
+    DiffStatistics::from_diff(
+        diff,
+        block_id.shard,
+        diff.min_message().cloned().unwrap_or_default(),
+        diff.max_message().cloned().unwrap_or_default(),
+    )
+}
+
+async fn prepare_rollback_commit_pointers_test_data()
+-> anyhow::Result<RollbackCommitPointersTestData> {
+    let (ctx, _tmp_dir) = StorageContext::new_temp().await?;
     let queue_factory = QueueFactoryStdImpl {
         state: QueueStateImplFactory::new(ctx)?,
         config: QueueConfig {
@@ -1626,31 +1673,10 @@ async fn test_rollback_commit_pointers() -> anyhow::Result<()> {
         },
         zerostate_id: ZerostateId::default(),
     };
-
+    let storage = queue_factory.state.storage.clone();
     let partitions = FastHashSet::from_iter([0, 1].map(QueuePartitionIdx));
-
     let queue: QueueImpl<QueueStateStdImpl, StoredObject> = queue_factory.create()?;
-
     let shard = ShardIdent::new_full(0);
-
-    let create_diff = |key, account| -> anyhow::Result<QueueDiffWithMessages<StoredObject>> {
-        let mut diff = QueueDiffWithMessages::new();
-        let stored_object = create_stored_object(key, RouterAddr {
-            workchain: -1,
-            account: HashBytes::from([account; 32]),
-        })?;
-        diff.messages.insert(stored_object.key(), stored_object);
-        Ok(diff)
-    };
-    let create_statistics = |diff: &QueueDiffWithMessages<StoredObject>, block_id: &BlockId| {
-        DiffStatistics::from_diff(
-            diff,
-            block_id.shard,
-            diff.min_message().cloned().unwrap_or_default(),
-            diff.max_message().cloned().unwrap_or_default(),
-        )
-    };
-
     let block_mc1 = BlockId {
         shard: ShardIdent::MASTERCHAIN,
         seqno: 1,
@@ -1742,26 +1768,23 @@ async fn test_rollback_commit_pointers() -> anyhow::Result<()> {
             updated: true,
         },
     ];
-    let diff_mc1 = create_diff(1, 1)?;
-    let diff_sc1 = create_diff(2, 2)?;
-    let diff_mc2 = create_diff(3, 3)?;
-    let diff_mc3 = create_diff(4, 4)?;
-    let diff_sc2 = create_diff(5, 5)?;
-    let diff_mc4 = create_diff(6, 6)?;
+    let diff_mc1 = create_rollback_commit_pointers_diff(1, 1)?;
+    let diff_sc1 = create_rollback_commit_pointers_diff(2, 2)?;
+    let diff_mc2 = create_rollback_commit_pointers_diff(3, 3)?;
+    let diff_mc3 = create_rollback_commit_pointers_diff(4, 4)?;
+    let diff_sc2 = create_rollback_commit_pointers_diff(5, 5)?;
+    let diff_mc4 = create_rollback_commit_pointers_diff(6, 6)?;
     let hash_mc1 = HashBytes::from([1; 32]);
     let hash_sc1 = HashBytes::from([2; 32]);
     let hash_mc2 = HashBytes::from([3; 32]);
     let hash_mc3 = HashBytes::from([4; 32]);
     let hash_sc2 = HashBytes::from([5; 32]);
     let hash_mc4 = HashBytes::from([6; 32]);
-    let top_shards = [ShardIdent::MASTERCHAIN, shard];
-
-    // build and commit the full mc1 -> sb1 -> mc2 -> mc3 -> sb2 -> mc4 queue chain
     queue.apply_diff(
         diff_mc1.clone(),
         block_mc1.as_short_id(),
         &hash_mc1,
-        create_statistics(&diff_mc1, &block_mc1),
+        create_rollback_commit_pointers_statistics(&diff_mc1, &block_mc1),
         Some(DiffZone::Both),
     )?;
     queue.commit_diff(&top_mc1, &partitions)?;
@@ -1769,14 +1792,14 @@ async fn test_rollback_commit_pointers() -> anyhow::Result<()> {
         diff_sc1.clone(),
         block_sc1.as_short_id(),
         &hash_sc1,
-        create_statistics(&diff_sc1, &block_sc1),
+        create_rollback_commit_pointers_statistics(&diff_sc1, &block_sc1),
         Some(DiffZone::Both),
     )?;
     queue.apply_diff(
         diff_mc2.clone(),
         block_mc2.as_short_id(),
         &hash_mc2,
-        create_statistics(&diff_mc2, &block_mc2),
+        create_rollback_commit_pointers_statistics(&diff_mc2, &block_mc2),
         Some(DiffZone::Committed),
     )?;
     queue.commit_diff(&top_mc2, &partitions)?;
@@ -1784,7 +1807,7 @@ async fn test_rollback_commit_pointers() -> anyhow::Result<()> {
         diff_mc3.clone(),
         block_mc3.as_short_id(),
         &hash_mc3,
-        create_statistics(&diff_mc3, &block_mc3),
+        create_rollback_commit_pointers_statistics(&diff_mc3, &block_mc3),
         Some(DiffZone::Committed),
     )?;
     queue.commit_diff(&top_mc3, &partitions)?;
@@ -1792,18 +1815,65 @@ async fn test_rollback_commit_pointers() -> anyhow::Result<()> {
         diff_sc2.clone(),
         block_sc2.as_short_id(),
         &hash_sc2,
-        create_statistics(&diff_sc2, &block_sc2),
+        create_rollback_commit_pointers_statistics(&diff_sc2, &block_sc2),
         Some(DiffZone::Committed),
     )?;
     queue.apply_diff(
         diff_mc4.clone(),
         block_mc4.as_short_id(),
         &hash_mc4,
-        create_statistics(&diff_mc4, &block_mc4),
+        create_rollback_commit_pointers_statistics(&diff_mc4, &block_mc4),
         Some(DiffZone::Committed),
     )?;
     queue.commit_diff(&top_mc4, &partitions)?;
     assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc4));
+    Ok(RollbackCommitPointersTestData {
+        _tmp_dir,
+        storage,
+        partitions,
+        queue,
+        shard,
+        block_mc1,
+        block_sc1,
+        block_mc2,
+        block_mc3,
+        block_sc2,
+        block_mc4,
+        top_mc1,
+        top_mc2,
+        top_mc3,
+        top_mc4,
+        diff_sc2,
+        diff_mc4,
+        hash_sc2,
+        hash_mc4,
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_rollback_commit_pointers() -> anyhow::Result<()> {
+    let RollbackCommitPointersTestData {
+        _tmp_dir,
+        partitions,
+        queue,
+        shard,
+        block_mc1,
+        block_sc1,
+        block_mc2,
+        block_mc3,
+        block_sc2,
+        block_mc4,
+        top_mc1,
+        top_mc2,
+        top_mc3,
+        top_mc4,
+        diff_sc2,
+        diff_mc4,
+        hash_sc2,
+        hash_mc4,
+        ..
+    } = prepare_rollback_commit_pointers_test_data().await?;
+    let top_shards = [ShardIdent::MASTERCHAIN, shard];
 
     // first rollback: mc4 -> mc3, then cleanup and recommit the same sb2/mc4 diffs
     let removed_commit_pointer_shards = queue.rollback_commit_pointers(&block_mc3, &top_mc3)?;
@@ -1838,14 +1908,14 @@ async fn test_rollback_commit_pointers() -> anyhow::Result<()> {
         diff_sc2.clone(),
         block_sc2.as_short_id(),
         &hash_sc2,
-        create_statistics(&diff_sc2, &block_sc2),
+        create_rollback_commit_pointers_statistics(&diff_sc2, &block_sc2),
         Some(DiffZone::Committed),
     )?;
     queue.apply_diff(
         diff_mc4.clone(),
         block_mc4.as_short_id(),
         &hash_mc4,
-        create_statistics(&diff_mc4, &block_mc4),
+        create_rollback_commit_pointers_statistics(&diff_mc4, &block_mc4),
         Some(DiffZone::Committed),
     )?;
     queue.commit_diff(&top_mc4, &partitions)?;
@@ -1885,6 +1955,47 @@ async fn test_rollback_commit_pointers() -> anyhow::Result<()> {
             .is_none()
     );
 
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_rollback_commit_pointers_missing_unchanged_diff_keeps_old_state() -> anyhow::Result<()>
+{
+    let RollbackCommitPointersTestData {
+        _tmp_dir,
+        storage,
+        partitions,
+        queue,
+        shard,
+        block_sc1,
+        block_sc2,
+        block_mc3,
+        block_mc4,
+        top_mc3,
+        ..
+    } = prepare_rollback_commit_pointers_test_data().await?;
+    let ranges: Vec<_> = partitions
+        .iter()
+        .map(|partition| QueueRange {
+            shard_ident: shard,
+            partition: *partition,
+            from: QueueKey::MIN,
+            to: QueueKey::MAX,
+        })
+        .collect();
+    storage.begin_transaction().delete(&ranges)?;
+    assert!(
+        queue
+            .get_diff_info(&shard, block_sc1.seqno, DiffZone::Both)?
+            .is_none()
+    );
+    let err = queue
+        .rollback_commit_pointers(&block_mc3, &top_mc3)
+        .unwrap_err();
+    assert!(err.to_string().contains("target diff is missing"));
+    assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc4));
+    let commit_pointers = storage.make_snapshot().read_commit_pointers()?;
+    assert_eq!(commit_pointers.get(&shard).unwrap().seqno, block_sc2.seqno);
     Ok(())
 }
 

--- a/collator/tests/internal_queue.rs
+++ b/collator/tests/internal_queue.rs
@@ -1508,6 +1508,7 @@ async fn test_version() -> anyhow::Result<()> {
 
     let queue: QueueImpl<QueueStateStdImpl, StoredObject> = queue_factory.create()?;
 
+    // define the applied mc block, the ahead mc block, and an extra shard top block
     let block_mc1 = BlockId {
         shard: ShardIdent::MASTERCHAIN,
         seqno: 1,
@@ -1610,6 +1611,279 @@ async fn test_version() -> anyhow::Result<()> {
 
     let version = queue.get_last_committed_mc_block_id()?;
     assert_eq!(version, Some(block_mc2));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_rollback_commit_pointers() -> anyhow::Result<()> {
+    let (ctx, _tmp_dir) = StorageContext::new_temp().await?;
+
+    let queue_factory = QueueFactoryStdImpl {
+        state: QueueStateImplFactory::new(ctx)?,
+        config: QueueConfig {
+            gc_interval: Duration::from_secs(1),
+        },
+        zerostate_id: ZerostateId::default(),
+    };
+
+    let partitions = FastHashSet::from_iter([0, 1].map(QueuePartitionIdx));
+
+    let queue: QueueImpl<QueueStateStdImpl, StoredObject> = queue_factory.create()?;
+
+    let shard = ShardIdent::new_full(0);
+
+    let create_diff = |key, account| -> anyhow::Result<QueueDiffWithMessages<StoredObject>> {
+        let mut diff = QueueDiffWithMessages::new();
+        let stored_object = create_stored_object(key, RouterAddr {
+            workchain: -1,
+            account: HashBytes::from([account; 32]),
+        })?;
+        diff.messages.insert(stored_object.key(), stored_object);
+        Ok(diff)
+    };
+    let create_statistics = |diff: &QueueDiffWithMessages<StoredObject>, block_id: &BlockId| {
+        DiffStatistics::from_diff(
+            diff,
+            block_id.shard,
+            diff.min_message().cloned().unwrap_or_default(),
+            diff.max_message().cloned().unwrap_or_default(),
+        )
+    };
+
+    let block_mc1 = BlockId {
+        shard: ShardIdent::MASTERCHAIN,
+        seqno: 1,
+        root_hash: HashBytes::from([11; 32]),
+        file_hash: HashBytes::from([12; 32]),
+    };
+    let block_sc1 = BlockId {
+        shard,
+        seqno: 1,
+        root_hash: HashBytes::from([21; 32]),
+        file_hash: HashBytes::from([22; 32]),
+    };
+    let block_mc2 = BlockId {
+        shard: ShardIdent::MASTERCHAIN,
+        seqno: 2,
+        root_hash: HashBytes::from([31; 32]),
+        file_hash: HashBytes::from([32; 32]),
+    };
+    let block_mc3 = BlockId {
+        shard: ShardIdent::MASTERCHAIN,
+        seqno: 3,
+        root_hash: HashBytes::from([41; 32]),
+        file_hash: HashBytes::from([42; 32]),
+    };
+    let block_sc2 = BlockId {
+        shard,
+        seqno: 2,
+        root_hash: HashBytes::from([51; 32]),
+        file_hash: HashBytes::from([52; 32]),
+    };
+    let block_mc4 = BlockId {
+        shard: ShardIdent::MASTERCHAIN,
+        seqno: 4,
+        root_hash: HashBytes::from([61; 32]),
+        file_hash: HashBytes::from([62; 32]),
+    };
+    let top_mc1 = vec![TopBlockIdUpdated {
+        block: TopBlockId {
+            ref_by_mc_seqno: block_mc1.seqno,
+            block_id: block_mc1,
+        },
+        updated: true,
+    }];
+    let top_mc2 = vec![
+        TopBlockIdUpdated {
+            block: TopBlockId {
+                ref_by_mc_seqno: block_mc2.seqno,
+                block_id: block_mc2,
+            },
+            updated: true,
+        },
+        TopBlockIdUpdated {
+            block: TopBlockId {
+                ref_by_mc_seqno: block_mc2.seqno,
+                block_id: block_sc1,
+            },
+            updated: true,
+        },
+    ];
+    let top_mc3 = vec![
+        TopBlockIdUpdated {
+            block: TopBlockId {
+                ref_by_mc_seqno: block_mc3.seqno,
+                block_id: block_mc3,
+            },
+            updated: true,
+        },
+        TopBlockIdUpdated {
+            block: TopBlockId {
+                ref_by_mc_seqno: block_mc2.seqno,
+                block_id: block_sc1,
+            },
+            updated: false,
+        },
+    ];
+    let top_mc4 = vec![
+        TopBlockIdUpdated {
+            block: TopBlockId {
+                ref_by_mc_seqno: block_mc4.seqno,
+                block_id: block_mc4,
+            },
+            updated: true,
+        },
+        TopBlockIdUpdated {
+            block: TopBlockId {
+                ref_by_mc_seqno: block_mc4.seqno,
+                block_id: block_sc2,
+            },
+            updated: true,
+        },
+    ];
+    let diff_mc1 = create_diff(1, 1)?;
+    let diff_sc1 = create_diff(2, 2)?;
+    let diff_mc2 = create_diff(3, 3)?;
+    let diff_mc3 = create_diff(4, 4)?;
+    let diff_sc2 = create_diff(5, 5)?;
+    let diff_mc4 = create_diff(6, 6)?;
+    let hash_mc1 = HashBytes::from([1; 32]);
+    let hash_sc1 = HashBytes::from([2; 32]);
+    let hash_mc2 = HashBytes::from([3; 32]);
+    let hash_mc3 = HashBytes::from([4; 32]);
+    let hash_sc2 = HashBytes::from([5; 32]);
+    let hash_mc4 = HashBytes::from([6; 32]);
+    let top_shards = [ShardIdent::MASTERCHAIN, shard];
+
+    // build and commit the full mc1 -> sb1 -> mc2 -> mc3 -> sb2 -> mc4 queue chain
+    queue.apply_diff(
+        diff_mc1.clone(),
+        block_mc1.as_short_id(),
+        &hash_mc1,
+        create_statistics(&diff_mc1, &block_mc1),
+        Some(DiffZone::Both),
+    )?;
+    queue.commit_diff(&top_mc1, &partitions)?;
+    queue.apply_diff(
+        diff_sc1.clone(),
+        block_sc1.as_short_id(),
+        &hash_sc1,
+        create_statistics(&diff_sc1, &block_sc1),
+        Some(DiffZone::Both),
+    )?;
+    queue.apply_diff(
+        diff_mc2.clone(),
+        block_mc2.as_short_id(),
+        &hash_mc2,
+        create_statistics(&diff_mc2, &block_mc2),
+        Some(DiffZone::Committed),
+    )?;
+    queue.commit_diff(&top_mc2, &partitions)?;
+    queue.apply_diff(
+        diff_mc3.clone(),
+        block_mc3.as_short_id(),
+        &hash_mc3,
+        create_statistics(&diff_mc3, &block_mc3),
+        Some(DiffZone::Committed),
+    )?;
+    queue.commit_diff(&top_mc3, &partitions)?;
+    queue.apply_diff(
+        diff_sc2.clone(),
+        block_sc2.as_short_id(),
+        &hash_sc2,
+        create_statistics(&diff_sc2, &block_sc2),
+        Some(DiffZone::Committed),
+    )?;
+    queue.apply_diff(
+        diff_mc4.clone(),
+        block_mc4.as_short_id(),
+        &hash_mc4,
+        create_statistics(&diff_mc4, &block_mc4),
+        Some(DiffZone::Committed),
+    )?;
+    queue.commit_diff(&top_mc4, &partitions)?;
+    assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc4));
+
+    // first rollback: mc4 -> mc3, then cleanup and recommit the same sb2/mc4 diffs
+    let removed_commit_pointer_shards = queue.rollback_commit_pointers(&block_mc3, &top_mc3)?;
+    assert!(removed_commit_pointer_shards.is_empty());
+    assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc3));
+    assert!(
+        queue
+            .get_diff_info(
+                &ShardIdent::MASTERCHAIN,
+                block_mc4.seqno,
+                DiffZone::Uncommitted
+            )?
+            .is_some()
+    );
+    assert!(
+        queue
+            .get_diff_info(&shard, block_sc2.seqno, DiffZone::Uncommitted)?
+            .is_some()
+    );
+    queue.clear_uncommitted_state(&partitions, &top_shards)?;
+    assert!(
+        queue
+            .get_diff_info(&ShardIdent::MASTERCHAIN, block_mc4.seqno, DiffZone::Both)?
+            .is_none()
+    );
+    assert!(
+        queue
+            .get_diff_info(&shard, block_sc2.seqno, DiffZone::Both)?
+            .is_none()
+    );
+    queue.apply_diff(
+        diff_sc2.clone(),
+        block_sc2.as_short_id(),
+        &hash_sc2,
+        create_statistics(&diff_sc2, &block_sc2),
+        Some(DiffZone::Committed),
+    )?;
+    queue.apply_diff(
+        diff_mc4.clone(),
+        block_mc4.as_short_id(),
+        &hash_mc4,
+        create_statistics(&diff_mc4, &block_mc4),
+        Some(DiffZone::Committed),
+    )?;
+    queue.commit_diff(&top_mc4, &partitions)?;
+    assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc4));
+
+    // second rollback: mc4 -> mc2, then cleanup without recommitting rolled-back diffs
+    let removed_commit_pointer_shards = queue.rollback_commit_pointers(&block_mc2, &top_mc2)?;
+    assert!(removed_commit_pointer_shards.is_empty());
+    assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc2));
+    queue.clear_uncommitted_state(&partitions, &top_shards)?;
+    assert!(
+        queue
+            .get_diff_info(&ShardIdent::MASTERCHAIN, block_mc3.seqno, DiffZone::Both)?
+            .is_none()
+    );
+    assert!(
+        queue
+            .get_diff_info(&shard, block_sc2.seqno, DiffZone::Both)?
+            .is_none()
+    );
+
+    // third rollback: mc2 -> mc1, removing the shard pointer and cleaning sb1/mc2
+    let removed_commit_pointer_shards = queue.rollback_commit_pointers(&block_mc1, &top_mc1)?;
+    assert_eq!(removed_commit_pointer_shards, vec![shard]);
+    assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc1));
+    let mut top_shards = vec![ShardIdent::MASTERCHAIN];
+    top_shards.extend(removed_commit_pointer_shards);
+    queue.clear_uncommitted_state(&partitions, &top_shards)?;
+    assert!(
+        queue
+            .get_diff_info(&ShardIdent::MASTERCHAIN, block_mc2.seqno, DiffZone::Both)?
+            .is_none()
+    );
+    assert!(
+        queue
+            .get_diff_info(&shard, block_sc1.seqno, DiffZone::Both)?
+            .is_none()
+    );
 
     Ok(())
 }


### PR DESCRIPTION
This situation can occur when the node is stopped while block commit is in progress. In this case, the queue may have been committed at MB70, while the masterchain state has not yet been fully applied. To prevent errors when applying the new diff for MB70, we roll back the queue commit pointers to the last applied masterchain state, MB69.

## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

[None]

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

[None]

---

### COMPATIBILITY

Fully compatible

### SPECIAL DEPLOYMENT ACTIONS

[Not Required]

---

### PERFORMANCE IMPACT

[No impact expected]

---

### TESTS

#### Unit Tests

Covered by:
- test_rollback_commit_pointers
- test_rollback_commit_pointers_missing_unchanged_diff_keeps_old_state

#### Network Tests

[No coverage]

#### Manual Tests

Manual tests used:
- add a hack to fail the node after mc block 10 after queue commit but before block commit
- start local net with 3 nodes
- wait for the node fail
- remove the hack
- restart - the rollback should be applied, the net should continue to work