### PR TITLE
feature(collator): wait until mc block is committed in the node state before committing messages queue

### DIFF
--- a/collator/src/manager/blocks_cache.rs
+++ b/collator/src/manager/blocks_cache.rs
@@ -477,12 +477,14 @@ impl BlocksCache {
         &self,
         block_id: &BlockId,
         validation_result: ValidationStatus,
-    ) -> bool {
+    ) -> Option<CandidateStatus> {
         let (new_status, signatures, total_weight) = match validation_result {
             ValidationStatus::Complete(res) => {
                 (CandidateStatus::Validated, res.signatures, res.total_weight)
             }
-            ValidationStatus::Skipped => (CandidateStatus::Synced, Default::default(), 0),
+            ValidationStatus::Skipped => {
+                (CandidateStatus::ValidationSkipped, Default::default(), 0)
+            }
         };
 
         tracing::debug!(target: tracing_targets::COLLATION_MANAGER,
@@ -496,7 +498,7 @@ impl BlocksCache {
                 target: tracing_targets::COLLATION_MANAGER,
                 "Block does not exist in cache - skip validation result",
             );
-            return false;
+            return None;
         };
 
         match &mut entry.data {
@@ -506,17 +508,25 @@ impl BlocksCache {
                 status,
                 ..
             } => {
+                if *status == CandidateStatus::Synced {
+                    tracing::debug!(
+                        target: tracing_targets::COLLATION_MANAGER,
+                        "Block is Synced, validation status was not updated - skip validation result",
+                    );
+                    return None;
+                }
                 let changed = *status != new_status;
-                candidate_stuff.signatures = signatures;
-                candidate_stuff.total_signature_weight = total_weight;
-                *status = new_status;
                 if !changed {
                     tracing::debug!(
                         target: tracing_targets::COLLATION_MANAGER,
                         "Block is Collated, validation status was not updated - skip validation result",
                     );
+                    return None;
                 }
-                changed
+                candidate_stuff.signatures = signatures;
+                candidate_stuff.total_signature_weight = total_weight;
+                *status = new_status;
+                Some(new_status)
             }
             // We have already received a block from bc, discard validation result
             BlockCacheEntryData::Received { .. } => {
@@ -524,7 +534,7 @@ impl BlocksCache {
                     target: tracing_targets::COLLATION_MANAGER,
                     "Block is Received, validation status was not updated - skip validation result",
                 );
-                false
+                None
             }
         }
     }

--- a/collator/src/manager/commit.rs
+++ b/collator/src/manager/commit.rs
@@ -77,19 +77,18 @@ where
                 let to_blocks_keys = master_block.get_top_blocks_keys()?;
                 self.blocks_cache.set_gc_to_boundary(&to_blocks_keys);
 
-                // check if mc block was not sent to sync
-                let mut mc_block_was_not_sent_to_sync = true;
+                let mut should_commit_queue_diff = false;
 
-                // send to sync only if was not received from bc
+                // send to sync only if the collated master block was validated
                 if matches!(&master_block.data, BlockCacheEntryData::Collated {
+                    status: CandidateStatus::Validated,
                     received_after_collation: false,
                     ..
                 }) {
                     let histogram =
                         HistogramGuard::begin("tycho_collator_send_blocks_to_sync_time");
 
-                    mc_block_was_not_sent_to_sync =
-                        !self.send_block_to_sync(master_block.data, Some(partitions.clone()))?;
+                    self.send_block_to_sync(master_block.data, Some(partitions.clone()))?;
 
                     for shard_block in shard_blocks {
                         self.send_block_to_sync(shard_block.data, None)?;
@@ -106,17 +105,33 @@ where
                     // because we are not sure that block will be applied
                     // and should wait until block_accepted event is received
                     top_processed_to_anchor_to_notify = None;
+                } else if matches!(&master_block.data, BlockCacheEntryData::Collated {
+                    status: CandidateStatus::ValidationSkipped | CandidateStatus::Collated,
+                    ..
+                }) {
+                    tracing::debug!(
+                        target: tracing_targets::COLLATION_MANAGER,
+                        "Skip sync and queue commit for non-validated master block",
+                    );
+
+                    // if current master block was not validated
+                    // then we should not notify top processed to anchor to mempool now
+                    // because we are not sure that block is correct
+                    top_processed_to_anchor_to_notify = None;
                 } else {
+                    // if mc block was already synced from bc
+                    // then we will not receive OwnBlockApplied event,
+                    // so we have to commit messages queue right now
+                    should_commit_queue_diff = true;
+
                     // if current block was committed by received one
                     // then `on_block_accepted` will not be called further
                     // so we need to notify `top_processed_to_anchor` to mempool here
                     top_processed_to_anchor_to_notify = master_block.top_processed_to_anchor;
                 }
 
-                // if mc block was not sent to sync by any reason then
-                // we will not receive OwnBlockApplied event,
-                // so we have to commit messages queue right now
-                if mc_block_was_not_sent_to_sync {
+                // commit messages queue right now
+                if should_commit_queue_diff {
                     let _histogram = HistogramGuard::begin(
                         "tycho_collator_send_blocks_to_sync_commit_diffs_time",
                     );
@@ -170,8 +185,14 @@ where
                 status,
                 received_after_collation: false,
                 ..
-            } if status != CandidateStatus::Synced => candidate_stuff,
-            // do not try to apply block because it is already applied,
+            } if !matches!(
+                status,
+                CandidateStatus::Synced | CandidateStatus::ValidationSkipped
+            ) =>
+            {
+                candidate_stuff
+            }
+            // do not try to apply block if it is already applied or not validated,
             // more likely we have synced to some next applied mc block
             _ => return Ok(false),
         };

--- a/collator/src/manager/commit.rs
+++ b/collator/src/manager/commit.rs
@@ -122,11 +122,13 @@ where
                     );
 
                     Self::commit_block_queue_diff(
+                        self.state_node_adapter.clone(),
                         self.mq_adapter.clone(),
                         &master_block.block_id,
                         &master_block.top_shard_blocks_info,
                         &partitions,
-                    )?;
+                    )
+                    .await?;
                 }
             }
             McBlockSubgraphExtract::AlreadyExtracted => {

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -238,11 +238,12 @@ where
                                         let _histogram =
                                             HistogramGuard::begin("tycho_collator_send_blocks_to_sync_commit_diffs_time");
                                         Self::commit_block_queue_diff(
+                                            mgr.state_node_adapter.clone(),
                                             mgr.mq_adapter.clone(),
                                             state.block_id(),
                                             &state.shards()?.top_shard_blocks_info()?,
                                             &queue_partitions.expect("should be Some for master block"),
-                                        )?;
+                                        ).await?;
                                     }
 
                                     // handle applied block in mempool

--- a/collator/src/manager/mod.rs
+++ b/collator/src/manager/mod.rs
@@ -19,9 +19,9 @@ use self::state_event_listener::{ChannelStateEventListener, StateEvent};
 use self::state_update_handler::ProcessMcStateUpdateMode;
 use self::sync::ShouldSyncToAppliedMcBlock;
 use self::types::{
-    ActiveCollator, CollatedBlockInfo, CollationState, CollationStatus, CollationSyncState,
-    CollatorJoinTask, CollatorState, HandledBlockFromBcCtx, ImportedAnchorEvent, NextCollationStep,
-    ValidatorJoinTask,
+    ActiveCollator, CandidateStatus, CollatedBlockInfo, CollationState, CollationStatus,
+    CollationSyncState, CollatorJoinTask, CollatorState, HandledBlockFromBcCtx,
+    ImportedAnchorEvent, NextCollationStep, ValidatorJoinTask,
 };
 use crate::collator::{
     CollationAbortReason, Collator, CollatorFactory, CollatorResult, DebugCollatorResult,
@@ -1715,17 +1715,31 @@ where
         let _histogram = HistogramGuard::begin("tycho_collator_handle_validated_master_block_time");
 
         // update block validation status
-        let updated = self
+        let updated_status = self
             .blocks_cache
             .store_master_block_validation_result(&block_id, status);
-        if !updated {
-            return Ok(vec![]);
-        }
-
-        // process valid block
-        let collator_tasks = self
-            .commit_valid_master_block(&block_id, skip_process_delayed_mc_state_update)
-            .await?;
+        let collator_tasks = match updated_status {
+            Some(CandidateStatus::Validated) => {
+                self.commit_valid_master_block(&block_id, skip_process_delayed_mc_state_update)
+                    .await?
+            }
+            Some(CandidateStatus::ValidationSkipped) => {
+                tracing::debug!(
+                    target: tracing_targets::COLLATION_MANAGER,
+                    "Skip committing master block because validation was skipped",
+                );
+                vec![]
+            }
+            Some(status) => {
+                tracing::debug!(
+                    target: tracing_targets::COLLATION_MANAGER,
+                    ?status,
+                    "Skip committing master block for non-validated status",
+                );
+                vec![]
+            }
+            None => return Ok(vec![]),
+        };
 
         Ok(collator_tasks)
     }

--- a/collator/src/manager/msgs_queue.rs
+++ b/collator/src/manager/msgs_queue.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
@@ -673,11 +674,13 @@ where
             if is_last {
                 let partitions = subgraph.get_partitions();
                 Self::commit_block_queue_diff(
+                    state_node_adapter,
                     mq_adapter.clone(),
                     &mc_block_entry.block_id,
                     &mc_block_entry.top_shard_blocks_info,
                     &partitions,
-                )?;
+                )
+                .await?;
 
                 // when we run sync by any reason we should drop uncommitted queue updates
                 // after restoring the required state
@@ -784,15 +787,45 @@ where
         Ok(Some(block_id))
     }
 
-    #[tracing::instrument(skip_all, fields(block_id = %block_id))]
-    pub(super) fn commit_block_queue_diff(
+    /// Commits applied messages queue diffs upto provided top blocks.
+    /// ATTENTION! Waits until provided top mc block is committed in the node state,
+    /// so MUST NOT be called inside the `StateSubscriber::handle_state` flow.
+    #[tracing::instrument(skip_all, fields(%mc_block_id))]
+    pub(super) async fn commit_block_queue_diff(
+        state_node_adapter: Arc<dyn StateNodeAdapter>,
         mq_adapter: Arc<dyn MessageQueueAdapter<EnqueuedMessage>>,
-        block_id: &BlockId,
+        mc_block_id: &BlockId,
         top_shard_blocks_info: &[TopBlockIdUpdated],
         partitions: &FastHashSet<QueuePartitionIdx>,
     ) -> Result<()> {
-        if !block_id.is_masterchain() {
+        if !mc_block_id.is_masterchain() {
             return Ok(());
+        }
+
+        // SAFETY: it is okay if collator will stuck here
+        //      because we should not commit messages queue
+        //      until block is committed to secure consistency
+
+        // await until block is committed in the node state
+        let mut last_applied_mc_block_id_rx = state_node_adapter.watch_last_applied_mc_block_id();
+        loop {
+            if let Some(last_applied_mc_block_id) = *last_applied_mc_block_id_rx.borrow_and_update()
+            {
+                match mc_block_id.seqno.cmp(&last_applied_mc_block_id.seqno) {
+                    Ordering::Less => break,
+                    Ordering::Equal if *mc_block_id == last_applied_mc_block_id => break,
+                    Ordering::Equal => {
+                        bail!(
+                            "should not try to commit queue diff for invalid or not validated mc block: \
+                            curr_mc_block_id: {}, last_applied_mc_block_id: {}",
+                            mc_block_id,
+                            last_applied_mc_block_id,
+                        );
+                    }
+                    Ordering::Greater => {}
+                }
+            }
+            last_applied_mc_block_id_rx.changed().await?;
         }
 
         let _histogram = HistogramGuard::begin("tycho_collator_commit_queue_diffs_time");
@@ -800,19 +833,20 @@ where
         let mut top_blocks = top_shard_blocks_info.to_vec();
         top_blocks.push(TopBlockIdUpdated {
             block: TopBlockId {
-                ref_by_mc_seqno: block_id.seqno,
-                block_id: *block_id,
+                ref_by_mc_seqno: mc_block_id.seqno,
+                block_id: *mc_block_id,
             },
             updated: true,
         });
 
-        if let Err(err) = mq_adapter.commit_diff(top_blocks, partitions) {
-            bail!(
-                "Error committing message queue diff of block ({}): {:?}",
-                block_id,
-                err,
-            )
-        }
+        mq_adapter
+            .commit_diff(top_blocks, partitions)
+            .with_context(|| {
+                format!(
+                    "Error committing message queue diffs on mc block: {}",
+                    mc_block_id,
+                )
+            })?;
 
         tracing::info!(target: tracing_targets::COLLATION_MANAGER,
             "message queue diff was committed",

--- a/collator/src/manager/tests/manager_tests.rs
+++ b/collator/src/manager/tests/manager_tests.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use parking_lot::Mutex;
+use tokio::sync::watch;
 use tracing::level_filters::LevelFilter;
 use tycho_block_util::archive::WithArchiveData;
 use tycho_block_util::block::{BlockStuff, BlockStuffAug};
@@ -4382,6 +4383,8 @@ struct TestStateNodeAdapter {
     >,
     mcstate_tracker: MinRefMcStateTracker,
     zerostate_id: ZerostateId,
+
+    watch_last_mc_block_id: watch::Sender<Option<BlockId>>,
 }
 
 impl Default for TestStateNodeAdapter {
@@ -4390,6 +4393,7 @@ impl Default for TestStateNodeAdapter {
             storage: Default::default(),
             mcstate_tracker: MinRefMcStateTracker::new(),
             zerostate_id: ZerostateId::default(),
+            watch_last_mc_block_id: watch::channel(None).0,
         }
     }
 }
@@ -4651,7 +4655,7 @@ impl TestStateNodeAdapter {
         shard_descr.top_sc_block_updated = top_sc_block_updated;
         let shards_descr = [(shard_block_id.shard, shard_descr)].into_iter().collect();
 
-        self.create_and_store_block_and_queue_diff(
+        let res = self.create_and_store_block_and_queue_diff(
             shard,
             seqno,
             start_lt,
@@ -4664,12 +4668,21 @@ impl TestStateNodeAdapter {
             Some(shards_descr),
             mc_is_key_block,
             processed_upto,
-        )
+        )?;
+
+        self.watch_last_mc_block_id
+            .send_replace(Some(*res.block_stuff.id()));
+
+        Ok(res)
     }
 }
 
 #[async_trait]
 impl StateNodeAdapter for TestStateNodeAdapter {
+    fn watch_last_applied_mc_block_id(&self) -> watch::Receiver<Option<BlockId>> {
+        self.watch_last_mc_block_id.subscribe()
+    }
+
     fn load_init_block_id(&self) -> Option<BlockId> {
         Some(BlockId {
             shard: ShardIdent::MASTERCHAIN,

--- a/collator/src/manager/tests/manager_tests.rs
+++ b/collator/src/manager/tests/manager_tests.rs
@@ -40,7 +40,8 @@ use crate::manager::msgs_queue::RestoreQueueContext;
 use crate::manager::state_update_handler::GlobalCapabilitiesExt;
 use crate::manager::sync::ShouldSyncToAppliedMcBlock;
 use crate::manager::types::{
-    BlockCacheStoreResult, CollationSyncState, McBlockSubgraphExtract, NextCollationStep,
+    BlockCacheEntryData, BlockCacheStoreResult, CandidateStatus, CollationSyncState,
+    McBlockSubgraphExtract, NextCollationStep,
 };
 use crate::manager::{CollatedBlockInfo, CollationStatus};
 use crate::mempool::MempoolAdapterStubImpl;
@@ -2151,15 +2152,18 @@ async fn test_queue_restore_on_sync() {
     assert_eq!(top_sc_block_seqno, Some(&3));
 
     // commit master block 02 first emulating faster validation for it
-    test_adapter
-        .blocks_cache
-        .store_master_block_validation_result(
-            &test_adapter.last_mc_block_id,
-            ValidationStatus::Complete(ValidationComplete {
-                signatures: Default::default(),
-                total_weight: 100,
-            }),
-        );
+    assert_eq!(
+        test_adapter
+            .blocks_cache
+            .store_master_block_validation_result(
+                &test_adapter.last_mc_block_id,
+                ValidationStatus::Complete(ValidationComplete {
+                    signatures: Default::default(),
+                    total_weight: 100,
+                }),
+            ),
+        Some(CandidateStatus::Validated)
+    );
     let extracted_subgraph = test_adapter
         .blocks_cache
         .extract_mc_block_subgraph_for_sync(&test_adapter.last_mc_block_id);
@@ -2194,15 +2198,18 @@ async fn test_queue_restore_on_sync() {
         .unwrap();
 
     // commit master block 01 after 02
-    test_adapter
-        .blocks_cache
-        .store_master_block_validation_result(
-            &mc_block_id_1,
-            ValidationStatus::Complete(ValidationComplete {
-                signatures: Default::default(),
-                total_weight: 100,
-            }),
-        );
+    assert_eq!(
+        test_adapter
+            .blocks_cache
+            .store_master_block_validation_result(
+                &mc_block_id_1,
+                ValidationStatus::Complete(ValidationComplete {
+                    signatures: Default::default(),
+                    total_weight: 100,
+                }),
+            ),
+        Some(CandidateStatus::Validated)
+    );
     let extracted_subgraph = test_adapter
         .blocks_cache
         .extract_mc_block_subgraph_for_sync(&mc_block_id_1);
@@ -3665,6 +3672,128 @@ impl Validator for NoopValidator {
 }
 
 type CleanupTestCollationManager = CollationManager<CollatorStdImplFactory, NoopValidator>;
+
+#[tokio::test]
+async fn test_skipped_validation_does_not_commit_collated_master() {
+    try_init_test_tracing(tracing_subscriber::filter::LevelFilter::TRACE);
+
+    // create queue, message factory, state adapter, and block cache fixtures
+    let (mq_adapter, _tmp_dir) = create_test_queue_adapter::<EnqueuedMessage>()
+        .await
+        .unwrap();
+    let msgs_factory =
+        TestMessageFactory::new(BTreeMap::new(), |info, cell| EnqueuedMessage { info, cell });
+    let state_adapter = Arc::new(TestStateNodeAdapter::default());
+    let blocks_cache = BlocksCache::new(&Default::default());
+
+    // prepare wallets and initial adapter state for one shard
+    let shard = ShardIdent::new_full(0);
+    let mut transfers_wallets = BTreeMap::<u8, IntAddr>::new();
+    for i in 100..110 {
+        transfers_wallets.insert(i, IntAddr::Std(StdAddr::new(0, HashBytes([i; 32]))));
+    }
+    for i in 110..120 {
+        transfers_wallets.insert(i, IntAddr::Std(StdAddr::new(-1, HashBytes([i; 32]))));
+    }
+
+    let mut test_adapter = TestAdapter {
+        state_adapter: state_adapter.clone(),
+        mq_adapter: mq_adapter.clone(),
+        msgs_factory,
+        blocks_cache,
+        account_lt: 0,
+        transfers_wallets,
+        processed_to_stuff: TestProcessedToStuff::new(shard),
+        last_sc_block_id: BlockId {
+            shard,
+            seqno: 0,
+            root_hash: HashBytes::default(),
+            file_hash: HashBytes::default(),
+        },
+        last_mc_block_id: BlockId {
+            shard: ShardIdent::MASTERCHAIN,
+            seqno: 0,
+            root_hash: HashBytes::default(),
+            file_hash: HashBytes::default(),
+        },
+        last_sc_blocks: BTreeMap::new(),
+        last_mc_blocks: BTreeMap::new(),
+    };
+
+    // create a collated shard candidate that will be referenced by master
+    let generated_block_info = test_adapter.gen_shard_block(
+        shard,
+        1,
+        (test_adapter.last_sc_block_id, 0),
+        (test_adapter.last_mc_block_id, 0),
+        10,
+    );
+    let StoreBlockResult {
+        block_stuff: last_sc_block_stuff,
+        ..
+    } = test_adapter.store_as_candidate(generated_block_info);
+
+    // mark shard progress so master collation can include the shard candidate
+    test_adapter.processed_to_stuff.set_processed_to(
+        ShardIdent::MASTERCHAIN,
+        test_adapter.last_sc_blocks.get(&1).unwrap(),
+    );
+
+    // create a collated master candidate that will receive skipped validation
+    let generated_block_info = test_adapter.gen_master_block(
+        1,
+        (test_adapter.last_mc_block_id, 0),
+        &last_sc_block_stuff.data,
+        true,
+        false,
+        5,
+    );
+    let mc_block_id = *generated_block_info.block_stuff.id();
+    test_adapter.store_as_candidate(generated_block_info);
+
+    // build a manager that shares the prepared cache and queue fixtures
+    let manager = CleanupTestCollationManager {
+        keypair: Arc::new(KeyPair::from(&SecretKey::from_bytes([7; 32]))),
+        config: Arc::new(CollatorConfig::default()),
+        state_node_adapter: state_adapter,
+        state_event_receiver: Mutex::new(None),
+        mpool_adapter: MempoolAdapterStubImpl::with_stub_externals(None),
+        mq_adapter,
+        collator_factory: CollatorStdImplFactory {
+            wu_tuner_event_sender: None,
+        },
+        validator: Arc::new(NoopValidator),
+        cancel_validation_runner: Default::default(),
+        active_collation_sessions: Default::default(),
+        active_collators: Default::default(),
+        blocks_cache: test_adapter.blocks_cache.clone(),
+        last_processed_mc_block_id: Default::default(),
+        collation_sync_state: Default::default(),
+        validator_set_cache: Default::default(),
+        mempool_config_override: None,
+        delayed_mc_state_update: Default::default(),
+    };
+
+    // handle skipped validation and verify it does not start commit flow
+    let collator_tasks = manager
+        .handle_validated_master_block(mc_block_id, ValidationStatus::Skipped, false)
+        .await
+        .unwrap();
+    assert!(collator_tasks.is_empty());
+
+    // verify the candidate stays cached as validation-skipped, not synced
+    let extracted_subgraph = test_adapter
+        .blocks_cache
+        .extract_mc_block_subgraph_for_sync(&mc_block_id);
+    let McBlockSubgraphExtract::Extracted(subgraph) = extracted_subgraph else {
+        panic!("skipped validation must keep the collated candidate in cache");
+    };
+    let BlockCacheEntryData::Collated { status, .. } = subgraph.master_block.data else {
+        panic!("skipped validation must keep the candidate collated");
+    };
+    assert_eq!(status, CandidateStatus::ValidationSkipped);
+    assert_ne!(status, CandidateStatus::Synced);
+}
 
 #[tokio::test]
 async fn test_cache_gc_on_skipped_sync() {

--- a/collator/src/manager/types.rs
+++ b/collator/src/manager/types.rs
@@ -211,6 +211,7 @@ impl BlockCandidateStuff {
 pub(super) enum CandidateStatus {
     Collated,
     Validated,
+    ValidationSkipped,
     Synced,
 }
 

--- a/collator/src/state_node.rs
+++ b/collator/src/state_node.rs
@@ -66,6 +66,8 @@ pub trait StateNodeEventListener: Send + Sync {
 pub trait StateNodeAdapter: Send + Sync + 'static {
     /// Return id of last master block that was applied to node local state
     fn load_last_applied_mc_block_id(&self) -> Result<BlockId>;
+    /// Get watch to observe last mc block id changes
+    fn watch_last_applied_mc_block_id(&self) -> watch::Receiver<Option<BlockId>>;
     /// Return master or shard state on specified block from node local state
     async fn load_state(
         &self,
@@ -213,6 +215,10 @@ impl StateNodeAdapter for StateNodeAdapterStdImpl {
         );
 
         Ok(las_applied_mc_block_id)
+    }
+
+    fn watch_last_applied_mc_block_id(&self) -> watch::Receiver<Option<BlockId>> {
+        self.storage.node_state().watch_last_mc_block_id()
     }
 
     async fn load_state(

--- a/core/src/storage/node_state/mod.rs
+++ b/core/src/storage/node_state/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwapOption;
 use bytes::Bytes;
+use tokio::sync::watch;
 use tycho_storage::kv::InstanceId;
 use tycho_types::models::*;
 use tycho_types::prelude::*;
@@ -20,6 +21,8 @@ pub struct NodeStateStorage {
     zerostate_id: ArcSwapOption<ZerostateId>,
     zerostate_proof: ArcSwapOption<Cell>,
     zerostate_proof_bytes: ArcSwapOption<Bytes>,
+
+    watch_last_mc_block_id: watch::Sender<Option<BlockId>>,
 }
 
 pub enum NodeSyncState {
@@ -36,6 +39,8 @@ impl NodeStateStorage {
             zerostate_id: Default::default(),
             zerostate_proof: Default::default(),
             zerostate_proof_bytes: Default::default(),
+
+            watch_last_mc_block_id: watch::channel(None).0,
         };
 
         let state = &this.db.state;
@@ -44,6 +49,10 @@ impl NodeStateStorage {
                 .insert(INSTANCE_ID, rand::random::<InstanceId>())
                 .unwrap();
         }
+
+        // init last mc block id watch
+        let last_mc_block_id = this.load_last_mc_block_id();
+        this.watch_last_mc_block_id.send_replace(last_mc_block_id);
 
         this
     }
@@ -61,10 +70,15 @@ impl NodeStateStorage {
 
     pub fn store_last_mc_block_id(&self, id: &BlockId) {
         self.store_block_id(&self.last_mc_block_id, id);
+        self.watch_last_mc_block_id.send_replace(Some(*id));
     }
 
     pub fn load_last_mc_block_id(&self) -> Option<BlockId> {
         self.load_block_id(&self.last_mc_block_id)
+    }
+
+    pub fn watch_last_mc_block_id(&self) -> watch::Receiver<Option<BlockId>> {
+        self.watch_last_mc_block_id.subscribe()
     }
 
     pub fn store_init_mc_block_id(&self, id: &BlockId) {


### PR DESCRIPTION
This is a follow-up for #1105 

## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

[None]

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

[None]

---

### COMPATIBILITY

Fully compatible

### SPECIAL DEPLOYMENT ACTIONS

[Not Required]

---

### PERFORMANCE IMPACT

[No impact expected]

---

### TESTS

#### Unit Tests

Same as in #1105
+ test_skipped_validation_does_not_commit_collated_master

#### Network Tests

[No special coverage]

#### Manual Tests

Same as in #1105