### PR TITLE
Fix/consensus/duplicate dag events

### DIFF
--- a/consensus/src/dag/commit/inspector.rs
+++ b/consensus/src/dag/commit/inspector.rs
@@ -11,7 +11,7 @@ use crate::models::{
     CounterU16, DagPoint, Digest, IllFormedPoint, InvalidPoint, MempoolPeerCounters,
     MempoolPeerStats, PointId, PointInfo, Round, TransInvalidPoint,
 };
-use crate::moderator::JournalEvent;
+use crate::moderator::JournalDagEvent;
 
 type RoundDataMap = FastHashMap<PeerId, PeerRoundData>;
 struct PeerRoundData {
@@ -70,21 +70,21 @@ impl RoundInspector {
         mem::replace(&mut self.stats, FastHashMap::with_capacity(capacity))
     }
 
-    pub fn take_events(&mut self) -> Vec<JournalEvent> {
+    pub fn take_events(&mut self) -> Vec<JournalDagEvent> {
         let trans_invalid = mem::take(&mut self.trans_invalid)
             .into_iter()
-            .map(JournalEvent::TransInvalid);
+            .map(JournalDagEvent::TransInvalid);
         let invalid = mem::take(&mut self.invalid)
             .into_iter()
-            .map(JournalEvent::Invalid);
+            .map(JournalDagEvent::Invalid);
         let ill_formed = mem::take(&mut self.ill_formed)
             .into_iter()
-            .map(JournalEvent::IllFormed);
+            .map(JournalDagEvent::IllFormed);
         let forks = mem::take(&mut self.forks)
             .into_iter()
-            .map(|fork| JournalEvent::Equivocated(fork.author, fork.round, fork.items));
+            .map(|fork| JournalDagEvent::Equivocated(fork.author, fork.round, fork.items));
         let not_referenced = mem::take(&mut self.not_referenced).into_iter().map(|nr| {
-            JournalEvent::EvidenceNoInclusion {
+            JournalDagEvent::EvidenceNoInclusion {
                 signer: nr.signer,
                 blamed: nr.blamed,
                 proofs: nr.proofs,

--- a/consensus/src/dag/commit/inspector.rs
+++ b/consensus/src/dag/commit/inspector.rs
@@ -98,7 +98,7 @@ impl RoundInspector {
             .collect()
     }
 
-    pub fn inspect(&mut self, r_0: &DagRound, emit_stats: bool) -> TaskResult<()> {
+    pub fn inspect(&mut self, r_0: &DagRound) -> TaskResult<()> {
         let leader_used = r_0.used_anchor_proof().get();
 
         // map has full peer set for this round, but maybe with empty value
@@ -114,7 +114,7 @@ impl RoundInspector {
             let mut has_valid = false;
 
             for version in authored {
-                if emit_stats && version.has_proof() {
+                if version.has_proof() {
                     // not more than one version can have a proving point
                     author_counters.points_proved += 1;
                 }

--- a/consensus/src/dag/commit/mod.rs
+++ b/consensus/src/dag/commit/mod.rs
@@ -159,14 +159,17 @@ impl Committer {
         let drained =
             (self.dag).drain_upto(anchor_round - conf.consensus.commit_history_rounds.get());
         let last_non_executable = self.first_executable.prev().max(conf.genesis_round);
+        let stats_since = stats_ranges.stats_since(anchor_round, conf);
         for r_0 in &drained {
             if r_0.round() >= last_non_executable {
-                let emit_stats = stats_ranges.can_emit_stats(r_0.round(), anchor_round);
-                self.inspector.inspect(r_0, emit_stats)?;
+                self.inspector.inspect(r_0)?;
             }
             if r_0.round() == last_non_executable {
                 self.inspector.take_stats(); // was used only to refill state
                 self.inspector.take_events();
+            }
+            if stats_since.is_none_or(|stats_since| r_0.round() < stats_since) {
+                self.inspector.take_stats(); // suppression: drop every unsuitable
             }
         }
         let drained = drained

--- a/consensus/src/dag/commit/mod.rs
+++ b/consensus/src/dag/commit/mod.rs
@@ -17,7 +17,7 @@ use crate::intercom::StatsRanges;
 use crate::models::{
     AnchorData, AnyLink, DagPoint, MempoolPeerStats, PointInfo, Round, ValidPoint,
 };
-use crate::moderator::JournalEvent;
+use crate::moderator::JournalDagEvent;
 
 #[derive(thiserror::Error, Debug)]
 #[error("Committer encountered local history conflict at round {}", .0.0)]
@@ -154,7 +154,7 @@ impl Committer {
         anchor_round: Round,
         stats_ranges: &StatsRanges,
         conf: &MempoolConfig,
-    ) -> TaskResult<(FastHashMap<PeerId, MempoolPeerStats>, Vec<JournalEvent>)> {
+    ) -> TaskResult<(FastHashMap<PeerId, MempoolPeerStats>, Vec<JournalDagEvent>)> {
         // in case previous anchor was triggered directly - rounds are already dropped
         let drained =
             (self.dag).drain_upto(anchor_round - conf.consensus.commit_history_rounds.get());

--- a/consensus/src/dag/producer.rs
+++ b/consensus/src/dag/producer.rs
@@ -65,8 +65,8 @@ impl Producer {
             key_pair,
             head.current().round(),
             head.current().leader(),
-            includes,
-            witness,
+            &includes,
+            &witness,
             conf,
         )
     }
@@ -80,8 +80,8 @@ impl Producer {
         current_round: Round,
         current_leader: Option<&PeerId>,
 
-        includes: Vec<PointInfo>,
-        witness: Vec<PointInfo>,
+        includes: &FastHashMap<PeerId, PointInfo>,
+        witness: &FastHashMap<PeerId, PointInfo>,
 
         conf: &MempoolConfig,
     ) -> Result<Point, ProduceError> {
@@ -99,7 +99,7 @@ impl Producer {
             _ => None,
         };
 
-        let (anchor_proof, anchor_trigger) = link::anchor_links(current_round, &includes, &witness);
+        let (anchor_proof, anchor_trigger) = link::anchor_links(current_round, includes, witness);
 
         let role = if proven_vertex.is_some() {
             let last_own_point = last_own_point.as_ref().expect("guarded by `proven_vertex`");
@@ -162,19 +162,15 @@ impl Producer {
             last.evidence.len() >= last.signers.reliable_minority()
         }));
 
-        let prev_info = (includes.iter()).find(|point| point.author() == local_id);
+        let prev_info = includes.get(&local_id);
 
         Self::check_prev_point(prev_info, proven_vertex)?;
 
-        let (time, anchor_time) = Self::get_time(
-            &role.anchor_proof(&local_id),
-            prev_info,
-            &includes,
-            &witness,
-        );
+        let (time, anchor_time) =
+            Self::get_time(&role.anchor_proof(&local_id), prev_info, includes, witness);
 
         let includes = includes
-            .into_iter()
+            .values()
             .map(|info| (*info.author(), *info.digest()))
             .collect::<FastHashMap<_, _>>();
 
@@ -185,7 +181,7 @@ impl Producer {
         );
 
         let witness = witness
-            .into_iter()
+            .values()
             .map(|info| (*info.author(), *info.digest()))
             .collect::<FastHashMap<_, _>>();
 
@@ -211,7 +207,7 @@ impl Producer {
         ))
     }
 
-    fn includes(finished_dag_round: &DagRound) -> Vec<PointInfo> {
+    fn includes(finished_dag_round: &DagRound) -> FastHashMap<PeerId, PointInfo> {
         let includes = finished_dag_round.threshold().get_reached();
         assert!(
             includes.len() >= finished_dag_round.peer_count().majority(),
@@ -228,10 +224,10 @@ impl Producer {
         finished_dag_round: &DagRound,
         local_id: &PeerId,
         last_own_point: Option<&LastOwnPoint>,
-    ) -> Vec<PointInfo> {
+    ) -> FastHashMap<PeerId, PointInfo> {
         let round = finished_dag_round.round();
         let Some(witness_round) = finished_dag_round.prev().upgrade() else {
-            return Vec::new();
+            return FastHashMap::default();
         };
 
         let includes = last_own_point
@@ -254,17 +250,17 @@ impl Producer {
                     loc.state
                         .get_or_reject()
                         .ok()
-                        .map(|signed| signed.first_resolved.info().clone())
+                        .map(|signed| (*peer, signed.first_resolved.info().clone()))
                 }
             })
-            .collect::<Vec<_>>()
+            .collect::<_>()
     }
 
     fn get_time(
         anchor_proof: &AnyLink<'_>,
         prev_info: Option<&PointInfo>,
-        includes: &[PointInfo],
-        witness: &[PointInfo],
+        includes: &FastHashMap<PeerId, PointInfo>,
+        witness: &FastHashMap<PeerId, PointInfo>,
     ) -> (UnixTime, UnixTime) {
         let anchor_time = match anchor_proof {
             AnyLink::ToSelf => {
@@ -278,9 +274,7 @@ impl Producer {
                     Through::Witness(peer_id) => (peer_id, &witness),
                 };
 
-                let info = through
-                    .iter()
-                    .find(|point| point.author() == peer_id)
+                let info = (through.get(peer_id))
                     .expect("path to anchor proof should exist in new point dependencies");
 
                 info.anchor_time()
@@ -338,8 +332,8 @@ mod link {
 
     pub fn anchor_links(
         current_round: Round,
-        includes: &[PointInfo],
-        witness: &[PointInfo],
+        includes: &FastHashMap<PeerId, PointInfo>,
+        witness: &FastHashMap<PeerId, PointInfo>,
     ) -> (AnchorLink, AnchorLink) {
         let trigger_source = link_source(includes, witness, AnchorStageRole::Trigger);
         let max_proof_source = link_source(includes, witness, AnchorStageRole::Proof);
@@ -364,24 +358,24 @@ mod link {
     }
 
     fn link_source<'a>(
-        includes: &'a [PointInfo],
-        witness: &'a [PointInfo],
+        includes: &'a FastHashMap<PeerId, PointInfo>,
+        witness: &'a FastHashMap<PeerId, PointInfo>,
         link_field: AnchorStageRole,
     ) -> LinkSource<'a> {
-        let incl_info = includes
+        let (_, incl_info) = includes
             .iter()
-            .max_by_key(|point| point.anchor_round(link_field))
+            .max_by_key(|(_, info)| info.anchor_round(link_field))
             .expect("non-empty list of includes for own point");
 
         let newer_witness = witness
             .iter()
-            .max_by_key(|wit_info| wit_info.anchor_round(link_field))
-            .filter(|wit_info| {
+            .max_by_key(|(_, wit_info)| wit_info.anchor_round(link_field))
+            .filter(|(_, wit_info)| {
                 wit_info.anchor_round(link_field) > incl_info.anchor_round(link_field)
             });
 
         match newer_witness {
-            Some(info) => LinkSource {
+            Some((_, info)) => LinkSource {
                 info,
                 path: Through::Witness(*info.author()),
             },

--- a/consensus/src/dag/threshold.rs
+++ b/consensus/src/dag/threshold.rs
@@ -1,3 +1,4 @@
+use std::mem;
 use std::sync::atomic;
 use std::sync::atomic::AtomicU32;
 use std::time::Duration;
@@ -132,7 +133,7 @@ impl Threshold {
     }
 
     /// use only after [`Self::reached()`] was awaited to completion
-    pub fn get_reached(&self) -> Vec<PointInfo> {
+    pub fn get_reached(&self) -> FastHashMap<PeerId, PointInfo> {
         let mut work = match self.work.try_lock() {
             Ok(guard) => guard,
             Err(e) => panic!("threshold lock must be released: {e}"),
@@ -181,7 +182,7 @@ impl Threshold {
             removed_from_channel,
         );
 
-        work.ready.values().cloned().collect()
+        mem::take(&mut work.ready)
     }
 
     fn push_ready(ready: &mut FastHashMap<PeerId, PointInfo>, info: PointInfo) {
@@ -384,7 +385,7 @@ mod test {
         let thresh = Arc::into_inner(thresh).expect("must be single reference");
         let work = thresh.work.into_inner();
 
-        assert_eq!(count.ready as usize, work.ready.len(), "ready count");
+        assert_eq!(work.ready.len(), 0, "all ready taken");
 
         assert_eq!(count.delayed as usize, work.delayed.len(), "delayed count");
 

--- a/consensus/src/intercom/core/query/impl_.rs
+++ b/consensus/src/intercom/core/query/impl_.rs
@@ -12,7 +12,7 @@ use crate::intercom::core::query::response::{
 };
 use crate::intercom::{Dispatcher, QueryRequestTag};
 use crate::models::{Point, PointId, Round};
-use crate::moderator::JournalEvent;
+use crate::moderator::JournalNetworkEvent;
 
 pub enum QueryError {
     Network(anyhow::Error),
@@ -54,7 +54,7 @@ impl BroadcastQuery {
         QueryResponse::parse_broadcast(&response).map_err(QueryError::TlError)
     }
     pub fn report(&self, peer_id: &PeerId, error: TlError) {
-        let event = JournalEvent::BadResponse(*peer_id, QueryRequestTag::Broadcast, error);
+        let event = JournalNetworkEvent::BadResponse(*peer_id, QueryRequestTag::Broadcast, error);
         self.dispatcher.moderator().report(event);
     }
 }
@@ -93,7 +93,7 @@ impl SignatureQuery {
         QueryResponse::parse_signature(&response).map_err(QueryError::TlError)
     }
     pub fn report(&self, peer_id: &PeerId, error: TlError) {
-        let event = JournalEvent::BadResponse(*peer_id, QueryRequestTag::Signature, error);
+        let event = JournalNetworkEvent::BadResponse(*peer_id, QueryRequestTag::Signature, error);
         self.dispatcher.moderator().report(event);
     }
 }
@@ -151,7 +151,7 @@ impl DownloadQuery {
         }
     }
 
-    pub fn report(&self, event: JournalEvent) {
+    pub fn report(&self, event: JournalNetworkEvent) {
         self.0.dispatcher.moderator().report(event);
     }
 }

--- a/consensus/src/intercom/core/responder.rs
+++ b/consensus/src/intercom/core/responder.rs
@@ -18,7 +18,7 @@ use crate::intercom::core::query::request::{
 use crate::intercom::core::query::response::QueryResponse;
 use crate::intercom::{BroadcastFilter, Downloader, PeerSchedule, Uploader};
 use crate::models::Point;
-use crate::moderator::{JournalEvent, Moderator};
+use crate::moderator::{JournalNetworkEvent, Moderator};
 use crate::storage::MempoolStore;
 
 #[derive(Clone, Default)]
@@ -159,7 +159,8 @@ impl ResponderInner {
                     error = %tl_error,
                     "unexpected query",
                 );
-                (state.moderator).report(JournalEvent::UnknownQuery(*peer_id, tl_error));
+                let event = JournalNetworkEvent::UnknownQuery(*peer_id, tl_error);
+                state.moderator.report(event);
                 return None;
             }
         };
@@ -191,7 +192,7 @@ impl ResponderInner {
                     peer_id = display(peer_id.alt()),
                     "query limit reached",
                 );
-                let event = JournalEvent::QueryLimitReached(*peer_id, tag);
+                let event = JournalNetworkEvent::QueryLimitReached(*peer_id, tag);
                 state.moderator.report(event);
                 response.set_hard_limited();
                 return None;
@@ -207,7 +208,7 @@ impl ResponderInner {
                     error = %tl_error,
                     "bad request",
                 );
-                let event = JournalEvent::BadRequest(*peer_id, tag, tl_error);
+                let event = JournalNetworkEvent::BadRequest(*peer_id, tag, tl_error);
                 state.moderator.report(event);
                 return None;
             }
@@ -234,7 +235,7 @@ impl ResponderInner {
                             digest = display(wrong_id.digest.alt()),
                             "broadcasted other's point",
                         );
-                        let event = JournalEvent::SenderNotAuthor(*peer_id, *wrong_id);
+                        let event = JournalNetworkEvent::SenderNotAuthor(*peer_id, *wrong_id);
                         (state.moderator).report(event);
                         return None;
                     }
@@ -246,7 +247,8 @@ impl ResponderInner {
                             error = %integrity_err,
                             "bad point",
                         );
-                        let event = JournalEvent::PointIntegrityError(*peer_id, tag, integrity_err);
+                        let event =
+                            JournalNetworkEvent::PointIntegrityError(*peer_id, tag, integrity_err);
                         (state.moderator).report(event);
                         return None;
                     }
@@ -257,7 +259,7 @@ impl ResponderInner {
                             error = %tl_error,
                             "bad request",
                         );
-                        let event = JournalEvent::BadRequest(*peer_id, tag, tl_error);
+                        let event = JournalNetworkEvent::BadRequest(*peer_id, tag, tl_error);
                         state.moderator.report(event);
                         return None;
                     }

--- a/consensus/src/intercom/dependency/downloader.rs
+++ b/consensus/src/intercom/dependency/downloader.rs
@@ -28,7 +28,7 @@ use crate::intercom::{Dispatcher, PeerSchedule, QueryRequestTag};
 use crate::models::{
     EvidenceSigError, ParseResult, PeerCount, Point, PointId, PointIntegrityError,
 };
-use crate::moderator::JournalEvent;
+use crate::moderator::JournalNetworkEvent;
 
 #[derive(Clone)]
 pub struct Downloader {
@@ -350,7 +350,7 @@ impl DownloadTask {
                     peer = display(out.peer_id.alt()),
                     "bad response",
                 );
-                self.query.report(JournalEvent::BadResponse(
+                self.query.report(JournalNetworkEvent::BadResponse(
                     out.peer_id,
                     QueryRequestTag::Download,
                     tl_error,
@@ -366,7 +366,7 @@ impl DownloadTask {
                     peer = display(out.peer_id.alt()),
                     "bad point",
                 );
-                self.query.report(JournalEvent::PointIntegrityError(
+                self.query.report(JournalNetworkEvent::PointIntegrityError(
                     out.peer_id,
                     QueryRequestTag::Download,
                     bad_point,
@@ -386,7 +386,7 @@ impl DownloadTask {
                     digest = display(wrong_id.digest.alt()),
                     "returned wrong point",
                 );
-                self.query.report(JournalEvent::ReplacedPoint {
+                self.query.report(JournalNetworkEvent::ReplacedPoint {
                     peer_id: out.peer_id,
                     requested: *self.query.point_id(),
                     received: *wrong_id,

--- a/consensus/src/intercom/dependency/peer_queue.rs
+++ b/consensus/src/intercom/dependency/peer_queue.rs
@@ -70,7 +70,7 @@ impl PeerQueue {
         if status.is_ready_to_query(attempt) {
             status.is_in_flight = true;
             status.last_attempt = Some(attempt);
-            self.0.upsert(peer_id, Reverse(status), PartialEq::ne).ok();
+            self.0.upsert(peer_id, Reverse(status), PartialEq::ne);
             Some(peer_id)
         } else {
             None
@@ -87,7 +87,7 @@ impl PeerQueue {
             return false;
         };
         f(&mut status);
-        self.0.upsert(*peer_id, Reverse(status), PartialEq::ne).ok();
+        self.0.upsert(*peer_id, Reverse(status), PartialEq::ne);
         true
     }
 

--- a/consensus/src/intercom/peer_schedule/epoch_starts.rs
+++ b/consensus/src/intercom/peer_schedule/epoch_starts.rs
@@ -30,6 +30,13 @@ impl EpochStarts {
         self.started[2]
     }
 
+    pub fn epoch_start(&self, round: Round) -> Option<Round> {
+        match self.arr_idx(round)? {
+            3 => self.next,
+            idx => Some(self.started[idx]),
+        }
+    }
+
     pub fn arr_idx(&self, round: Round) -> Option<usize> {
         if self.next.is_some_and(|r| round >= r) {
             Some(3)

--- a/consensus/src/intercom/peer_schedule/stats_ranges.rs
+++ b/consensus/src/intercom/peer_schedule/stats_ranges.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use tycho_network::PeerId;
 use tycho_util::FastHashMap;
 
+use crate::engine::MempoolConfig;
 use crate::intercom::peer_schedule::epoch_starts::EpochStarts;
 use crate::models::Round;
 
@@ -12,26 +13,28 @@ pub struct StatsRanges {
 }
 
 impl StatsRanges {
-    /// Slasher stats cannot be merged at epoch switch bounds because the same stats slot
-    /// may be reused by different peers:
-    /// * at vset change, peers may have the same `validator_idx`
-    /// * at subset change, peers have different `validator_idx`
+    /// Slasher stats cannot be merged at epoch switch bounds because:
+    /// * at vset change, different peers may have the same `validator_idx`
+    /// * at subset change, the same peer may have different `validator_idx`
     ///
-    /// We suppress stats of an older epoch in the anchors of a newer epoch
-    pub fn can_emit_stats(&self, stats_round: Round, anchor_round: Round) -> bool {
-        // pre-GC'ed stats round is always less than its anchor round
-        assert!(stats_round < anchor_round, "method params in wrong order");
-
-        let Some(stats_idx) = self.epoch_starts.arr_idx(stats_round) else {
-            return false; // too old to guarantee subset equality
-        };
-        let Some(anchor_idx) = self.epoch_starts.arr_idx(anchor_round) else {
-            unreachable!("stats_round < anchor_round"); // we've returned false already
-        };
+    /// We suppress stats of an older epoch in the anchors of a newer epoch:
+    /// * last `max_consensus_lag_rounds` round stats in ending epoch are suppressed
+    ///   because anchor data will be attributed to the next validator|slasher session
+    /// * stats and achor must belong to the same epoch - that way we suppress
+    ///   trailing stats from the previous epoch for a newer epoch anchor
+    /// * stats for too old (removed from schedule) epoch are suppressed too
+    ///
+    /// Returns `None` if anchor stats are suppressed
+    pub fn stats_since(&self, anchor_round: Round, conf: &MempoolConfig) -> Option<Round> {
         // anchors are expected at least every `max_consensus_lag_rounds` or consensus stalls,
         // so it's the longest tail of rounds to GC or (in this case) of stats to skip;
         // that's the rounds offset for `vset_switch_round` reserved by collator up to pause bound
-        stats_idx == anchor_idx
+
+        let a = self.epoch_starts.epoch_start(anchor_round);
+        let b = (self.epoch_starts)
+            .epoch_start(anchor_round + conf.consensus.max_consensus_lag_rounds.get());
+
+        if a == b { a } else { None }
     }
 
     #[allow(dead_code, reason = "will be used soon")]

--- a/consensus/src/moderator/ban/core.rs
+++ b/consensus/src/moderator/ban/core.rs
@@ -21,7 +21,10 @@ use crate::moderator::journal::item::{
     BanItem, BanOrigin, JournalItem, JournalItemFull, UnbanItem, UnbanOrigin,
 };
 use crate::moderator::journal::record_key::RecordKeyFactory;
-use crate::moderator::{BanConfig, DelayedDbTask, JournalEvent, RecordKey, RecordValueShort};
+use crate::moderator::{
+    BanConfig, DelayedDbTask, JournalDagEventIndex, JournalEvent, RecordKey, RecordValueShort,
+};
+use crate::utils::{UpsertResult, ValueOrderedMap};
 
 #[derive(Clone)]
 pub struct BanCore(Arc<BanCoreInner>);
@@ -37,6 +40,7 @@ struct BanCoreInner {
 impl BanCore {
     pub fn new(
         config: BanConfig,
+        dedup_dag_events: usize,
         record_key_factory: RecordKeyFactory,
         delayed_db_tasks_tx: mpsc::UnboundedSender<DelayedDbTask>,
     ) -> Self {
@@ -48,7 +52,7 @@ impl BanCore {
             delayed_db_tasks_tx,
             _updater: JoinTask::new({
                 let weak = weak.clone();
-                let task = UnbanScheduler::default().run(weak, updates_rx);
+                let task = UnbanScheduler::new(dedup_dag_events).run(weak, updates_rx);
                 async move { task.await.expect("moderator unban scheduler") }
             }),
         }))
@@ -144,13 +148,21 @@ impl BanCore {
     }
 }
 
-#[derive(Default)]
 struct UnbanScheduler {
     last_bans: FastHashMap<PeerId, (delay_queue::Key, CurrentBan)>,
     auto_unbans: DelayQueue<PeerId>,
+    deduplication: ValueOrderedMap<JournalDagEventIndex, UnixTime>,
 }
 
 impl UnbanScheduler {
+    fn new(dedup_dag_events: usize) -> Self {
+        Self {
+            last_bans: Default::default(),
+            auto_unbans: Default::default(),
+            deduplication: ValueOrderedMap::with_max_len(dedup_dag_events),
+        }
+    }
+
     async fn run(
         mut self,
         weak: Weak<BanCoreInner>,
@@ -186,15 +198,30 @@ impl UnbanScheduler {
         }
     }
 
-    #[allow(clippy::unused_self, reason = "style + may use later")]
-    fn on_event(&self, inner: &BanCoreInner, event: JournalEvent) -> TaskResult<()> {
+    fn on_event(&mut self, inner: &BanCoreInner, event: JournalEvent) -> TaskResult<()> {
+        let time = UnixTime::now();
+
+        if event.action().store()
+            && let JournalEvent::Dag(event) = &event
+        {
+            // always update time for LRU fashion
+            match self.deduplication.upsert(event.index(), time, |_, _| true) {
+                UpsertResult::OkInserted | UpsertResult::OkEvicted(_, _) => {}
+                UpsertResult::OkUpdated(_) => return Ok(()), // duplicate
+                UpsertResult::ErrRejected => unreachable!(),
+                UpsertResult::ErrTooLow => {
+                    tracing::error!("too large burst of events like {event}");
+                }
+            }
+        }
+
         let mut state = inner.state.lock().unwrap();
 
         let mut event_item = None;
         let mut maybe_ban = None;
 
         if event.action().store() {
-            let key = state.kf.new_key();
+            let key = state.kf.new_millis(time.millis());
 
             maybe_ban = (event.action().is_ban_related())
                 .then(|| state.maybe_ban(event.peer_id(), &key, event.tag(), &inner.config))

--- a/consensus/src/moderator/config.rs
+++ b/consensus/src/moderator/config.rs
@@ -56,6 +56,9 @@ pub struct JournalConfig {
 
     #[serde(with = "tycho_util::serde_helpers::humantime")]
     pub batch_interval: Duration,
+
+    /// Size of LRU cache for point-related events that may be duplicated at `Engine` restart
+    pub dedup_dag_events: usize,
 }
 
 impl Default for JournalConfig {
@@ -64,6 +67,7 @@ impl Default for JournalConfig {
             ttl: BanConfigDuration(Duration::from_hours(30 * 24)),
             clean_interval: Duration::from_hours(1),
             batch_interval: Duration::from_secs(2),
+            dedup_dag_events: 1000,
         }
     }
 }

--- a/consensus/src/moderator/impl_.rs
+++ b/consensus/src/moderator/impl_.rs
@@ -22,8 +22,8 @@ use crate::moderator::journal::batch::batch;
 use crate::moderator::journal::item::{JournalItem, JournalItemFull};
 use crate::moderator::journal::record_key::RecordKeyFactory;
 use crate::moderator::{
-    BanConfigDuration, DelayedDbTask, JournalConfig, JournalEvent, JournalPoint, JournalStore,
-    ModeratorConfig, RecordFull,
+    BanConfigDuration, DelayedDbTask, JournalConfig, JournalEvent, JournalNetworkEvent,
+    JournalPoint, JournalStore, ModeratorConfig, RecordFull,
 };
 use crate::storage::MempoolDb;
 
@@ -68,7 +68,12 @@ impl Moderator {
             })
             .context("channel db delayed write of node start")?;
 
-        let ban_core = BanCore::new(config.bans, record_key_factory, delayed_db_tasks_tx);
+        let ban_core = BanCore::new(
+            config.bans,
+            config.journal.dedup_dag_events,
+            record_key_factory,
+            delayed_db_tasks_tx,
+        );
 
         let is_init = Arc::new(AtomicBool::new(false));
         let (init_tx, init_rx) = oneshot::channel();
@@ -126,8 +131,8 @@ impl Moderator {
         self.0.set_peer_schedule(peer_schedule);
     }
 
-    pub(crate) fn report(&self, data: JournalEvent) {
-        self.0.report(data);
+    pub(crate) fn report<T: Into<JournalEvent>>(&self, data: T) {
+        self.0.report(data.into());
     }
 
     pub(crate) fn apply_mempool_config(&self, conf: &MempoolConfig) {
@@ -454,11 +459,14 @@ fn meter_event(item: &JournalItem) {
         return;
     };
     let kind = match event {
-        JournalEvent::BadRequest(_, query, _) => format!("{query:?} request tl err"),
-        JournalEvent::BadResponse(_, query, _) => format!("{query:?} response tl err"),
-        JournalEvent::QueryLimitReached(_, query) => format!("{query:?} rate limit"),
-        JournalEvent::PointIntegrityError(_, query, err) => format!("{query:?} {err:?}"),
-        other => format!("{:?}", other.tag()),
+        JournalEvent::Network(network) => match network {
+            JournalNetworkEvent::BadRequest(_, query, _) => format!("{query:?} request tl err"),
+            JournalNetworkEvent::BadResponse(_, query, _) => format!("{query:?} response tl err"),
+            JournalNetworkEvent::QueryLimitReached(_, query) => format!("{query:?} rate limit"),
+            JournalNetworkEvent::PointIntegrityError(_, query, err) => format!("{query:?} {err:?}"),
+            other => format!("{:?}", other.tag()),
+        },
+        JournalEvent::Dag(event) => format!("{:?}", event.tag()),
     };
     let labels = [("kind", kind), ("peer_id", format!("{}", event.peer_id()))];
     metrics::counter!("tycho_mempool_moderator_event", &labels).increment(1);

--- a/consensus/src/moderator/journal/event.rs
+++ b/consensus/src/moderator/journal/event.rs
@@ -14,6 +14,11 @@ use crate::moderator::EventTag;
 use crate::moderator::journal::item::JournalAction;
 
 pub enum JournalEvent {
+    Network(JournalNetworkEvent),
+    Dag(JournalDagEvent),
+}
+
+pub enum JournalNetworkEvent {
     // from Responder
     UnknownQuery(PeerId, TlError),
     BadRequest(PeerId, QueryRequestTag, TlError),
@@ -29,6 +34,9 @@ pub enum JournalEvent {
         requested: PointId,
         received: PointId,
     },
+}
+
+pub enum JournalDagEvent {
     // from RoundInspector
     Equivocated(PeerId, Round, Vec<Digest>),
     /// proofs contain signatures for their prev points which are skipped in blamed points
@@ -42,7 +50,49 @@ pub enum JournalEvent {
     TransInvalid(TransInvalidPoint),
 }
 
+impl From<JournalNetworkEvent> for JournalEvent {
+    fn from(event: JournalNetworkEvent) -> Self {
+        Self::Network(event)
+    }
+}
+
+impl From<JournalDagEvent> for JournalEvent {
+    fn from(event: JournalDagEvent) -> Self {
+        Self::Dag(event)
+    }
+}
+
 impl JournalEvent {
+    pub fn tag(&self) -> EventTag {
+        match self {
+            Self::Network(event) => event.tag(),
+            Self::Dag(event) => event.tag(),
+        }
+    }
+
+    pub fn peer_id(&self) -> &PeerId {
+        match self {
+            Self::Network(event) => event.peer_id(),
+            Self::Dag(event) => event.peer_id(),
+        }
+    }
+
+    pub fn action(&self) -> JournalAction {
+        match self {
+            Self::Network(event) => event.action(),
+            Self::Dag(event) => event.action(),
+        }
+    }
+
+    pub fn fill_points<'a>(&'a self, _points: &mut Vec<&'a Point>, point_keys: &mut Vec<PointKey>) {
+        match self {
+            Self::Network(event) => event.fill_points(_points, point_keys),
+            Self::Dag(event) => event.fill_points(_points, point_keys),
+        }
+    }
+}
+
+impl JournalNetworkEvent {
     pub fn tag(&self) -> EventTag {
         match self {
             Self::UnknownQuery(_, _) | Self::BadRequest(_, _, _) | Self::BadResponse(_, _, _) => {
@@ -51,15 +101,10 @@ impl JournalEvent {
             Self::QueryLimitReached(_, _) => EventTag::QueryLimitReached,
             Self::PointIntegrityError(_, _, _) => EventTag::PointIntegrityError,
             Self::SenderNotAuthor(_, _) | Self::ReplacedPoint { .. } => EventTag::ReplacedPoint,
-            Self::Equivocated(_, _, _) => EventTag::ForkedPoint,
-            Self::EvidenceNoInclusion { .. } => EventTag::EvidenceNoInclusion,
-            Self::IllFormed(_) => EventTag::IllFormedPoint,
-            Self::Invalid(_) | Self::TransInvalid(_) => EventTag::InvalidPoint,
         }
     }
 
-    pub fn peer_id(&self) -> &PeerId {
-        #[allow(clippy::match_same_arms, reason = "common order")]
+    fn peer_id(&self) -> &PeerId {
         match self {
             Self::UnknownQuery(peer_id, _)
             | Self::BadRequest(peer_id, _, _)
@@ -67,19 +112,11 @@ impl JournalEvent {
             | Self::QueryLimitReached(peer_id, _)
             | Self::PointIntegrityError(peer_id, _, _)
             | Self::SenderNotAuthor(peer_id, _)
-            | Self::ReplacedPoint { peer_id, .. }
-            | Self::Equivocated(peer_id, _, _) => peer_id,
-            Self::EvidenceNoInclusion { signer, .. } => signer,
-            Self::IllFormed(ill) => &ill.id().author,
-            Self::Invalid(invalid) => invalid.info().author(),
-            Self::TransInvalid(invalid) => invalid.info().author(),
+            | Self::ReplacedPoint { peer_id, .. } => peer_id,
         }
     }
 
-    pub fn action(&self) -> JournalAction {
-        // Note: there's an inevitable lag between storing point statuses and corresponding events,
-        //   so in general a restored status doesn't mean that event is also (re)stored,
-        //   but a possibility to lose an event at restart is more preferable than double accounting
+    fn action(&self) -> JournalAction {
         match self {
             Self::UnknownQuery(_, _)
             | Self::BadRequest(_, _, _)
@@ -87,9 +124,60 @@ impl JournalEvent {
             | Self::QueryLimitReached(_, _)
             | Self::PointIntegrityError(_, _, _)
             | Self::SenderNotAuthor(_, _)
-            | Self::ReplacedPoint { .. }
-            | Self::Equivocated(_, _, _)
-            | Self::EvidenceNoInclusion { .. } => JournalAction::StoreAndCheckBan,
+            | Self::ReplacedPoint { .. } => JournalAction::StoreAndCheckBan,
+        }
+    }
+
+    fn fill_points<'a>(&'a self, _points: &mut Vec<&'a Point>, point_keys: &mut Vec<PointKey>) {
+        match self {
+            Self::UnknownQuery(_, _)
+            | Self::BadRequest(_, _, _)
+            | Self::BadResponse(_, _, _)
+            | Self::QueryLimitReached(_, _)
+            | Self::PointIntegrityError(_, _, _) => {}
+            Self::SenderNotAuthor(_, point_id) => {
+                point_keys.push(point_id.key());
+            }
+            Self::ReplacedPoint {
+                requested,
+                received,
+                ..
+            } => {
+                point_keys.push(requested.key());
+                point_keys.push(received.key());
+            }
+        };
+    }
+}
+
+impl JournalDagEvent {
+    pub fn tag(&self) -> EventTag {
+        match self {
+            Self::Equivocated(_, _, _) => EventTag::ForkedPoint,
+            Self::EvidenceNoInclusion { .. } => EventTag::EvidenceNoInclusion,
+            Self::IllFormed(_) => EventTag::IllFormedPoint,
+            Self::Invalid(_) | Self::TransInvalid(_) => EventTag::InvalidPoint,
+        }
+    }
+
+    fn peer_id(&self) -> &PeerId {
+        match self {
+            Self::Equivocated(peer_id, _, _) => peer_id,
+            Self::EvidenceNoInclusion { signer, .. } => signer,
+            Self::IllFormed(ill) => &ill.id().author,
+            Self::Invalid(invalid) => invalid.info().author(),
+            Self::TransInvalid(invalid) => invalid.info().author(),
+        }
+    }
+
+    fn action(&self) -> JournalAction {
+        // Note: there's an inevitable lag between storing point statuses and corresponding events,
+        //   so in general a restored status doesn't mean that event is also (re)stored,
+        //   but a possibility to lose an event at restart is more preferable than double accounting
+        match self {
+            Self::Equivocated(_, _, _) | Self::EvidenceNoInclusion { .. } => {
+                JournalAction::StoreAndCheckBan
+            }
             Self::IllFormed(ill) => match ill.reason() {
                 IllFormedReason::AfterLoadFromDb { .. } => JournalAction::Ignore, // (re)stored
                 _ => JournalAction::StoreAndCheckBan,
@@ -110,27 +198,8 @@ impl JournalEvent {
         }
     }
 
-    pub fn fill_points<'a>(&'a self, _points: &mut Vec<&'a Point>, point_keys: &mut Vec<PointKey>) {
-        #[allow(clippy::match_same_arms, reason = "common order")]
+    fn fill_points<'a>(&'a self, _points: &mut Vec<&'a Point>, point_keys: &mut Vec<PointKey>) {
         let invalid_reason = match self {
-            Self::UnknownQuery(_, _)
-            | Self::BadRequest(_, _, _)
-            | Self::BadResponse(_, _, _)
-            | Self::QueryLimitReached(_, _)
-            | Self::PointIntegrityError(_, _, _) => return,
-            Self::SenderNotAuthor(_, point_id) => {
-                point_keys.push(point_id.key());
-                return;
-            }
-            Self::ReplacedPoint {
-                requested,
-                received,
-                ..
-            } => {
-                point_keys.push(requested.key());
-                point_keys.push(received.key());
-                return;
-            }
             Self::Equivocated(_, round, digests) => {
                 for digest in digests {
                     point_keys.push(PointKey::new(*round, *digest));
@@ -187,9 +256,83 @@ impl JournalEvent {
             }
         }
     }
+    pub fn index(&self) -> JournalDagEventIndex {
+        JournalDagEventIndex::new(self)
+    }
+}
+
+/// Semantically unique and ordered bytes to deduplicate events on mempool restarts
+#[derive(Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct JournalDagEventIndex(Box<[u8]>);
+
+impl JournalDagEventIndex {
+    fn new(event: &JournalDagEvent) -> Self {
+        Self(Self::unique_bytes(event).into_boxed_slice())
+    }
+
+    fn unique_bytes(event: &JournalDagEvent) -> Vec<u8> {
+        const POINT_ID_WITH_LABEL_BYTES: usize = 4 + 1 + 32 + 32;
+        fn write_point_id_with_label(to: &mut Vec<u8>, label: u8, point_id: &PointId) {
+            to.extend_from_slice(&point_id.round.0.to_be_bytes());
+            to.push(label);
+            to.extend_from_slice(point_id.author.as_bytes());
+            to.extend_from_slice(point_id.digest.inner());
+        }
+
+        match event {
+            JournalDagEvent::Equivocated(peer_id, round, digests) => {
+                let mut vec = Vec::with_capacity(4 + 1 + 32);
+                vec.extend_from_slice(&round.0.to_be_bytes());
+                vec.push(1);
+                vec.extend_from_slice(peer_id.as_bytes());
+                _ = digests; // explicit: reasons make no difference
+                vec
+            }
+            JournalDagEvent::EvidenceNoInclusion {
+                signer,
+                blamed,
+                proofs,
+            } => {
+                let mut vec = Vec::with_capacity(4 + 1 + 32);
+                let min_blamed_round = blamed.iter().map(|id| id.round.0).min().unwrap_or_default();
+                vec.extend_from_slice(&min_blamed_round.to_be_bytes());
+                vec.push(2);
+                vec.extend_from_slice(signer.as_bytes());
+                _ = proofs; // explicit: reasons make no difference
+                vec
+            }
+            JournalDagEvent::IllFormed(ill) => {
+                let mut vec = Vec::with_capacity(POINT_ID_WITH_LABEL_BYTES);
+                write_point_id_with_label(&mut vec, 3, ill.id());
+                _ = ill.reason(); // explicit: reasons make no difference
+                vec
+            }
+            JournalDagEvent::Invalid(invalid) => {
+                let mut vec = Vec::with_capacity(POINT_ID_WITH_LABEL_BYTES);
+                write_point_id_with_label(&mut vec, 4, invalid.info().id());
+                _ = invalid.reason(); // explicit: reasons make no difference
+                vec
+            }
+            JournalDagEvent::TransInvalid(invalid) => {
+                let mut vec = Vec::with_capacity(POINT_ID_WITH_LABEL_BYTES);
+                write_point_id_with_label(&mut vec, 5, invalid.info().id());
+                _ = invalid.root_cause(); // explicit: reasons make no difference
+                vec
+            }
+        }
+    }
 }
 
 impl Display for JournalEvent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JournalEvent::Network(event) => event.fmt(f),
+            JournalEvent::Dag(event) => event.fmt(f),
+        }
+    }
+}
+
+impl Display for JournalNetworkEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::UnknownQuery(_, tl_err) => {
@@ -219,6 +362,13 @@ impl Display for JournalEvent {
                 let rc = received.alt();
                 write!(f, "wrong point: requested {rq:?} received {rc:?}")
             }
+        }
+    }
+}
+
+impl Display for JournalDagEvent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
             Self::Equivocated(_, round, digests) => {
                 write!(f, "{} forks at {} round", digests.len(), round.0)
             }

--- a/consensus/src/moderator/journal/record_key.rs
+++ b/consensus/src/moderator/journal/record_key.rs
@@ -20,7 +20,6 @@ impl RecordKeyFactory {
         }
     }
 
-    #[cfg(test)]
     pub fn new_millis(&mut self, created: u64) -> RecordKey {
         RecordKey {
             created: UnixTime::from_millis(created),

--- a/consensus/src/moderator/journal/test.rs
+++ b/consensus/src/moderator/journal/test.rs
@@ -17,7 +17,8 @@ use crate::moderator::journal::batch::batch;
 use crate::moderator::journal::item::{JournalItem, JournalItemFull};
 use crate::moderator::journal::record_key::RecordKeyFactory;
 use crate::moderator::{
-    JournalEvent, JournalPoint, JournalPointRef, JournalStore, RecordFull, RecordValue,
+    JournalDagEvent, JournalEvent, JournalNetworkEvent, JournalPoint, JournalPointRef,
+    JournalStore, RecordFull, RecordValue,
 };
 use crate::storage::{MempoolDb, MempoolStore};
 use crate::test_utils::{default_test_config, test_logger};
@@ -41,11 +42,15 @@ async fn point_not_corrupt_across_batches() -> Result<()> {
     let point_id = *point.info().id();
     let first = JournalItemFull {
         key: key_factory.new_millis(1_000),
-        item: JournalItem::Event(JournalEvent::SenderNotAuthor(PeerId([1; _]), point_id)),
+        item: JournalItem::Event(
+            JournalNetworkEvent::SenderNotAuthor(PeerId([1; _]), point_id).into(),
+        ),
     };
     let second = JournalItemFull {
         key: key_factory.new_millis(2_000),
-        item: JournalItem::Event(JournalEvent::SenderNotAuthor(PeerId([2; _]), point_id)),
+        item: JournalItem::Event(
+            JournalNetworkEvent::SenderNotAuthor(PeerId([2; _]), point_id).into(),
+        ),
     };
 
     store.store_records(batch(&[first]), journal_point_max_bytes)?;
@@ -176,45 +181,48 @@ fn gen_items(count: u8, points: &[Point]) -> Vec<JournalItemFull> {
 
     for i in 0..count {
         let peer_id = PeerId([i; _]);
-        let event = match i % 4 {
-            0 => match points.get(i as usize) {
-                Some(point) => JournalEvent::SenderNotAuthor(peer_id, *point.info().id()),
-                None => JournalEvent::UnknownQuery(peer_id, TlError::InvalidData),
-            },
-            1 => match points.get(i as usize) {
-                Some(point) => JournalEvent::ReplacedPoint {
+        let event: JournalEvent = match i % 4 {
+            0 => <_>::from(match points.get(i as usize) {
+                Some(point) => JournalNetworkEvent::SenderNotAuthor(peer_id, *point.info().id()),
+                None => JournalNetworkEvent::UnknownQuery(peer_id, TlError::InvalidData),
+            }),
+            1 => <_>::from(match points.get(i as usize) {
+                Some(point) => JournalNetworkEvent::ReplacedPoint {
                     peer_id,
                     requested: *point.info().id(), // should be unique but won't
                     received: *point.info().id(),
                 },
-                None => JournalEvent::BadRequest(
+                None => JournalNetworkEvent::BadRequest(
                     peer_id,
                     QueryRequestTag::Signature,
                     TlError::UnexpectedEof,
                 ),
-            },
-            2 => match points.get(i as usize) {
-                Some(point) => JournalEvent::EvidenceNoInclusion {
+            }),
+            2 => <_>::from(match points.get(i as usize) {
+                Some(point) => JournalDagEvent::EvidenceNoInclusion {
                     signer: peer_id,
                     blamed: vec![*point.info().id()],
                     proofs: vec![*point.info().id()],
                 },
-                None => JournalEvent::Equivocated(
+                None => JournalDagEvent::Equivocated(
                     peer_id,
                     Round(rand::rng().next_u32()),
                     std::array::from_fn::<_, 3, _>(|j| *Digest::wrap(&[j as u8; _])).to_vec(),
                 ),
-            },
+            }),
             3 => match points.get(i as usize) {
-                Some(point) => {
+                Some(point) => <_>::from({
                     let info = point.info().clone();
                     let reason = InvalidReason::MustHaveSkippedRound(*point.info().id());
                     match DagPoint::new_invalid(info, Cert::default(), &<_>::random(), reason) {
-                        DagPoint::Invalid(invalid) => JournalEvent::Invalid(invalid),
+                        DagPoint::Invalid(invalid) => JournalDagEvent::Invalid(invalid),
                         _ => unreachable!(),
                     }
-                }
-                None => JournalEvent::QueryLimitReached(peer_id, QueryRequestTag::Broadcast),
+                }),
+                None => <_>::from(JournalNetworkEvent::QueryLimitReached(
+                    peer_id,
+                    QueryRequestTag::Broadcast,
+                )),
             },
             _ => unreachable!(),
         };

--- a/consensus/src/test_utils/dag.rs
+++ b/consensus/src/test_utils/dag.rs
@@ -67,15 +67,16 @@ pub async fn populate_points<const PEER_COUNT: usize>(
 ) {
     let prev_dag_round = dag_round.prev().upgrade().expect("prev DAG round exists");
     let prev_points = prev_dag_round
-        .select(|(_, loc)| {
+        .select(|(peer_id, loc)| {
             loc.versions
                 .values()
                 .map(|a| a.clone().now_or_never().expect("must be ready"))
                 .map(|p| p.expect("shutdown"))
                 .map(|p| p.valid().expect("must be valid").info().clone())
                 .next()
+                .map(|info| (*peer_id, info))
         })
-        .collect::<Vec<_>>();
+        .collect();
 
     let mut points = FastHashMap::default();
     for idx in 0..PEER_COUNT {
@@ -136,7 +137,7 @@ fn point<const PEER_COUNT: usize>(
     round: Round,
     idx: usize,
     peers: &[(PeerId, Arc<KeyPair>); PEER_COUNT],
-    includes: &[PointInfo],
+    includes: &FastHashMap<PeerId, PointInfo>,
     round_leader: Option<&PeerId>,
     input_buffer: &InputBuffer,
     conf: &MempoolConfig,
@@ -148,9 +149,7 @@ fn point<const PEER_COUNT: usize>(
     );
     let peer_count = PeerCount::try_from(PEER_COUNT).expect("enough peers in non-genesis round");
 
-    let author = peers[idx].0;
-
-    let prev_info = includes.iter().find(|info| info.author() == author);
+    let prev_info = includes.get(&peers[idx].0);
 
     let last_own_point = prev_info.map(|info| LastOwnPoint {
         digest: *info.digest(),
@@ -176,8 +175,8 @@ fn point<const PEER_COUNT: usize>(
         &peers[idx].1,
         round,
         round_leader,
-        includes.to_vec(),
-        Default::default(),
+        includes,
+        &Default::default(),
         conf,
     )
     .expect("failed to create point")

--- a/consensus/src/utils/value_ordered_map.rs
+++ b/consensus/src/utils/value_ordered_map.rs
@@ -14,12 +14,25 @@ pub struct ValueOrderedMap<K, V> {
     max_len: usize,
 }
 
+#[derive(Eq, PartialEq, Debug)]
+pub enum UpsertResult<K, V> {
+    /// KV inserted without eviction
+    OkInserted,
+    /// key is found and its old value is replaced
+    OkUpdated(V),
+    /// map is at `max_len` and insert pushed some tuple out of map
+    OkEvicted(K, V),
+    /// key is found, but value didn't satisfy `update_if` clause
+    ErrRejected,
+    /// map is at `max_len` and all retained `(value, key)` are greater than passed one
+    ErrTooLow,
+}
+
 impl<K, V> ValueOrderedMap<K, V>
 where
     K: Hash + Eq + Ord,
     V: Ord,
 {
-    #[cfg(test)]
     pub fn with_max_len(max_len: usize) -> Self {
         Self {
             inner: IndexMap::with_capacity_and_hasher(max_len, ahash::RandomState::new()),
@@ -28,11 +41,7 @@ where
     }
 
     /// Updates contained value if a function of `(new, old)` evaluates to `true`.
-    /// * Returns an `Err(passed value)` in O(log n) time
-    ///   * if replace failed because of maintained priority
-    ///   * if a new entry could extend the map beyond `max_len`
-    /// * Returns `Ok` in O(n + log n) time, with `Some(replaced value)` if it existed
-    pub fn upsert<F>(&mut self, k: K, v: V, update_if: F) -> Result<Option<V>, V>
+    pub fn upsert<F>(&mut self, k: K, v: V, update_if: F) -> UpsertResult<K, V>
     where
         F: FnOnce(&V, &V) -> bool,
     {
@@ -44,29 +53,30 @@ where
         match self.inner.entry(k) {
             indexmap::map::Entry::Occupied(mut occupied) => {
                 if !update_if(&v, occupied.get()) {
-                    return Err(v);
+                    return UpsertResult::ErrRejected;
                 }
 
-                let prev = occupied.insert(v);
+                let prev_v = occupied.insert(v);
                 let target = if occupied.index() < pos { pos - 1 } else { pos };
                 occupied.move_index(target);
 
-                Ok(Some(prev))
+                UpsertResult::OkUpdated(prev_v)
             }
             indexmap::map::Entry::Vacant(vacant) => {
                 if was_full && pos == 0 {
-                    return Err(v);
+                    return UpsertResult::ErrTooLow;
                 }
 
                 if was_full {
                     // Replace the minimum, then rotate only the prefix preceding the candidate.
-                    let (_, mut occupied) = vacant.replace_index(0);
-                    occupied.insert(v);
+                    let (old_k, mut occupied) = vacant.replace_index(0);
+                    let old_v = occupied.insert(v);
                     occupied.move_index(pos - 1);
+                    UpsertResult::OkEvicted(old_k, old_v)
                 } else {
                     vacant.shift_insert(pos, v);
+                    UpsertResult::OkInserted
                 }
-                Ok(None)
             }
         }
     }
@@ -109,6 +119,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::utils::value_ordered_map::UpsertResult::*;
 
     impl<K, V> ValueOrderedMap<K, V>
     where
@@ -127,13 +138,13 @@ mod test {
 
         let mut vom = ValueOrderedMap::with_max_len(4);
 
-        assert_eq!(vom.upsert('b', 0, PartialOrd::ge), Ok(None));
+        assert_eq!(vom.upsert('b', 0, PartialOrd::ge), OkInserted);
 
-        assert!(vom.upsert('a', 0, PartialOrd::ge).is_ok());
+        assert_eq!(vom.upsert('a', 0, PartialOrd::ge), OkInserted);
 
-        assert!(vom.upsert('c', 2, PartialOrd::ge).is_ok());
+        assert_eq!(vom.upsert('c', 2, PartialOrd::ge), OkInserted);
 
-        assert!(vom.upsert('d', 1, PartialOrd::ge).is_ok());
+        assert_eq!(vom.upsert('d', 1, PartialOrd::ge), OkInserted);
 
         assert_eq!(vom.vec(), vec![('c', 2), ('d', 1), ('b', 0), ('a', 0)]);
 
@@ -141,23 +152,23 @@ mod test {
 
         // ordered inserts
 
-        assert_eq!(vom.upsert('a', 2, PartialOrd::ge), Ok(Some(0)));
+        assert_eq!(vom.upsert('a', 2, PartialOrd::ge), OkUpdated(0));
 
         assert_eq!(vom.vec(), vec![('c', 2), ('a', 2), ('d', 1), ('b', 0)]);
 
-        assert!(vom.upsert('a', 3, PartialOrd::ge).is_ok());
+        assert_eq!(vom.upsert('a', 3, PartialOrd::ge), OkUpdated(2));
 
         assert_eq!(vom.vec(), vec![('a', 3), ('c', 2), ('d', 1), ('b', 0)]);
 
-        assert!(vom.upsert('a', 1, PartialOrd::ge).is_err());
+        assert_eq!(vom.upsert('a', 1, PartialOrd::ge), ErrRejected);
 
         assert_eq!(vom.vec(), vec![('a', 3), ('c', 2), ('d', 1), ('b', 0)]);
 
-        assert!(vom.upsert('a', 1, PartialOrd::le).is_ok());
+        assert_eq!(vom.upsert('a', 1, PartialOrd::le), OkUpdated(3));
 
         assert_eq!(vom.vec(), vec![('c', 2), ('d', 1), ('a', 1), ('b', 0)]);
 
-        assert!(vom.upsert('a', 0, PartialOrd::le).is_ok());
+        assert_eq!(vom.upsert('a', 0, PartialOrd::le), OkUpdated(1));
 
         assert_eq!(vom.vec(), vec![('c', 2), ('d', 1), ('b', 0), ('a', 0)]);
 
@@ -172,30 +183,30 @@ mod test {
 
         assert_eq!(map.vec(), [(3, 1), (2, 0), (1, 0), (0, 0)]);
 
-        assert_eq!(map.upsert(4, -1, PartialEq::ne), Err(-1));
+        assert_eq!(map.upsert(4, -1, PartialEq::ne), ErrTooLow);
     }
 
     #[test]
     fn bounded_map_retains_greatest_value_key_pairs() {
         let mut map = ValueOrderedMap::with_max_len(3);
 
-        assert_eq!(map.upsert('a', 1, PartialEq::ne), Ok(None));
-        assert_eq!(map.upsert('b', 2, PartialEq::ne), Ok(None));
-        assert_eq!(map.upsert('c', 3, PartialEq::ne), Ok(None));
-        assert_eq!(map.upsert('d', 0, PartialEq::ne), Err(0));
+        assert_eq!(map.upsert('a', 1, PartialEq::ne), OkInserted);
+        assert_eq!(map.upsert('b', 2, PartialEq::ne), OkInserted);
+        assert_eq!(map.upsert('c', 3, PartialEq::ne), OkInserted);
+        assert_eq!(map.upsert('d', 0, PartialEq::ne), ErrTooLow);
         assert_eq!(map.vec(), [('c', 3), ('b', 2), ('a', 1)]);
 
-        assert_eq!(map.upsert('e', 1, PartialEq::ne), Ok(None));
+        assert_eq!(map.upsert('e', 1, PartialEq::ne), OkEvicted('a', 1));
         assert_eq!(map.vec(), [('c', 3), ('b', 2), ('e', 1)]);
 
-        assert_eq!(map.upsert('d', 2, PartialEq::ne), Ok(None));
+        assert_eq!(map.upsert('d', 2, PartialEq::ne), OkEvicted('e', 1));
         assert_eq!(map.vec(), [('c', 3), ('d', 2), ('b', 2)]);
         assert_eq!(map.get(&'a'), None);
 
-        assert_eq!(map.upsert('a', 2, PartialEq::ne), Err(2));
+        assert_eq!(map.upsert('a', 2, PartialEq::ne), ErrTooLow);
         assert_eq!(map.vec(), [('c', 3), ('d', 2), ('b', 2)]);
 
-        assert_eq!(map.upsert('e', 4, PartialEq::ne), Ok(None));
+        assert_eq!(map.upsert('e', 4, PartialEq::ne), OkEvicted('b', 2));
         assert_eq!(map.vec(), [('e', 4), ('c', 3), ('d', 2)]);
     }
 
@@ -203,7 +214,7 @@ mod test {
     fn zero_bound_rejects_every_entry() {
         let mut map = ValueOrderedMap::with_max_len(0);
 
-        assert_eq!(map.upsert('a', 1, PartialEq::ne), Err(1));
+        assert_eq!(map.upsert('a', 1, PartialEq::ne), ErrTooLow);
         assert_eq!(map.max(), None);
         assert_eq!(map.iter().next(), None);
     }

--- a/util/src/time/mod.rs
+++ b/util/src/time/mod.rs
@@ -160,6 +160,16 @@ static MONOTONIC_CLOCK: LazyLock<MonotonicClock> = LazyLock::new(|| MonotonicClo
 });
 impl MonotonicClock {
     pub fn now_millis() -> u64 {
+        let since_epoch = Self::since_unix_epoch();
+        u64::try_from(since_epoch.as_millis()).unwrap_or_else(|_| {
+            panic!(
+                "current time millis exceed u64: {}",
+                since_epoch.as_millis()
+            )
+        })
+    }
+
+    pub fn since_unix_epoch() -> Duration {
         // initialize lazy lock
         let Self {
             init_instant,
@@ -180,7 +190,7 @@ impl MonotonicClock {
             )
         });
 
-        let since_epoch = system_time
+        system_time
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap_or_else(|err| {
                 panic!(
@@ -188,14 +198,7 @@ impl MonotonicClock {
                     std::time::SystemTime::UNIX_EPOCH,
                     humantime::format_duration(err.duration())
                 )
-            });
-
-        u64::try_from(since_epoch.as_millis()).unwrap_or_else(|_| {
-            panic!(
-                "current time millis exceed u64: {}",
-                since_epoch.as_millis()
-            )
-        })
+            })
     }
 }
 


### PR DESCRIPTION
When Engine restarts on HistoryConflict, it replays dag history above top known anchor and may create duplicate moderator events. Now they are filtered in a size-based LRU before hitting storage and accounting logic.

`Fix on stats emission` is slasher-consensus prerequisite and is not used yet.

`Maps to produce point` removes intermediate vector and makes `find()` a bit cheaper. 

## Pull Request Checklist

### NODE CONFIGURATION MODEL CHANGES

Added mempool journal config `dedup_dag_events` default `1000` 

### BLOCKCHAIN CONFIGURATION MODEL CHANGES

None

---

### COMPATIBILITY

Full

### SPECIAL DEPLOYMENT ACTIONS

Not Required

---

### PERFORMANCE IMPACT

No impact expected

---

### TESTS

#### Unit Tests

No coverage

#### Network Tests

No coverage

#### Manual Tests

trnsfers-30k

---

**Notes/Additional Comments:**  