### PR TITLE
fix(queue): drop commit pointers and last committed mark if unable to rollback

### DIFF
--- a/cli/src/node/mod.rs
+++ b/cli/src/node/mod.rs
@@ -14,8 +14,10 @@ use tycho_collator::manager::CollationManager;
 use tycho_collator::mempool::{
     MempoolAdapter, MempoolAdapterSingleNodeImpl, MempoolAdapterStdImpl,
 };
-use tycho_collator::queue_adapter::{MessageQueueAdapter, MessageQueueAdapterStdImpl};
-use tycho_collator::state_node::{CollatorSyncContext, StateNodeAdapter, StateNodeAdapterStdImpl};
+use tycho_collator::queue_adapter::{MessageQueueAdapterAsync, MessageQueueAdapterStdImpl};
+use tycho_collator::state_node::{
+    CollatorSyncContext, DiffLoader, StateNodeAdapter, StateNodeAdapterStdImpl,
+};
 use tycho_collator::types::CollatorConfig;
 use tycho_collator::validator::{
     ValidatorNetworkContext, ValidatorStdImpl, ValidatorStdImplConfig,
@@ -216,7 +218,15 @@ impl Node {
         };
         let queue = queue_factory.create()?;
         let message_queue_adapter = MessageQueueAdapterStdImpl::new(queue);
-        message_queue_adapter.recover_after_restart(&mc_state)?;
+        message_queue_adapter
+            .recover_after_restart(
+                &mc_state,
+                DiffLoader::new(
+                    base.core_storage.block_handle_storage(),
+                    base.core_storage.block_storage(),
+                ),
+            )
+            .await?;
 
         let validator = ValidatorStdImpl::new(
             ValidatorNetworkContext {

--- a/collator/src/internal_queue/queue.rs
+++ b/collator/src/internal_queue/queue.rs
@@ -88,6 +88,8 @@ pub trait Queue<V>: Send
 where
     V: InternalMessageValue + Send + Sync,
 {
+    fn zerostate_id(&self) -> ZerostateId;
+
     /// Create iterator for specified shard and return it
     fn iterator(
         &self,
@@ -124,12 +126,15 @@ where
         partitions: &FastHashSet<QueuePartitionIdx>,
     ) -> Result<()>;
 
-    /// Roll back commit pointers to the specified top blocks.
+    /// Roll back commit pointers to the specified ones.
     fn rollback_commit_pointers(
         &self,
         to_mc_block_id: &BlockId,
-        to_top_blocks: &[TopBlockIdUpdated],
+        to_commit_pointers: FastHashMap<ShardIdent, (Option<QueueKey>, u32)>,
     ) -> Result<Vec<ShardIdent>>;
+
+    /// Clear commit pointers and last committed mc block id.
+    fn clear_commit_pointers(&self) -> Result<Vec<ShardIdent>>;
 
     /// Remove all data in uncommitted zone
     fn clear_uncommitted_state(
@@ -208,6 +213,10 @@ where
     P: QueueState<V> + Send + Sync + 'static,
     V: InternalMessageValue + Send + Sync,
 {
+    fn zerostate_id(&self) -> ZerostateId {
+        self.zerostate_id
+    }
+
     fn iterator(
         &self,
         partition: QueuePartitionIdx,
@@ -443,97 +452,44 @@ where
 
     fn rollback_commit_pointers(
         &self,
-        to_mc_block_id: &BlockId,
-        to_top_blocks: &[TopBlockIdUpdated],
+        mc_block_id: &BlockId,
+        to_commit_pointers: FastHashMap<ShardIdent, (Option<QueueKey>, u32)>,
     ) -> Result<Vec<ShardIdent>> {
         let _global_write_guard = self.global_lock.write();
 
         let old_commit_pointers = self.state.get_commit_pointers()?;
+
+        // build new commit pointers
         let mut new_commit_pointers = FastHashMap::default();
-        let mut clear_commit_state = false;
-
-        for item in to_top_blocks {
-            let block_id = &item.block.block_id;
-
-            let diff = self
-                .state
-                .get_diff_info(&block_id.shard, block_id.seqno, DiffZone::Both)?;
-
-            let diff = match diff {
-                None if item.updated && item.block.ref_by_mc_seqno > self.zerostate_id.seqno => {
-                    // SAFETY: In this recovery fallback, a missing updated target diff is treated as
-                    //      an already GC-collected queue boundary. Since the target MC commit may not be
-                    //      idempotently committable without its diff info, the whole queue commit state is
-                    //      reset and the following clear_uncommitted_state call removes the remaining tails.
-                    tracing::warn!(
-                        target: tracing_targets::MQ,
-                        "Clearing all commit pointers after missing updated shard {} with mc ref {} (zerostate {}) \
-                        during rollback to seqno {}: target diff is missing and old commit pointers: {:?}",
-                        block_id.shard,
-                        item.block.ref_by_mc_seqno,
-                        self.zerostate_id.seqno,
-                        block_id.seqno,
-                        old_commit_pointers,
-                    );
-                    clear_commit_state = true;
-                    break;
+        for (shard_id, (max_message, seqno)) in to_commit_pointers {
+            if let Some(max_message) = max_message {
+                if new_commit_pointers
+                    .insert(shard_id, (max_message, seqno))
+                    .is_some()
+                {
+                    bail!("Duplicate shard in rollback_commit_pointers: {}", shard_id);
                 }
-                None if !item.updated => {
-                    if let Some(old_pointer) = old_commit_pointers.get(&block_id.shard) {
-                        if old_pointer.seqno != block_id.seqno {
-                            // SAFETY: In this recovery fallback, a missing target diff is treated as an
-                            //      already GC-collected queue boundary. Dropping this shard pointer lets the
-                            //      following clear_uncommitted_state call remove the remaining ahead-of-applied
-                            //      queue suffix for this shard.
-                            tracing::warn!(
-                                target: tracing_targets::MQ,
-                                "Dropping commit pointer for unchanged shard {} during rollback to seqno {}: \
-                                target diff is missing and old pointer seqno is {}",
-                                block_id.shard,
-                                block_id.seqno,
-                                old_pointer.seqno,
-                            );
-                            continue;
-                        }
-                        if new_commit_pointers
-                            .insert(block_id.shard, (old_pointer.queue_key, old_pointer.seqno))
-                            .is_some()
-                        {
-                            bail!(
-                                "Duplicate shard in rollback_commit_pointers: {}",
-                                block_id.shard
-                            );
-                        }
+            } else {
+                // check if missed mandatory commit pointers in rollback
+                if let Some(old_pointer) = old_commit_pointers.get(&shard_id) {
+                    if old_pointer.seqno != seqno {
+                        bail!(
+                            "Cannot roll back commit pointer for shard {} on seqno {}: diff is missing",
+                            shard_id,
+                            seqno,
+                        );
                     }
-                    continue;
+                    if new_commit_pointers
+                        .insert(shard_id, (old_pointer.queue_key, old_pointer.seqno))
+                        .is_some()
+                    {
+                        bail!("Duplicate shard in rollback_commit_pointers: {}", shard_id);
+                    }
                 }
-                None => continue,
-                Some(diff) => diff,
-            };
-
-            if new_commit_pointers
-                .insert(block_id.shard, (diff.max_message, diff.seqno))
-                .is_some()
-            {
-                bail!(
-                    "Duplicate shard in rollback_commit_pointers: {}",
-                    block_id.shard
-                );
             }
         }
 
-        // fully clear commit state when unable to rollback
-        if clear_commit_state {
-            let removed_commit_pointer_shards: Vec<_> =
-                old_commit_pointers.keys().copied().collect();
-            tracing::debug!(target: tracing_targets::MQ,
-                ?removed_commit_pointer_shards,
-                "rollback_commit_pointers: clear_commit_pointers",
-            );
-            self.state.clear_commit_pointers()?;
-            return Ok(removed_commit_pointer_shards);
-        }
-
+        // detect commit pointers that will be removed
         let removed_commit_pointer_shards: Vec<_> = old_commit_pointers
             .keys()
             .filter(|shard_id| !new_commit_pointers.contains_key(shard_id))
@@ -543,11 +499,22 @@ where
         tracing::debug!(target: tracing_targets::MQ,
             ?new_commit_pointers,
             ?removed_commit_pointer_shards,
-            "rollback_commit_pointers",
+            "rollback_commit_pointers: replace_commit_pointers",
         );
 
         self.state
-            .replace_commit_pointers(new_commit_pointers, to_mc_block_id)?;
+            .replace_commit_pointers(new_commit_pointers, mc_block_id)?;
+
+        Ok(removed_commit_pointer_shards)
+    }
+
+    fn clear_commit_pointers(&self) -> Result<Vec<ShardIdent>> {
+        let _global_write_guard = self.global_lock.write();
+
+        let old_commit_pointers = self.state.get_commit_pointers()?;
+        let removed_commit_pointer_shards: Vec<_> = old_commit_pointers.keys().copied().collect();
+
+        self.state.clear_commit_pointers()?;
 
         Ok(removed_commit_pointer_shards)
     }

--- a/collator/src/internal_queue/queue.rs
+++ b/collator/src/internal_queue/queue.rs
@@ -450,6 +450,7 @@ where
 
         let old_commit_pointers = self.state.get_commit_pointers()?;
         let mut new_commit_pointers = FastHashMap::default();
+        let mut clear_commit_state = false;
 
         for item in to_top_blocks {
             let block_id = &item.block.block_id;
@@ -460,23 +461,39 @@ where
 
             let diff = match diff {
                 None if item.updated && item.block.ref_by_mc_seqno > self.zerostate_id.seqno => {
-                    bail!(
-                        "Diff not found for block_id: {} ref {} zerostate {} during commit pointers rollback",
-                        block_id,
+                    // SAFETY: In this recovery fallback, a missing updated target diff is treated as
+                    //      an already GC-collected queue boundary. Since the target MC commit may not be
+                    //      idempotently committable without its diff info, the whole queue commit state is
+                    //      reset and the following clear_uncommitted_state call removes the remaining tails.
+                    tracing::warn!(
+                        target: tracing_targets::MQ,
+                        "Clearing all commit pointers after missing updated shard {} with mc ref {} (zerostate {}) \
+                        during rollback to seqno {}: target diff is missing and old commit pointers: {:?}",
+                        block_id.shard,
                         item.block.ref_by_mc_seqno,
-                        self.zerostate_id.seqno
-                    )
+                        self.zerostate_id.seqno,
+                        block_id.seqno,
+                        old_commit_pointers,
+                    );
+                    clear_commit_state = true;
+                    break;
                 }
                 None if !item.updated => {
                     if let Some(old_pointer) = old_commit_pointers.get(&block_id.shard) {
                         if old_pointer.seqno != block_id.seqno {
-                            bail!(
-                                "Cannot roll back commit pointer for unchanged shard {} to seqno {}: \
+                            // SAFETY: In this recovery fallback, a missing target diff is treated as an
+                            //      already GC-collected queue boundary. Dropping this shard pointer lets the
+                            //      following clear_uncommitted_state call remove the remaining ahead-of-applied
+                            //      queue suffix for this shard.
+                            tracing::warn!(
+                                target: tracing_targets::MQ,
+                                "Dropping commit pointer for unchanged shard {} during rollback to seqno {}: \
                                 target diff is missing and old pointer seqno is {}",
                                 block_id.shard,
                                 block_id.seqno,
                                 old_pointer.seqno,
                             );
+                            continue;
                         }
                         if new_commit_pointers
                             .insert(block_id.shard, (old_pointer.queue_key, old_pointer.seqno))
@@ -503,6 +520,18 @@ where
                     block_id.shard
                 );
             }
+        }
+
+        // fully clear commit state when unable to rollback
+        if clear_commit_state {
+            let removed_commit_pointer_shards: Vec<_> =
+                old_commit_pointers.keys().copied().collect();
+            tracing::debug!(target: tracing_targets::MQ,
+                ?removed_commit_pointer_shards,
+                "rollback_commit_pointers: clear_commit_pointers",
+            );
+            self.state.clear_commit_pointers()?;
+            return Ok(removed_commit_pointer_shards);
         }
 
         let removed_commit_pointer_shards: Vec<_> = old_commit_pointers

--- a/collator/src/internal_queue/state/storage.rs
+++ b/collator/src/internal_queue/state/storage.rs
@@ -101,6 +101,10 @@ pub trait QueueState<V: InternalMessageValue>: Send + Sync {
         mc_block_id: &BlockId,
     ) -> Result<()>;
 
+    /// Clear commit pointers and last committed mc block id.
+    /// ATTENTION! Overrides old value without checks.
+    fn clear_commit_pointers(&self) -> Result<()>;
+
     /// Load statistics for given partition and ranges
     fn load_diff_statistics(
         &self,
@@ -219,7 +223,8 @@ impl<V: InternalMessageValue> QueueState<V> for QueueStateStdImpl {
     ) -> Result<()> {
         let mut tx = self.storage.begin_transaction();
         tx.commit_messages(commit_pointers)?;
-        self.write_commit_transaction(tx, mc_block_id)
+        tx.set_last_committed_mc_block_id(mc_block_id)?;
+        self.write_transaction(tx)
     }
 
     fn replace_commit_pointers(
@@ -230,7 +235,16 @@ impl<V: InternalMessageValue> QueueState<V> for QueueStateStdImpl {
         let old_commit_pointers = self.storage.make_snapshot().read_commit_pointers()?;
         let mut tx = self.storage.begin_transaction();
         tx.replace_commit_pointers(&old_commit_pointers, commit_pointers)?;
-        self.write_commit_transaction(tx, mc_block_id)
+        tx.set_last_committed_mc_block_id(mc_block_id)?;
+        self.write_transaction(tx)
+    }
+
+    fn clear_commit_pointers(&self) -> Result<()> {
+        let old_commit_pointers = self.storage.make_snapshot().read_commit_pointers()?;
+        let mut tx = self.storage.begin_transaction();
+        tx.replace_commit_pointers(&old_commit_pointers, FastHashMap::default())?;
+        tx.delete_last_committed_mc_block_id()?;
+        self.write_transaction(tx)
     }
 
     fn load_diff_statistics(
@@ -396,12 +410,7 @@ impl<V: InternalMessageValue> QueueState<V> for QueueStateStdImpl {
 }
 
 impl QueueStateStdImpl {
-    fn write_commit_transaction(
-        &self,
-        mut tx: InternalQueueTransaction,
-        mc_block_id: &BlockId,
-    ) -> Result<()> {
-        tx.set_last_committed_mc_block_id(mc_block_id)?;
+    fn write_transaction(&self, tx: InternalQueueTransaction) -> Result<()> {
         tx.write()?;
         let db = self.storage.db();
         db.rocksdb()

--- a/collator/src/queue_adapter.rs
+++ b/collator/src/queue_adapter.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
+use async_trait::async_trait;
 use tracing::instrument;
 use tycho_block_util::queue::{QueueKey, QueuePartitionIdx};
 use tycho_block_util::state::ShardStateStuff;
@@ -18,6 +19,7 @@ use crate::internal_queue::types::router::PartitionRouter;
 use crate::internal_queue::types::stats::{
     DiffStatistics, QueueStatistics, SeparatedStatisticsByPartitions,
 };
+use crate::state_node::DiffLoader;
 use crate::storage::models::DiffInfo;
 use crate::storage::snapshot::AccountStatistics;
 use crate::tracing_targets;
@@ -77,13 +79,6 @@ where
         partitions: &FastHashSet<QueuePartitionIdx>,
     ) -> Result<()>;
 
-    /// Roll back commit pointers to the specified top blocks.
-    fn rollback_commit_pointers(
-        &self,
-        to_mc_block_id: &BlockId,
-        to_top_shard_blocks: Vec<TopBlockIdUpdated>,
-    ) -> Result<Vec<ShardIdent>>;
-
     fn clear_uncommitted_state(&self, top_shards: &[ShardIdent]) -> Result<()>;
 
     /// Get diff for the given block from committed and/or uncommitted zone
@@ -121,55 +116,6 @@ where
         diff_info: DiffInfo,
         partition: QueuePartitionIdx,
     ) -> Result<(PartitionRouter, DiffStatistics)>;
-
-    /// Recovers message queue state after restart.
-    fn recover_after_restart(&self, mc_state: &ShardStateStuff) -> Result<()> {
-        let mc_block_id = mc_state.block_id();
-        assert!(
-            mc_block_id.is_masterchain(),
-            "latest masterchain block id and state must be provided"
-        );
-
-        let mut top_shards_for_queue_clean = mc_state.get_top_shards()?;
-
-        // rollback commit pointers if committed queue is ahead of last applied mc state
-        if let Some(last_committed_mc_block_id) = self.get_last_committed_mc_block_id()? {
-            if last_committed_mc_block_id.seqno > mc_block_id.seqno {
-                let top_shard_blocks_info = mc_state
-                    .shards()?
-                    .iter()
-                    .map(|item| {
-                        let (shard_id, shard_descr) = item?;
-                        Ok(TopBlockIdUpdated {
-                            block: TopBlockId {
-                                ref_by_mc_seqno: shard_descr.reg_mc_seqno,
-                                block_id: shard_descr.get_block_id(shard_id),
-                            },
-                            updated: shard_descr.top_sc_block_updated,
-                        })
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-                let removed_commit_pointer_shards =
-                    self.rollback_commit_pointers(mc_block_id, top_shard_blocks_info)?;
-                for shard in removed_commit_pointer_shards {
-                    if !top_shards_for_queue_clean.contains(&shard) {
-                        top_shards_for_queue_clean.push(shard);
-                    }
-                }
-            } else {
-                anyhow::ensure!(
-                    last_committed_mc_block_id.seqno != mc_block_id.seqno
-                        || last_committed_mc_block_id == *mc_block_id,
-                    "internal messages queue is committed on different masterchain block: \
-                    queue={last_committed_mc_block_id}, applied={mc_block_id}",
-                );
-            }
-        }
-
-        // We should clear uncommitted queue state because it may contain incorrect diffs
-        // that were created before node restart. We will restore queue strictly above last committed state
-        self.clear_uncommitted_state(&top_shards_for_queue_clean)
-    }
 }
 
 impl<V: InternalMessageValue> MessageQueueAdapterStdImpl<V> {
@@ -327,38 +273,6 @@ impl<V: InternalMessageValue> MessageQueueAdapter<V> for MessageQueueAdapterStdI
         Ok(())
     }
 
-    #[instrument(skip_all, fields(%to_mc_block_id))]
-    fn rollback_commit_pointers(
-        &self,
-        to_mc_block_id: &BlockId,
-        to_top_shard_blocks: Vec<TopBlockIdUpdated>,
-    ) -> Result<Vec<ShardIdent>> {
-        let start_time = std::time::Instant::now();
-
-        let mut to_top_blocks = to_top_shard_blocks;
-        to_top_blocks.push(TopBlockIdUpdated {
-            block: crate::types::TopBlockId {
-                ref_by_mc_seqno: to_mc_block_id.seqno,
-                block_id: *to_mc_block_id,
-            },
-            updated: true,
-        });
-
-        let removed_commit_pointer_shards = self
-            .queue
-            .rollback_commit_pointers(to_mc_block_id, &to_top_blocks)?;
-
-        let elapsed = start_time.elapsed();
-        tracing::info!(target: tracing_targets::MQ_ADAPTER,
-            top_blocks = ?to_top_blocks,
-            ?removed_commit_pointer_shards,
-            elapsed = %humantime::format_duration(elapsed),
-            "rollback_commit_pointers completed"
-        );
-
-        Ok(removed_commit_pointer_shards)
-    }
-
     #[instrument(skip_all)]
     fn clear_uncommitted_state(&self, top_shards: &[ShardIdent]) -> Result<()> {
         let start_time = std::time::Instant::now();
@@ -510,5 +424,178 @@ impl<V: InternalMessageValue> MessageQueueAdapter<V> for MessageQueueAdapterStdI
         );
 
         Ok((partition_router, diff_statistics))
+    }
+}
+
+#[async_trait]
+pub trait MessageQueueAdapterAsync<V>: MessageQueueAdapter<V>
+where
+    V: InternalMessageValue + Send + Sync,
+{
+    /// Recovers message queue state after restart.
+    async fn recover_after_restart(
+        &self,
+        mc_state: &ShardStateStuff,
+        diff_loader: DiffLoader<'_>,
+    ) -> Result<()>;
+}
+
+#[async_trait]
+impl<V: InternalMessageValue> MessageQueueAdapterAsync<V> for MessageQueueAdapterStdImpl<V> {
+    async fn recover_after_restart(
+        &self,
+        mc_state: &ShardStateStuff,
+        diff_loader: DiffLoader<'_>,
+    ) -> Result<()> {
+        let mc_block_id = mc_state.block_id();
+        assert!(
+            mc_block_id.is_masterchain(),
+            "latest masterchain block id and state must be provided"
+        );
+
+        let mut top_shards_for_queue_clean = mc_state.get_top_shards()?;
+
+        // rollback commit pointers if committed queue is ahead of last applied mc state
+        if let Some(last_committed_mc_block_id) = self.get_last_committed_mc_block_id()? {
+            if last_committed_mc_block_id.seqno > mc_block_id.seqno {
+                // collect top blocks info
+                let top_shard_blocks_info = mc_state
+                    .shards()?
+                    .iter()
+                    .map(|item| {
+                        let (shard_id, shard_descr) = item?;
+                        Ok(TopBlockIdUpdated {
+                            block: TopBlockId {
+                                ref_by_mc_seqno: shard_descr.reg_mc_seqno,
+                                block_id: shard_descr.get_block_id(shard_id),
+                            },
+                            updated: shard_descr.top_sc_block_updated,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                let removed_commit_pointer_shards = self
+                    .rollback_commit_pointers(mc_block_id, top_shard_blocks_info, diff_loader)
+                    .await?;
+                for shard in removed_commit_pointer_shards {
+                    if !top_shards_for_queue_clean.contains(&shard) {
+                        top_shards_for_queue_clean.push(shard);
+                    }
+                }
+            } else {
+                anyhow::ensure!(
+                    last_committed_mc_block_id.seqno != mc_block_id.seqno
+                        || last_committed_mc_block_id == *mc_block_id,
+                    "internal messages queue is committed on different masterchain block: \
+                    queue={last_committed_mc_block_id}, applied={mc_block_id}",
+                );
+            }
+        }
+
+        // We should clear uncommitted queue state because it may contain incorrect diffs
+        // that were created before node restart. We will restore queue strictly above last committed state
+        self.clear_uncommitted_state(&top_shards_for_queue_clean)
+    }
+}
+
+impl<V: InternalMessageValue> MessageQueueAdapterStdImpl<V> {
+    #[instrument(skip_all, fields(%to_mc_block_id))]
+    async fn rollback_commit_pointers(
+        &self,
+        to_mc_block_id: &BlockId,
+        to_top_shard_blocks: Vec<TopBlockIdUpdated>,
+        diff_loader: DiffLoader<'_>,
+    ) -> Result<Vec<ShardIdent>> {
+        let start_time = std::time::Instant::now();
+
+        let zerostate_id = self.queue.zerostate_id();
+
+        let mut to_top_blocks = to_top_shard_blocks;
+        to_top_blocks.push(TopBlockIdUpdated {
+            block: crate::types::TopBlockId {
+                ref_by_mc_seqno: to_mc_block_id.seqno,
+                block_id: *to_mc_block_id,
+            },
+            updated: true,
+        });
+
+        let mut clear_commit_state = false;
+
+        // build commit pointers for rollback
+        let mut to_commit_pointers = FastHashMap::default();
+        for item in &to_top_blocks {
+            let block_id = &item.block.block_id;
+
+            // try get diff max message
+            let diff_max_message = if let Some(diff) =
+                self.get_diff_info(&block_id.shard, block_id.seqno, DiffZone::Both)?
+            {
+                Some(diff.max_message)
+            } else {
+                diff_loader
+                    .load_diff(block_id)
+                    .await?
+                    .map(|d| d.diff().max_message)
+            };
+
+            // SAFETY: Queue is empty at master zerostate, while zerostate shard
+            // entries only remove their own commit pointers.
+            if diff_max_message.is_none() && item.block.ref_by_mc_seqno == zerostate_id.seqno {
+                if !block_id.is_masterchain() {
+                    tracing::warn!(
+                        target: tracing_targets::MQ,
+                        "Dropping commit pointer after missing zerostate shard diff for {} \
+                        with mc ref {} (zerostate {}) during rollback",
+                        block_id.as_short_id(),
+                        item.block.ref_by_mc_seqno,
+                        zerostate_id.seqno,
+                    );
+                    continue;
+                }
+                tracing::warn!(
+                    target: tracing_targets::MQ,
+                    "Clearing all commit pointers after missing diff for {} \
+                    with mc ref {} (zerostate {}) during rollback",
+                    block_id.as_short_id(),
+                    item.block.ref_by_mc_seqno,
+                    zerostate_id.seqno,
+                );
+                clear_commit_state = true;
+                break;
+            }
+
+            if to_commit_pointers
+                .insert(block_id.shard, (diff_max_message, block_id.seqno))
+                .is_some()
+            {
+                bail!(
+                    "Duplicate shard in rollback_commit_pointers: {}",
+                    block_id.shard
+                );
+            }
+        }
+
+        // fully clear commit state when unable to rollback
+        if clear_commit_state {
+            let removed_commit_pointer_shards = self.queue.clear_commit_pointers()?;
+            tracing::debug!(target: tracing_targets::MQ,
+                ?removed_commit_pointer_shards,
+                "rollback_commit_pointers: clear_commit_pointers",
+            );
+            return Ok(removed_commit_pointer_shards);
+        }
+
+        let removed_commit_pointer_shards = self
+            .queue
+            .rollback_commit_pointers(to_mc_block_id, to_commit_pointers)?;
+
+        let elapsed = start_time.elapsed();
+        tracing::info!(target: tracing_targets::MQ_ADAPTER,
+            top_blocks = ?to_top_blocks,
+            ?removed_commit_pointer_shards,
+            elapsed = %humantime::format_duration(elapsed),
+            "rollback_commit_pointers: completed"
+        );
+
+        Ok(removed_commit_pointer_shards)
     }
 }

--- a/collator/src/state_node.rs
+++ b/collator/src/state_node.rs
@@ -11,8 +11,8 @@ use tycho_block_util::queue::QueueDiffStuff;
 use tycho_block_util::state::ShardStateStuff;
 use tycho_core::global_config::ZerostateId;
 use tycho_core::storage::{
-    BlockHandle, BlockInfoForApply, CoreStorage, LoadStateHint, MaybeExistingHandle, NewBlockMeta,
-    StoreStateHint,
+    BlockHandle, BlockHandleStorage, BlockInfoForApply, BlockStorage, CoreStorage, LoadStateHint,
+    MaybeExistingHandle, NewBlockMeta, StoreStateHint,
 };
 use tycho_network::PeerId;
 use tycho_types::boc::BocRepr;
@@ -521,15 +521,12 @@ impl StateNodeAdapter for StateNodeAdapterStdImpl {
 
         tracing::debug!(target: tracing_targets::STATE_NODE_ADAPTER, "Load queue diff: {}", block_id.as_short_id());
 
-        let handle_storage = self.storage.block_handle_storage();
-        let block_storage = self.storage.block_storage();
-
-        match handle_storage.load_handle(block_id) {
-            Some(handle) if handle.has_queue_diff() => {
-                block_storage.load_queue_diff(&handle).await.map(Some)
-            }
-            _ => Ok(None),
-        }
+        DiffLoader::new(
+            self.storage.block_handle_storage(),
+            self.storage.block_storage(),
+        )
+        .load_diff(block_id)
+        .await
     }
 
     fn set_sync_context(&self, sync_context: CollatorSyncContext) {
@@ -654,6 +651,29 @@ impl StateNodeAdapterStdImpl {
         );
 
         Ok(())
+    }
+}
+
+pub struct DiffLoader<'a> {
+    handle_storage: &'a BlockHandleStorage,
+    block_storage: &'a BlockStorage,
+}
+
+impl<'a> DiffLoader<'a> {
+    pub fn new(handle_storage: &'a BlockHandleStorage, block_storage: &'a BlockStorage) -> Self {
+        Self {
+            handle_storage,
+            block_storage,
+        }
+    }
+
+    pub async fn load_diff(&self, block_id: &BlockId) -> Result<Option<QueueDiffStuff>> {
+        match self.handle_storage.load_handle(block_id) {
+            Some(handle) if handle.has_queue_diff() => {
+                self.block_storage.load_queue_diff(&handle).await.map(Some)
+            }
+            _ => Ok(None),
+        }
     }
 }
 

--- a/collator/src/storage/transaction.rs
+++ b/collator/src/storage/transaction.rs
@@ -300,6 +300,16 @@ impl InternalQueueTransaction {
 
         Ok(())
     }
+
+    /// Removes mc block id mark on which the queue was committed.
+    pub fn delete_last_committed_mc_block_id(&mut self) -> Result<()> {
+        let cf = self.db.internal_message_var.cf();
+
+        self.batch
+            .delete_cf(&cf, INT_QUEUE_LAST_COMMITTED_MC_BLOCK_ID_KEY);
+
+        Ok(())
+    }
 }
 
 pub fn delete_diff_tails_and_collect_seqno<T: ColumnFamily>(

--- a/collator/tests/internal_queue.rs
+++ b/collator/tests/internal_queue.rs
@@ -28,7 +28,7 @@ use tycho_types::models::{
     SkippedComputePhase, StdAddr, Transaction, TxInfo,
 };
 use tycho_types::num::Tokens;
-use tycho_util::FastHashSet;
+use tycho_util::{FastHashMap, FastHashSet};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct StoredObject {
@@ -1662,6 +1662,29 @@ fn create_rollback_commit_pointers_statistics(
         diff.max_message().cloned().unwrap_or_default(),
     )
 }
+fn create_rollback_commit_pointers(
+    queue: &QueueImpl<QueueStateStdImpl, StoredObject>,
+    top_blocks: &[TopBlockIdUpdated],
+) -> anyhow::Result<FastHashMap<ShardIdent, (Option<QueueKey>, u32)>> {
+    let mut commit_pointers = FastHashMap::default();
+    for item in top_blocks {
+        let block_id = &item.block.block_id;
+        let diff = queue.get_diff_info(&block_id.shard, block_id.seqno, DiffZone::Both)?;
+        if commit_pointers
+            .insert(
+                block_id.shard,
+                (diff.map(|diff| diff.max_message), block_id.seqno),
+            )
+            .is_some()
+        {
+            anyhow::bail!(
+                "Duplicate shard in rollback_commit_pointers: {}",
+                block_id.shard
+            );
+        }
+    }
+    Ok(commit_pointers)
+}
 
 async fn prepare_rollback_commit_pointers_test_data()
 -> anyhow::Result<RollbackCommitPointersTestData> {
@@ -1876,7 +1899,10 @@ async fn test_rollback_commit_pointers() -> anyhow::Result<()> {
     let top_shards = [ShardIdent::MASTERCHAIN, shard];
 
     // first rollback: mc4 -> mc3, then cleanup and recommit the same sb2/mc4 diffs
-    let removed_commit_pointer_shards = queue.rollback_commit_pointers(&block_mc3, &top_mc3)?;
+    let removed_commit_pointer_shards = queue.rollback_commit_pointers(
+        &block_mc3,
+        create_rollback_commit_pointers(&queue, &top_mc3)?,
+    )?;
     assert!(removed_commit_pointer_shards.is_empty());
     assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc3));
     assert!(
@@ -1922,7 +1948,10 @@ async fn test_rollback_commit_pointers() -> anyhow::Result<()> {
     assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc4));
 
     // second rollback: mc4 -> mc2, then cleanup without recommitting rolled-back diffs
-    let removed_commit_pointer_shards = queue.rollback_commit_pointers(&block_mc2, &top_mc2)?;
+    let removed_commit_pointer_shards = queue.rollback_commit_pointers(
+        &block_mc2,
+        create_rollback_commit_pointers(&queue, &top_mc2)?,
+    )?;
     assert!(removed_commit_pointer_shards.is_empty());
     assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc2));
     queue.clear_uncommitted_state(&partitions, &top_shards)?;
@@ -1938,7 +1967,10 @@ async fn test_rollback_commit_pointers() -> anyhow::Result<()> {
     );
 
     // third rollback: mc2 -> mc1, removing the shard pointer and cleaning sb1/mc2
-    let removed_commit_pointer_shards = queue.rollback_commit_pointers(&block_mc1, &top_mc1)?;
+    let removed_commit_pointer_shards = queue.rollback_commit_pointers(
+        &block_mc1,
+        create_rollback_commit_pointers(&queue, &top_mc1)?,
+    )?;
     assert_eq!(removed_commit_pointer_shards, vec![shard]);
     assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc1));
     let mut top_shards = vec![ShardIdent::MASTERCHAIN];
@@ -1959,7 +1991,7 @@ async fn test_rollback_commit_pointers() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_rollback_commit_pointers_missing_unchanged_diff_drops_shard_pointer()
+async fn test_rollback_commit_pointers_missing_unchanged_diff_reuses_old_pointer()
 -> anyhow::Result<()> {
     let RollbackCommitPointersTestData {
         _tmp_dir,
@@ -1972,6 +2004,12 @@ async fn test_rollback_commit_pointers_missing_unchanged_diff_drops_shard_pointe
         top_mc3,
         ..
     } = prepare_rollback_commit_pointers_test_data().await?;
+    let removed_commit_pointer_shards = queue.rollback_commit_pointers(
+        &block_mc3,
+        create_rollback_commit_pointers(&queue, &top_mc3)?,
+    )?;
+    assert!(removed_commit_pointer_shards.is_empty());
+    assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc3));
     let ranges: Vec<_> = partitions
         .iter()
         .map(|partition| QueueRange {
@@ -1987,16 +2025,19 @@ async fn test_rollback_commit_pointers_missing_unchanged_diff_drops_shard_pointe
             .get_diff_info(&shard, block_sc1.seqno, DiffZone::Both)?
             .is_none()
     );
-    let removed_commit_pointer_shards = queue.rollback_commit_pointers(&block_mc3, &top_mc3)?;
-    assert_eq!(removed_commit_pointer_shards, vec![shard]);
+    let removed_commit_pointer_shards = queue.rollback_commit_pointers(
+        &block_mc3,
+        create_rollback_commit_pointers(&queue, &top_mc3)?,
+    )?;
+    assert!(removed_commit_pointer_shards.is_empty());
     assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc3));
     let commit_pointers = storage.make_snapshot().read_commit_pointers()?;
-    assert!(!commit_pointers.contains_key(&shard));
+    assert_eq!(commit_pointers.get(&shard).unwrap().seqno, block_sc1.seqno);
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_rollback_commit_pointers_missing_updated_diff_clears_commit_state()
+async fn test_rollback_commit_pointers_missing_updated_diff_errors_without_boundary()
 -> anyhow::Result<()> {
     let RollbackCommitPointersTestData {
         _tmp_dir,
@@ -2005,6 +2046,7 @@ async fn test_rollback_commit_pointers_missing_updated_diff_clears_commit_state(
         queue,
         shard,
         block_mc3,
+        block_mc4,
         top_mc3,
         ..
     } = prepare_rollback_commit_pointers_test_data().await?;
@@ -2023,13 +2065,17 @@ async fn test_rollback_commit_pointers_missing_updated_diff_clears_commit_state(
             .get_diff_info(&ShardIdent::MASTERCHAIN, block_mc3.seqno, DiffZone::Both)?
             .is_none()
     );
-    let removed_commit_pointer_shards = queue.rollback_commit_pointers(&block_mc3, &top_mc3)?;
-    assert_eq!(removed_commit_pointer_shards.len(), 2);
-    assert!(removed_commit_pointer_shards.contains(&ShardIdent::MASTERCHAIN));
-    assert!(removed_commit_pointer_shards.contains(&shard));
-    assert!(queue.get_last_committed_mc_block_id()?.is_none());
+    let err = queue
+        .rollback_commit_pointers(
+            &block_mc3,
+            create_rollback_commit_pointers(&queue, &top_mc3)?,
+        )
+        .unwrap_err();
+    assert!(err.to_string().contains("diff is missing"));
+    assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc4));
     let commit_pointers = storage.make_snapshot().read_commit_pointers()?;
-    assert!(commit_pointers.is_empty());
+    assert!(commit_pointers.contains_key(&ShardIdent::MASTERCHAIN));
+    assert!(commit_pointers.contains_key(&shard));
     Ok(())
 }
 

--- a/collator/tests/internal_queue.rs
+++ b/collator/tests/internal_queue.rs
@@ -1959,8 +1959,8 @@ async fn test_rollback_commit_pointers() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_rollback_commit_pointers_missing_unchanged_diff_keeps_old_state() -> anyhow::Result<()>
-{
+async fn test_rollback_commit_pointers_missing_unchanged_diff_drops_shard_pointer()
+-> anyhow::Result<()> {
     let RollbackCommitPointersTestData {
         _tmp_dir,
         storage,
@@ -1968,9 +1968,7 @@ async fn test_rollback_commit_pointers_missing_unchanged_diff_keeps_old_state() 
         queue,
         shard,
         block_sc1,
-        block_sc2,
         block_mc3,
-        block_mc4,
         top_mc3,
         ..
     } = prepare_rollback_commit_pointers_test_data().await?;
@@ -1989,13 +1987,49 @@ async fn test_rollback_commit_pointers_missing_unchanged_diff_keeps_old_state() 
             .get_diff_info(&shard, block_sc1.seqno, DiffZone::Both)?
             .is_none()
     );
-    let err = queue
-        .rollback_commit_pointers(&block_mc3, &top_mc3)
-        .unwrap_err();
-    assert!(err.to_string().contains("target diff is missing"));
-    assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc4));
+    let removed_commit_pointer_shards = queue.rollback_commit_pointers(&block_mc3, &top_mc3)?;
+    assert_eq!(removed_commit_pointer_shards, vec![shard]);
+    assert_eq!(queue.get_last_committed_mc_block_id()?, Some(block_mc3));
     let commit_pointers = storage.make_snapshot().read_commit_pointers()?;
-    assert_eq!(commit_pointers.get(&shard).unwrap().seqno, block_sc2.seqno);
+    assert!(!commit_pointers.contains_key(&shard));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_rollback_commit_pointers_missing_updated_diff_clears_commit_state()
+-> anyhow::Result<()> {
+    let RollbackCommitPointersTestData {
+        _tmp_dir,
+        storage,
+        partitions,
+        queue,
+        shard,
+        block_mc3,
+        top_mc3,
+        ..
+    } = prepare_rollback_commit_pointers_test_data().await?;
+    let ranges: Vec<_> = partitions
+        .iter()
+        .map(|partition| QueueRange {
+            shard_ident: ShardIdent::MASTERCHAIN,
+            partition: *partition,
+            from: QueueKey::MIN,
+            to: QueueKey::MAX,
+        })
+        .collect();
+    storage.begin_transaction().delete(&ranges)?;
+    assert!(
+        queue
+            .get_diff_info(&ShardIdent::MASTERCHAIN, block_mc3.seqno, DiffZone::Both)?
+            .is_none()
+    );
+    let removed_commit_pointer_shards = queue.rollback_commit_pointers(&block_mc3, &top_mc3)?;
+    assert_eq!(removed_commit_pointer_shards.len(), 2);
+    assert!(removed_commit_pointer_shards.contains(&ShardIdent::MASTERCHAIN));
+    assert!(removed_commit_pointer_shards.contains(&shard));
+    assert!(queue.get_last_committed_mc_block_id()?.is_none());
+    let commit_pointers = storage.make_snapshot().read_commit_pointers()?;
+    assert!(commit_pointers.is_empty());
     Ok(())
 }
 


### PR DESCRIPTION
## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

[None]

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

[None]

---

### COMPATIBILITY

Fully compatible

### SPECIAL DEPLOYMENT ACTIONS

[Not Required]

---

### PERFORMANCE IMPACT

[No impact expected]

---

### TESTS

#### Unit Tests

[No special coverage]

#### Network Tests

[No coverage]

#### Manual Tests

Manual tests used:
- apply hack to stop node after mc block 20 is accepted
- set low block gas limit to 8_000_000
- started local network on 3 nodes
- start transactions test
- wait until nodes stop
- disable hack and restart nodes
- they should rollback queue and continue collation