### PR TITLE
fix(core): check root hash of downloaded zerostates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4404,6 +4404,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-webpki",
+ "scopeguard",
  "serde",
  "serde_json",
  "socket2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4561,8 +4561,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-types"
-version = "0.3.4"
-source = "git+https://github.com/broxus/tycho-types.git?rev=3ff0cacbce582a18505fe0828f3081684c34b9dc#3ff0cacbce582a18505fe0828f3081684c34b9dc"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104f8eaefe8d4c12e480906a876f0c6dd6f68c1e7eaeb8fd2c236e8f729019fd"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4595,7 +4596,8 @@ dependencies = [
 [[package]]
 name = "tycho-types-abi-proc"
 version = "0.3.0"
-source = "git+https://github.com/broxus/tycho-types.git?rev=3ff0cacbce582a18505fe0828f3081684c34b9dc#3ff0cacbce582a18505fe0828f3081684c34b9dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c813c08a03554252747f9e5e88485d9af4c30077394a1c3bb6d774ddca56b07"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4606,7 +4608,8 @@ dependencies = [
 [[package]]
 name = "tycho-types-proc"
 version = "0.3.0"
-source = "git+https://github.com/broxus/tycho-types.git?rev=3ff0cacbce582a18505fe0828f3081684c34b9dc#3ff0cacbce582a18505fe0828f3081684c34b9dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad05cf4ab89631f8c11d85c3aa80f781502440f75361d251f866e0d76ae9d31"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 triomphe = "0.1.15"
 tycho-crypto = { version = "0.4", features = ["tl-proto", "serde", "rand9"] }
 tycho-executor = "0.3.6"
-tycho-types = { version = "0.3.4", features = ["tycho", "stats"] }
+tycho-types = { version = "0.3.5", features = ["tycho", "stats"] }
 tycho-vm = "0.3.6"
 uuid = "1.22.0"
 walkdir = "2.5.0"
@@ -182,7 +182,6 @@ tycho-wu-tuner = { path = "./wu-tuner", version = "0.3.10" }
 
 [patch.crates-io]
 # patches here
-tycho-types = { git = "https://github.com/broxus/tycho-types.git", rev = "3ff0cacbce582a18505fe0828f3081684c34b9dc" }
 
 [workspace.lints.rust]
 future_incompatible = "warn"

--- a/block-util/src/message/ext_msg_repr.rs
+++ b/block-util/src/message/ext_msg_repr.rs
@@ -90,7 +90,8 @@ impl ExtMsgRepr {
 
     // === General methods ===
 
-    pub fn validate<T: AsRef<[u8]>>(bytes: T) -> Result<Cell, InvalidExtMsg> {
+    // Only validates BOC structure without checking the full message size or structure.
+    pub fn pre_validate_boc<T: AsRef<[u8]>>(bytes: T) -> Result<Cell, InvalidExtMsg> {
         // Apply limits to the encoded BOC.
         if bytes.as_ref().len() > Self::MAX_BOC_SIZE {
             return Err(InvalidExtMsg::BocSizeExceeded);
@@ -113,6 +114,12 @@ impl ExtMsgRepr {
         if msg_root.is_exotic() {
             return Err(InvalidExtMsg::InvalidMessage(Error::InvalidData));
         }
+
+        Ok(msg_root)
+    }
+
+    pub fn validate<T: AsRef<[u8]>>(bytes: T) -> Result<Cell, InvalidExtMsg> {
+        let msg_root = Self::pre_validate_boc(bytes)?;
 
         // Start parsing the message (we are sure now that it is an ordinary cell).
         let mut cs = msg_root.as_slice_allow_exotic();

--- a/cli/src/cmd/debug/mempool.rs
+++ b/cli/src/cmd/debug/mempool.rs
@@ -379,7 +379,11 @@ async fn load_mc_zerostate(
     tracing::info!("loading zerostate {:?}", zerostate_block_id);
     let root_hash = storage
         .shard_state_storage()
-        .store_state_bytes(&zerostate_block_id, masterchain_zerostate)
+        .store_state_bytes(
+            &zerostate_block_id,
+            masterchain_zerostate,
+            Some(&mc_zerostate_id.root_hash),
+        )
         .await?;
     assert_eq!(root_hash, mc_zerostate_id.root_hash);
 

--- a/collator/src/mempool/impls/common/parser.rs
+++ b/collator/src/mempool/impls/common/parser.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use tycho_block_util::message::ExtMsgRepr;
-use tycho_types::boc::Boc;
 use tycho_types::models::MsgInfo;
 use tycho_types::prelude::Load;
 use tycho_util::metrics::HistogramGuard;
@@ -79,10 +78,10 @@ impl Parser {
     }
 
     fn parse_message_bytes(message: &[u8]) -> Option<Arc<ExternalMessage>> {
-        let cell = Boc::decode(message).ok()?;
-        if cell.is_exotic() || cell.level() != 0 || cell.repr_depth() > ExtMsgRepr::MAX_REPR_DEPTH {
-            return None;
-        }
+        // NOTE: Brief message validation, other checks will be run in executor.
+        // We can't use `ExtMsgRepr::validate` because it uses some hardcoded limits,
+        // and the executor knows these limits better.
+        let cell = ExtMsgRepr::pre_validate_boc(message).ok()?;
 
         let mut cs = cell.as_slice_allow_exotic();
         let MsgInfo::ExtIn(info) = MsgInfo::load_from(&mut cs).ok()? else {

--- a/collator/src/test_utils.rs
+++ b/collator/src/test_utils.rs
@@ -237,7 +237,7 @@ async fn load_states_from_dump(storage: &CoreStorage, dump_path: &Path) -> Resul
             let tempfile = std::fs::File::open(&temp_path)?;
             storage
                 .shard_state_storage()
-                .store_state_file(&block_id, tempfile)
+                .store_state_file(&block_id, tempfile, None)
                 .await?;
 
             if let Some(handle) = storage.block_handle_storage().load_handle(&block_id) {

--- a/core/src/block_strider/starter/cold_boot.rs
+++ b/core/src/block_strider/starter/cold_boot.rs
@@ -476,13 +476,9 @@ impl StarterInner {
 
         let mc_block_id = self.zerostate.as_block_id();
         tracing::info!(%mc_block_id, "importing masterchain zerostate");
-        let root_hash = state_storage
-            .store_state_bytes(&mc_block_id, mc_zerostate)
+        state_storage
+            .store_state_bytes(&mc_block_id, mc_zerostate, Some(&self.zerostate.root_hash))
             .await?;
-        anyhow::ensure!(
-            root_hash == self.zerostate.root_hash,
-            "imported zerostate root hash mismatch"
-        );
 
         let mc_zerostate = state_storage
             .load_state(mc_block_id.seqno, &mc_block_id)
@@ -529,13 +525,9 @@ impl StarterInner {
             };
 
             tracing::info!(%block_id, "importing shard zerostate");
-            let root_hash = state_storage
-                .store_state_bytes(&block_id, state_bytes)
+            state_storage
+                .store_state_bytes(&block_id, state_bytes, Some(&block_id.root_hash))
                 .await?;
-            anyhow::ensure!(
-                root_hash == block_id.root_hash,
-                "imported zerostate root hash mismatch"
-            );
         }
 
         anyhow::ensure!(
@@ -618,27 +610,14 @@ impl StarterInner {
         let handle_storage = self.storage.block_handle_storage();
 
         let (handle, state) = self
-            .download_shard_state(&zerostate_id, &zerostate_id, true)
+            .download_shard_state(&zerostate_id, &zerostate_id, true, &zerostate_id.root_hash)
             .await?;
-        anyhow::ensure!(
-            state.root_cell().repr_hash() == &zerostate_id.root_hash,
-            "downloaded zerostate hash mismatch: expected={}, got={}",
-            zerostate_id.root_hash,
-            state.root_cell().repr_hash(),
-        );
 
         for item in state.shards()?.latest_blocks() {
             let block_id = item?;
-            let (handle, state) = self
-                .download_shard_state(&zerostate_id, &block_id, true)
+            let (handle, _) = self
+                .download_shard_state(&zerostate_id, &block_id, true, &block_id.root_hash)
                 .await?;
-            anyhow::ensure!(
-                state.root_cell().repr_hash() == &block_id.root_hash,
-                "downloaded zerostate hash mismatch: expected={}, got={}",
-                block_id.root_hash,
-                state.root_cell().repr_hash(),
-            );
-
             handle_storage.set_block_committed(&handle);
         }
 
@@ -663,13 +642,12 @@ impl StarterInner {
             let state_update = block.as_ref().load_state_update()?;
 
             let (_, shard_state) = self
-                .download_shard_state(mc_block_id, block_id, false)
+                .download_shard_state(mc_block_id, block_id, false, &state_update.new_hash)
                 .await?;
             let state_hash = *shard_state.root_cell().repr_hash();
-            anyhow::ensure!(
-                state_update.new_hash == state_hash,
-                "downloaded shard state hash mismatch: expected={}, got={state_hash}",
-                state_update.new_hash,
+            assert_eq!(
+                state_update.new_hash, state_hash,
+                "storage must verify expected root hash"
             );
         }
 
@@ -795,6 +773,7 @@ impl StarterInner {
         mc_block_id: &BlockId,
         block_id: &BlockId,
         is_zerostate: bool,
+        expected_state_root: &HashBytes,
     ) -> Result<(BlockHandle, ShardStateStuff)> {
         enum StoreZeroStateFrom {
             File(FileBuilder),
@@ -811,7 +790,7 @@ impl StarterInner {
         let state_file_path = state_file.path().to_owned();
 
         // NOTE: Intentionally dont spawn yet
-        let remove_state_file = async move {
+        let remove_state_file = async move || {
             if let Err(e) = tokio::fs::remove_file(&state_file_path).await {
                 tracing::warn!(
                     path = %state_file_path.display(),
@@ -857,6 +836,11 @@ impl StarterInner {
                 .load_state(mc_seqno, block_id)
                 .await
                 .context("failed to load state on downloaded shard state")?;
+            anyhow::ensure!(
+                state.root_cell().repr_hash() == expected_state_root,
+                "stored state root hash mismatch: expected={expected_state_root}, got={}",
+                state.root_cell().repr_hash()
+            );
 
             if !handle.has_persistent_shard_state() {
                 let from = if state_file.exists() {
@@ -870,7 +854,7 @@ impl StarterInner {
                     .context("failed to store persistent shard state")?;
             }
 
-            remove_state_file.await;
+            remove_state_file().await;
 
             tracing::info!("using the stored shard state");
             return Ok((handle.clone(), state));
@@ -885,6 +869,7 @@ impl StarterInner {
                 Ok(file) => file,
                 Err(e) => {
                     tracing::error!(attempt, "failed to download persistent shard state: {e:?}");
+                    remove_state_file().await;
                     continue;
                 }
             };
@@ -892,11 +877,23 @@ impl StarterInner {
             // NOTE: `store_state_file` error is mostly unrecoverable since the operation
             //       context is too large to be atomic. This downloaded-state path is
             //       rebuild-only on interruption, unlike bootstrap raw import marker cleanup.
-            // TODO: Make this operation recoverable to allow an infinite number of attempts.
-            shard_states
-                .store_state_file(block_id, file)
+            // TODO: mark all errors before `apply_temp_cell` as recoverable.
+            match shard_states
+                .store_state_file(block_id, file, Some(expected_state_root))
                 .await
-                .context("failed to store shard state file")?;
+            {
+                Ok(root_hash) => {
+                    assert_eq!(
+                        &root_hash, expected_state_root,
+                        "storage must verify expected root hash"
+                    );
+                }
+                Err(e) => {
+                    tracing::error!("failed to store shard state file: {e:?}");
+                    remove_state_file().await;
+                    continue;
+                }
+            }
 
             let state = shard_states
                 .load_state(mc_seqno, block_id)
@@ -926,7 +923,7 @@ impl StarterInner {
                 .await
                 .context("failed to store persistent shard state")?;
 
-            remove_state_file.await;
+            remove_state_file().await;
 
             tracing::info!("using the downloaded shard state");
             return Ok((block_handle, state));

--- a/core/src/block_strider/starter/cold_boot.rs
+++ b/core/src/block_strider/starter/cold_boot.rs
@@ -620,12 +620,24 @@ impl StarterInner {
         let (handle, state) = self
             .download_shard_state(&zerostate_id, &zerostate_id, true)
             .await?;
+        anyhow::ensure!(
+            state.root_cell().repr_hash() == &zerostate_id.root_hash,
+            "downloaded zerostate hash mismatch: expected={}, got={}",
+            zerostate_id.root_hash,
+            state.root_cell().repr_hash(),
+        );
 
         for item in state.shards()?.latest_blocks() {
             let block_id = item?;
-            let (handle, _) = self
+            let (handle, state) = self
                 .download_shard_state(&zerostate_id, &block_id, true)
                 .await?;
+            anyhow::ensure!(
+                state.root_cell().repr_hash() == &block_id.root_hash,
+                "downloaded zerostate hash mismatch: expected={}, got={}",
+                block_id.root_hash,
+                state.root_cell().repr_hash(),
+            );
 
             handle_storage.set_block_committed(&handle);
         }
@@ -656,7 +668,8 @@ impl StarterInner {
             let state_hash = *shard_state.root_cell().repr_hash();
             anyhow::ensure!(
                 state_update.new_hash == state_hash,
-                "downloaded shard state hash mismatch"
+                "downloaded shard state hash mismatch: expected={}, got={state_hash}",
+                state_update.new_hash,
             );
         }
 

--- a/core/src/blockchain_rpc/service.rs
+++ b/core/src/blockchain_rpc/service.rs
@@ -714,7 +714,10 @@ impl<B> Inner<B> {
 
         let block = BlockData {
             data,
-            size: NonZeroU32::new(data_size).expect("shouldn't happen"),
+            size: match NonZeroU32::new(data_size) {
+                Some(size) => size,
+                None => return Ok(BlockFull::NotFound),
+            },
             chunk_size: NonZeroU32::new(BLOCK_DATA_CHUNK_SIZE).expect("shouldn't happen"),
         };
 

--- a/core/src/overlay_client/mod.rs
+++ b/core/src/overlay_client/mod.rs
@@ -435,12 +435,16 @@ impl Drop for Inner {
         if let Some(handle) = self.ping_task.take() {
             handle.abort();
         }
-
         if let Some(handle) = self.update_task.take() {
             handle.abort();
         }
-
+        if let Some(handle) = self.score_task.take() {
+            handle.abort();
+        }
         if let Some(handle) = self.cleanup_task.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.metrics_task.take() {
             handle.abort();
         }
     }

--- a/core/src/storage/block/blobs/mod.rs
+++ b/core/src/storage/block/blobs/mod.rs
@@ -420,6 +420,10 @@ impl BlobStorage {
     }
 
     pub async fn find_mc_block_data(&self, mc_seqno: u32) -> Result<Option<Block>> {
+        if mc_seqno == u32::MAX {
+            return Ok(None);
+        }
+
         let lower_bound = BlockId {
             shard: ShardIdent::MASTERCHAIN,
             seqno: mc_seqno,

--- a/core/src/storage/shard_state/entries_buffer.rs
+++ b/core/src/storage/shard_state/entries_buffer.rs
@@ -144,17 +144,20 @@ impl<'a> HashesEntry<'a> {
         })
     }
 
-    pub fn pruned_branch_depth(&self, n: u8, data: &[u8]) -> u16 {
+    pub fn pruned_branch_depth(&self, n: u8, data: &[u8]) -> Option<u16> {
         let level_mask = self.level_mask();
         let index = level_mask.hash_index(n) as usize;
         let level = level_mask.level() as usize;
 
-        if index == level {
+        Some(if index == level {
             let offset = Self::DEPTHS_OFFSET;
             u16::from_le_bytes([self.0[offset], self.0[offset + 1]])
         } else {
             let offset = 1 + 1 + level * 32 + index * 2;
+            if data.len() < offset + 2 {
+                return None;
+            }
             u16::from_be_bytes([data[offset], data[offset + 1]])
-        }
+        })
     }
 }

--- a/core/src/storage/shard_state/mod.rs
+++ b/core/src/storage/shard_state/mod.rs
@@ -805,16 +805,33 @@ impl ShardStateStorage {
     }
 
     // Stores shard state and returns the hash of its root cell.
-    pub async fn store_state_file(&self, block_id: &BlockId, boc: File) -> Result<HashBytes> {
-        self.store_state_raw_inner(block_id, boc).await
+    pub async fn store_state_file(
+        &self,
+        block_id: &BlockId,
+        boc: File,
+        expected_root_hash: Option<&HashBytes>,
+    ) -> Result<HashBytes> {
+        self.store_state_raw_inner(block_id, boc, expected_root_hash)
+            .await
     }
 
-    pub async fn store_state_bytes(&self, block_id: &BlockId, boc: Bytes) -> Result<HashBytes> {
+    pub async fn store_state_bytes(
+        &self,
+        block_id: &BlockId,
+        boc: Bytes,
+        expected_root_hash: Option<&HashBytes>,
+    ) -> Result<HashBytes> {
         let cursor = Cursor::new(boc);
-        self.store_state_raw_inner(block_id, cursor).await
+        self.store_state_raw_inner(block_id, cursor, expected_root_hash)
+            .await
     }
 
-    async fn store_state_raw_inner<R>(&self, block_id: &BlockId, boc: R) -> Result<HashBytes>
+    async fn store_state_raw_inner<R>(
+        &self,
+        block_id: &BlockId,
+        boc: R,
+        expected_root_hash: Option<&HashBytes>,
+    ) -> Result<HashBytes>
     where
         R: std::io::Read + Send + 'static,
     {
@@ -822,6 +839,7 @@ impl ShardStateStorage {
             cells_db: self.cells_db.clone(),
             cell_storage: self.cell_storage.clone(),
             temp_file_storage: self.temp_file_storage.clone(),
+            expected_root_hash: expected_root_hash.copied(),
         };
 
         let block_id = *block_id;

--- a/core/src/storage/shard_state/store_state_raw.rs
+++ b/core/src/storage/shard_state/store_state_raw.rs
@@ -25,6 +25,7 @@ pub struct StoreStateContext {
     pub cells_db: CellsDb,
     pub cell_storage: Arc<CellStorage>,
     pub temp_file_storage: TempFileStorage,
+    pub expected_root_hash: Option<HashBytes>,
 }
 
 impl StoreStateContext {
@@ -212,6 +213,13 @@ impl StoreStateContext {
 
         // Current entry contains root cell
         let root_hash = ctx.entries_buffer.repr_hash();
+        if let Some(expected_root_hash) = &self.expected_root_hash {
+            anyhow::ensure!(
+                root_hash == expected_root_hash,
+                "shard state root hash mismatch: expected={expected_root_hash}, got={}",
+                HashBytes::wrap(root_hash)
+            );
+        }
         ctx.final_check(root_hash)?;
 
         self.cell_storage
@@ -445,7 +453,7 @@ impl<'a> FinalizationContext<'a> {
 
     fn final_check(&self, root_hash: &[u8; 32]) -> Result<()> {
         tracing::info!(root_hash = %HashBytes::wrap(root_hash), "Final check");
-        tracing::info!(len=?self.cell_usages.len(), "Cell usages");
+        tracing::info!(len = ?self.cell_usages.len(), "Cell usages");
 
         anyhow::ensure!(
             self.cell_usages.len() == 1 && self.cell_usages.contains_key(root_hash),
@@ -599,6 +607,7 @@ mod test {
             cells_db: cells_db.clone(),
             cell_storage: cell_storage.clone(),
             temp_file_storage: storage.context().temp_files().clone(),
+            expected_root_hash: None,
         };
 
         for file in std::fs::read_dir(current_test_path.join("states"))? {
@@ -784,7 +793,11 @@ mod test {
 
         let root_hash = storage
             .shard_state_storage()
-            .store_state_bytes(&block_id, Bytes::from_static(ZEROSTATE_BOC))
+            .store_state_bytes(
+                &block_id,
+                Bytes::from_static(ZEROSTATE_BOC),
+                Some(&block_id.root_hash),
+            )
             .await?;
         assert_eq!(root_hash, block_id.root_hash);
 
@@ -799,7 +812,11 @@ mod test {
         // existing counters.
         let root_hash = storage
             .shard_state_storage()
-            .store_state_bytes(&next_block_id, Bytes::from_static(ZEROSTATE_BOC))
+            .store_state_bytes(
+                &next_block_id,
+                Bytes::from_static(ZEROSTATE_BOC),
+                Some(&block_id.root_hash),
+            )
             .await?;
         assert_eq!(root_hash, next_block_id.root_hash);
 

--- a/core/src/storage/shard_state/store_state_raw.rs
+++ b/core/src/storage/shard_state/store_state_raw.rs
@@ -494,7 +494,7 @@ impl<'a> RawCell<'a> {
         let mut reference_indices = ArrayVec::new();
         for _ in 0..ref_count {
             let index = src.read_be_uint(ref_size)? as usize;
-            if index > cell_count || index <= cell_index {
+            if index >= cell_count || index <= cell_index {
                 return Err(parser_error("reference index out of range"));
             } else {
                 // SAFETY: `ref_count` is in range 0..=4

--- a/core/src/storage/shard_state/store_state_raw.rs
+++ b/core/src/storage/shard_state/store_state_raw.rs
@@ -341,7 +341,9 @@ impl<'a> FinalizationContext<'a> {
                         .get(index)
                         .ok_or(StoreStateError::InvalidCell)
                         .context("Pruned branch data not found")?;
-                    child.pruned_branch_depth(hash_idx + is_merkle_cell as u8, child_data)
+                    child
+                        .pruned_branch_depth(hash_idx + is_merkle_cell as u8, child_data)
+                        .context("Invalid pruned branch")?
                 } else {
                     child.depth(hash_idx + is_merkle_cell as u8)
                 };

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -39,6 +39,7 @@ ring = { workspace = true }
 rustls = { workspace = true }
 rustls-pki-types = { workspace = true }
 rustls-webpki = { workspace = true }
+scopeguard = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 socket2 = { workspace = true }
 thiserror = { workspace = true }
@@ -55,6 +56,7 @@ tycho-util = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio-util = { workspace = true, features = ["rt"] }
 tempfile = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/network/src/overlay/background_tasks.rs
+++ b/network/src/overlay/background_tasks.rs
@@ -5,8 +5,10 @@ use anyhow::Result;
 use futures_util::StreamExt;
 use indexmap::IndexSet;
 use rand::Rng;
+use tl_proto::TlRead;
 use tycho_util::futures::JoinTask;
 use tycho_util::time::{now_sec, shifted_interval, shifted_interval_immediate};
+use tycho_util::tl::VecWithMaxLen;
 
 use crate::dht::{DhtClient, DhtQueryMode, DhtService};
 use crate::network::{KnownPeerHandle, Network, WeakNetwork};
@@ -356,7 +358,9 @@ impl OverlayServiceInner {
                     count = entries.len(),
                     "received public entries"
                 );
-                overlay.add_untrusted_entries(&self.local_id, &entries, now_sec());
+                overlay
+                    .add_untrusted_entries(&self.local_id, &entries, now_sec())
+                    .await;
             }
             PublicEntriesResponse::OverlayNotFound => {
                 tracing::debug!(
@@ -394,11 +398,12 @@ impl OverlayServiceInner {
         let res = dht_client.find_value(&key_hash, DhtQueryMode::Random).await;
         let is_empty = overlay.read_entries().is_empty();
 
-        let entries = match res {
+        #[derive(TlRead)]
+        struct LimitedEntries(#[tl(with = "VecWithMaxLen::<100>")] Vec<Arc<PublicEntry>>);
+
+        let LimitedEntries(mut entries) = match res {
             Some(value) => match &*value {
-                Value::Merged(value) => {
-                    tl_proto::deserialize::<Vec<Arc<PublicEntry>>>(&value.data)?
-                }
+                Value::Merged(value) => tl_proto::deserialize(&value.data)?,
                 Value::Peer(_) => {
                     tracing::warn!("expected a `Value::Merged`, but got a `Value::Peer`");
                     return Ok(DiscoveryStatus::Unchanged { is_empty });
@@ -409,10 +414,22 @@ impl OverlayServiceInner {
                 return Ok(DiscoveryStatus::Unchanged { is_empty });
             }
         };
+        let max_count = self.config.public_overlay_peer_store_max_entries;
+        if entries.len() > max_count {
+            tracing::warn!(
+                discovered = entries.len(),
+                max_count,
+                "truncating discovered entries",
+            );
+            entries.truncate(max_count);
+        }
+        let count = entries.len();
 
-        let updated = overlay.add_untrusted_entries(&self.local_id, &entries, now_sec());
+        let updated = overlay
+            .add_untrusted_entries(&self.local_id, &entries, now_sec())
+            .await;
 
-        tracing::debug!(count = entries.len(), updated, "discovered public entries");
+        tracing::debug!(count, updated, "discovered public entries");
         Ok(if updated {
             DiscoveryStatus::Changed
         } else {
@@ -492,16 +509,13 @@ impl OverlayServiceInner {
                 Ok(entry) => {
                     tracing::debug!(%peer_id, "received public entry");
 
-                    let any_added = overlay.add_untrusted_entries(
-                        &self.local_id,
-                        std::slice::from_ref(&entry),
-                        now_sec(),
-                    );
-
-                    if any_added {
-                        // Give some space for the executor between signature checks.
-                        tokio::task::yield_now().await;
-                    }
+                    overlay
+                        .add_untrusted_entries(
+                            &self.local_id,
+                            std::slice::from_ref(&entry),
+                            now_sec(),
+                        )
+                        .await;
                 }
                 Err(e) => tracing::debug!(%peer_id, "failed to get peer public overlay entry: {e}"),
             }

--- a/network/src/overlay/mod.rs
+++ b/network/src/overlay/mod.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
 use bytes::Buf;
+use futures_util::FutureExt;
+use futures_util::future::Either;
 use tl_proto::{TlError, TlRead};
 use tokio::sync::Notify;
 use tycho_util::futures::BoxFutureOrNoop;
@@ -166,10 +168,8 @@ impl Service<ServiceRequest> for OverlayService {
                     };
                     tracing::debug!("exchange_random_public_entries");
 
-                    let res = self.0.handle_exchange_public_entries(&req);
-                    return BoxFutureOrNoop::future(futures_util::future::ready(Some(
-                        Response::from_tl(res),
-                    )));
+                    let f = self.0.handle_exchange_public_entries(req);
+                    return BoxFutureOrNoop::future(f.map(|res| Some(Response::from_tl(res))));
                 }
                 rpc::GetPublicEntry::TL_ID => {
                     let req = match tl_proto::deserialize::<rpc::GetPublicEntry>(&req.body) {
@@ -192,10 +192,14 @@ impl Service<ServiceRequest> for OverlayService {
             }
             let offset = req.body.len() - req_body.len();
 
-            if let Some(private_overlay) = self.0.private_overlays.get(overlay_id) {
+            if let Some(private_overlay) =
+                self.0.private_overlays.get(overlay_id).map(|o| o.clone())
+            {
                 req.body.advance(offset);
                 return private_overlay.handle_query(req);
-            } else if let Some(public_overlay) = self.0.public_overlays.get(overlay_id) {
+            } else if let Some(public_overlay) =
+                self.0.public_overlays.get(overlay_id).map(|o| o.clone())
+            {
                 req.body.advance(offset);
                 return public_overlay.handle_query(req);
             }
@@ -240,10 +244,14 @@ impl Service<ServiceRequest> for OverlayService {
             }
             let offset = req.body.len() - req_body.len();
 
-            if let Some(private_overlay) = self.0.private_overlays.get(overlay_id) {
+            if let Some(private_overlay) =
+                self.0.private_overlays.get(overlay_id).map(|o| o.clone())
+            {
                 req.body.advance(offset);
                 return private_overlay.handle_message(req);
-            } else if let Some(public_overlay) = self.0.public_overlays.get(overlay_id) {
+            } else if let Some(public_overlay) =
+                self.0.public_overlays.get(overlay_id).map(|o| o.clone())
+            {
                 req.body.advance(offset);
                 return public_overlay.handle_message(req);
             }
@@ -335,43 +343,52 @@ impl OverlayServiceInner {
 
     fn handle_exchange_public_entries(
         &self,
-        req: &rpc::ExchangeRandomPublicEntries,
-    ) -> PublicEntriesResponse {
+        req: rpc::ExchangeRandomPublicEntries,
+    ) -> impl Future<Output = PublicEntriesResponse> + Send + 'static {
         // NOTE: validation is done in the TL parser.
         debug_assert!(req.entries.len() <= 20);
 
         // Find the overlay
         let overlay = match self.public_overlays.get(&req.overlay_id) {
-            Some(overlay) => overlay,
-            None => return PublicEntriesResponse::OverlayNotFound,
+            Some(overlay) => overlay.clone(),
+            None => {
+                return Either::Left(futures_util::future::ready(
+                    PublicEntriesResponse::OverlayNotFound,
+                ));
+            }
         };
 
-        // Add proposed entries to the overlay
-        overlay.add_untrusted_entries(&self.local_id, &req.entries, now_sec());
+        let local_id = self.local_id;
+        let n = self.config.exchange_public_entries_batch;
+        Either::Right(async move {
+            // Add proposed entries to the overlay
+            overlay
+                .add_untrusted_entries(&local_id, &req.entries, now_sec())
+                .await;
 
-        // Collect proposed entries to exclude from the response
-        let requested_ids = req
-            .entries
-            .iter()
-            .map(|id| id.peer_id)
-            .collect::<FastHashSet<_>>();
+            // Collect proposed entries to exclude from the response
+            let requested_ids = req
+                .entries
+                .iter()
+                .map(|id| id.peer_id)
+                .collect::<FastHashSet<_>>();
 
-        let entries = {
-            let entries = overlay.read_entries();
+            let entries = {
+                let entries = overlay.read_entries();
 
-            // Choose additional random entries to ensure we have enough new entries to send back
-            let n = self.config.exchange_public_entries_batch;
-            entries
-                .choose_multiple(&mut rand::rng(), n + requested_ids.len())
-                .filter_map(|item| {
-                    let is_new = !requested_ids.contains(&item.entry.peer_id);
-                    is_new.then(|| item.entry.clone())
-                })
-                .take(n)
-                .collect::<Vec<_>>()
-        };
+                // Choose additional random entries to ensure we have enough new entries to send back
+                entries
+                    .choose_multiple(&mut rand::rng(), n + requested_ids.len())
+                    .filter_map(|item| {
+                        let is_new = !requested_ids.contains(&item.entry.peer_id);
+                        is_new.then(|| item.entry.clone())
+                    })
+                    .take(n)
+                    .collect::<Vec<_>>()
+            };
 
-        PublicEntriesResponse::PublicEntries(entries)
+            PublicEntriesResponse::PublicEntries(entries)
+        })
     }
 
     fn handle_get_public_entry(&self, req: &rpc::GetPublicEntry) -> PublicEntryResponse {

--- a/network/src/overlay/public_overlay.rs
+++ b/network/src/overlay/public_overlay.rs
@@ -281,7 +281,7 @@ impl PublicOverlay {
     /// Adds the given entries to the overlay.
     ///
     /// NOTE: Will deadlock if called while `PublicOverlayEntriesReadGuard` is held.
-    pub(crate) fn add_untrusted_entries(
+    pub(crate) async fn add_untrusted_entries(
         &self,
         local_id: &PeerId,
         entries: &[Arc<PublicEntry>],
@@ -315,6 +315,12 @@ impl PublicOverlay {
             }
         };
 
+        // Rollback entries that were not inserted if the future is dropped
+        // before the final insertion.
+        let capacity_guard = scopeguard::guard(this, |this| {
+            this.entry_count.fetch_sub(to_add, Ordering::Release);
+        });
+
         // Prepare validation state
         let mut is_valid = vec![false; entries.len()];
         let mut has_valid = false;
@@ -334,6 +340,7 @@ impl PublicOverlay {
                 continue;
             };
 
+            tokio::task::yield_now().await;
             if !pubkey.verify_tl(
                 PublicEntryToSign {
                     overlay_id: this.overlay_id.as_bytes(),
@@ -351,6 +358,11 @@ impl PublicOverlay {
             *is_valid = true;
             has_valid = true;
         }
+
+        tokio::task::yield_now().await;
+
+        // NOTE: After this point the future cannot be interrupted so we defuse the guard.
+        scopeguard::ScopeGuard::into_inner(capacity_guard);
 
         // Second pass: insert all valid entries (if any)
         //
@@ -748,8 +760,8 @@ mod tests {
             }))
     }
 
-    #[test]
-    fn min_capacity_works_with_single_thread() {
+    #[tokio::test]
+    async fn min_capacity_works_with_single_thread() {
         let now = now_sec();
         let local_id: PeerId = rand::random();
 
@@ -758,10 +770,14 @@ mod tests {
             let overlay = make_overlay_with_min_capacity(10);
             let entries = generate_public_entries(&overlay, now, 10);
 
-            overlay.add_untrusted_entries(&local_id, &entries[..5], now);
+            overlay
+                .add_untrusted_entries(&local_id, &entries[..5], now)
+                .await;
             assert_eq!(count_entries(&overlay), 5);
 
-            overlay.add_untrusted_entries(&local_id, &entries[5..], now);
+            overlay
+                .add_untrusted_entries(&local_id, &entries[5..], now)
+                .await;
             assert_eq!(count_entries(&overlay), 10);
         }
 
@@ -769,7 +785,9 @@ mod tests {
         {
             let overlay = make_overlay_with_min_capacity(10);
             let entries = generate_public_entries(&overlay, now, 10);
-            overlay.add_untrusted_entries(&local_id, &entries, now);
+            overlay
+                .add_untrusted_entries(&local_id, &entries, now)
+                .await;
             assert_eq!(count_entries(&overlay), 10);
         }
 
@@ -777,7 +795,9 @@ mod tests {
         {
             let overlay = make_overlay_with_min_capacity(10);
             let entries = generate_public_entries(&overlay, now, 20);
-            overlay.add_untrusted_entries(&local_id, &entries, now);
+            overlay
+                .add_untrusted_entries(&local_id, &entries, now)
+                .await;
             assert_eq!(count_entries(&overlay), 10);
         }
 
@@ -785,7 +805,9 @@ mod tests {
         {
             let overlay = make_overlay_with_min_capacity(0);
             let entries = generate_public_entries(&overlay, now, 10);
-            overlay.add_untrusted_entries(&local_id, &entries, now);
+            overlay
+                .add_untrusted_entries(&local_id, &entries, now)
+                .await;
             assert_eq!(count_entries(&overlay), 0);
         }
 
@@ -795,7 +817,9 @@ mod tests {
             let entries = (0..10)
                 .map(|_| generate_invalid_public_entry(now))
                 .collect::<Vec<_>>();
-            overlay.add_untrusted_entries(&local_id, &entries, now);
+            overlay
+                .add_untrusted_entries(&local_id, &entries, now)
+                .await;
             assert_eq!(count_entries(&overlay), 0);
         }
 
@@ -814,7 +838,9 @@ mod tests {
                 generate_invalid_public_entry(now),
                 generate_public_entry(&overlay, now),
             ];
-            overlay.add_untrusted_entries(&local_id, &entries, now);
+            overlay
+                .add_untrusted_entries(&local_id, &entries, now)
+                .await;
             assert_eq!(count_entries(&overlay), 5);
         }
 
@@ -833,28 +859,33 @@ mod tests {
                 generate_public_entry(&overlay, now),
                 generate_public_entry(&overlay, now),
             ];
-            overlay.add_untrusted_entries(&local_id, &entries, now);
+            overlay
+                .add_untrusted_entries(&local_id, &entries, now)
+                .await;
             assert_eq!(count_entries(&overlay), 3);
         }
     }
 
-    #[test]
-    fn min_capacity_works_with_multi_thread() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn min_capacity_works_with_multi_thread() {
         let now = now_sec();
         let local_id: PeerId = rand::random();
 
         let overlay = make_overlay_with_min_capacity(201);
         let entries = generate_public_entries(&overlay, now, 7 * 3 * 10);
 
-        std::thread::scope(|s| {
-            for entries in entries.chunks_exact(7 * 3) {
-                s.spawn(|| {
-                    for entries in entries.chunks_exact(7) {
-                        overlay.add_untrusted_entries(&local_id, entries, now);
-                    }
-                });
-            }
-        });
+        let tracker = tokio_util::task::TaskTracker::new();
+        for entries in entries.chunks_exact(7 * 3) {
+            let overlay = overlay.clone();
+            let entries = entries.to_vec();
+            tracker.spawn(async move {
+                for entries in entries.chunks_exact(7) {
+                    overlay.add_untrusted_entries(&local_id, entries, now).await;
+                }
+            });
+        }
+        tracker.close();
+        tracker.wait().await;
 
         assert_eq!(count_entries(&overlay), 201);
     }

--- a/network/src/proto/overlay.rs
+++ b/network/src/proto/overlay.rs
@@ -34,7 +34,8 @@ impl PublicEntry {
     pub fn is_expired(&self, at: u32, ttl_sec: u32) -> bool {
         const CLOCK_THRESHOLD: u32 = 1;
 
-        self.created_at > at + CLOCK_THRESHOLD || self.created_at.saturating_add(ttl_sec) < at
+        self.created_at > at.saturating_add(CLOCK_THRESHOLD)
+            || self.created_at.saturating_add(ttl_sec) < at
     }
 }
 

--- a/network/src/types/peer_info.rs
+++ b/network/src/types/peer_info.rs
@@ -46,7 +46,7 @@ impl PeerInfo {
     pub fn verify_ext(&self, at: u32, signature_checked: &mut bool) -> bool {
         const CLOCK_THRESHOLD: u32 = 1;
 
-        let timings_ok = self.created_at <= at + CLOCK_THRESHOLD
+        let timings_ok = self.created_at <= at.saturating_add(CLOCK_THRESHOLD)
             && self.expires_at >= at
             && !self.address_list.is_empty();
 

--- a/util/src/fs/mapped_file.rs
+++ b/util/src/fs/mapped_file.rs
@@ -131,11 +131,12 @@ impl MappedFile {
             return Err(std::io::Error::last_os_error());
         }
 
+        let this = Self { length, ptr };
         if unsafe { libc::madvise(ptr, length, libc::MADV_RANDOM) } != 0 {
             return Err(std::io::Error::last_os_error());
         }
 
-        Ok(Self { length, ptr })
+        Ok(this)
     }
 
     /// Mapped buffer length in bytes

--- a/util/src/sync/once_take.rs
+++ b/util/src/sync/once_take.rs
@@ -40,6 +40,10 @@ impl<T> Drop for OnceTake<T> {
     }
 }
 
+// NOTE: `OnceTake` can be shared between threads and some other thread
+// can call `take` "sending" the value between threads.
+unsafe impl<T: Send> Sync for OnceTake<T> {}
+
 #[cfg(test)]
 mod test {
     use std::sync::{Arc, Mutex};


### PR DESCRIPTION
Give a hard error when starting from an invalid zerostate.

Later we should move this check into the downloader itself, but there is no way of properly retrying the initial apply.