### PR TITLE
fix(collator): improve public libraries diff handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2804,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -4356,8 +4356,7 @@ dependencies = [
 [[package]]
 name = "tycho-executor"
 version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04352220fdd532d450d9d2f2f54a8a92e6b223e1d6db54be7897242233fe0c"
+source = "git+https://github.com/broxus/tycho-vm.git?rev=e16ccb889e38fa2d031f744677ca35134f544086#e16ccb889e38fa2d031f744677ca35134f544086"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4671,8 +4670,7 @@ dependencies = [
 [[package]]
 name = "tycho-vm"
 version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398fd01d7033c604004294a42d2ec0096ff0337db303c250aea76a7515cf6f15"
+source = "git+https://github.com/broxus/tycho-vm.git?rev=e16ccb889e38fa2d031f744677ca35134f544086#e16ccb889e38fa2d031f744677ca35134f544086"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4693,8 +4691,7 @@ dependencies = [
 [[package]]
 name = "tycho-vm-proc"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aac25f611eb7ab6031a0a3c0ea14884989a7280073bb154b431a991f9adb779"
+source = "git+https://github.com/broxus/tycho-vm.git?rev=e16ccb889e38fa2d031f744677ca35134f544086#e16ccb889e38fa2d031f744677ca35134f544086"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,8 @@ tycho-wu-tuner = { path = "./wu-tuner", version = "0.3.11" }
 
 [patch.crates-io]
 # patches here
+tycho-executor = { git = "https://github.com/broxus/tycho-vm.git", rev = "e16ccb889e38fa2d031f744677ca35134f544086" }
+tycho-vm = { git = "https://github.com/broxus/tycho-vm.git", rev = "e16ccb889e38fa2d031f744677ca35134f544086" }
 
 [workspace.lints.rust]
 future_incompatible = "warn"

--- a/collator/src/collator/types.rs
+++ b/collator/src/collator/types.rs
@@ -863,7 +863,7 @@ impl ShardAccountStuff {
         account_meta: AccountMeta,
         tx: Lazy<Transaction>,
         tx_meta: &TransactionMeta,
-        mut public_libs_diff: Vec<PublicLibraryChange>,
+        public_libs_diff: FastHashMap<HashBytes, PublicLibraryChange>,
     ) {
         use std::collections::hash_map;
 
@@ -893,36 +893,24 @@ impl ShardAccountStuff {
         };
 
         if is_masterchain {
-            // Sort diff in reverse order (sort must be stable here).
-            public_libs_diff.sort_by(|a, b| a.lib_hash().cmp(b.lib_hash()).reverse());
-
-            // Merge diff with the previous.
-            let mut prev_hash = None::<HashBytes>;
-            for op in public_libs_diff {
-                let hash = op.lib_hash();
-                if matches!(&prev_hash, Some(prev_hash) if prev_hash == hash) {
-                    // Skip duplicates (only the last change will be used because of reverse order).
-                    continue;
-                }
-                prev_hash = Some(*hash);
-
-                match self.public_libs_diff.entry(*hash) {
+            for (hash, op) in public_libs_diff {
+                match self.public_libs_diff.entry(hash) {
                     hash_map::Entry::Vacant(entry) => {
                         entry.insert(match op {
                             PublicLibraryChange::Add(cell) => Some(cell),
-                            PublicLibraryChange::Remove(_) => None,
+                            PublicLibraryChange::Remove => None,
                         });
                     }
                     hash_map::Entry::Occupied(entry) => match (entry.get(), op) {
                         // Removed before, added later -> no diff.
                         // Added before, removed later -> no diff.
                         (None, PublicLibraryChange::Add(_))
-                        | (Some(_), PublicLibraryChange::Remove(_)) => {
+                        | (Some(_), PublicLibraryChange::Remove) => {
                             entry.remove();
                         }
                         // Removed before, removed now -> diff persists.
                         // Added before, added now -> diff persists.
-                        (None, PublicLibraryChange::Remove(_))
+                        (None, PublicLibraryChange::Remove)
                         | (Some(_), PublicLibraryChange::Add(_)) => {}
                     },
                 }


### PR DESCRIPTION
Public libraries diff provided by the executor is normalized now and can be applied as is.